### PR TITLE
Add new NimBLEUUID constructor, solves #17

### DIFF
--- a/src/NimBLEUUID.cpp
+++ b/src/NimBLEUUID.cpp
@@ -157,7 +157,9 @@ NimBLEUUID::NimBLEUUID(ble_uuid128_t* uuid) {
 
 
 /**
- * @brief Create a UUID from the 128bit value using hex parts instead of string, so BLEUUID("ebe0ccb0-7a0a-4b0c-8a1a-6ff2997da3a6") becomes BLEUUID(0xebe0ccb0, 0x7a0a, 0x4b0c, 0x8a1a6ff2997da3a6)
+ * @brief Create a UUID from the 128bit value using hex parts instead of string, 
+ * instead of BLEUUID("ebe0ccb0-7a0a-4b0c-8a1a-6ff2997da3a6"), it becomes 
+ * BLEUUID(0xebe0ccb0, 0x7a0a, 0x4b0c, 0x8a1a6ff2997da3a6)
  *
  * @param [in] first  The first 32bit of the UUID.
  * @param [in] second The next 16bit of the UUID.

--- a/src/NimBLEUUID.cpp
+++ b/src/NimBLEUUID.cpp
@@ -156,6 +156,24 @@ NimBLEUUID::NimBLEUUID(ble_uuid128_t* uuid) {
 } // NimBLEUUID
 
 
+/**
+ * @brief Create a UUID from the 128bit value using hex parts instead of string, so BLEUUID("ebe0ccb0-7a0a-4b0c-8a1a-6ff2997da3a6") becomes BLEUUID(0xebe0ccb0, 0x7a0a, 0x4b0c, 0x8a1a6ff2997da3a6)
+ *
+ * @param [in] first  The first 32bit of the UUID.
+ * @param [in] second The next 16bit of the UUID.
+ * @param [in] third  The next 16bit of the UUID.
+ * @param [in] fourth The last 64bit of the UUID, combining the last 2 parts of the string equivalent
+ */
+NimBLEUUID::NimBLEUUID(uint32_t first, uint16_t second, uint16_t third, uint64_t fourth) {
+    m_uuid.u.type        = BLE_UUID_TYPE_128;
+    memcpy(m_uuid.u128.value + 12, &first,  4);
+    memcpy(m_uuid.u128.value + 10, &second, 2);
+    memcpy(m_uuid.u128.value + 8,  &third,  2);
+    memcpy(m_uuid.u128.value,      &fourth, 8);
+    m_valueSet = true;
+}
+
+
 NimBLEUUID::NimBLEUUID() {
     m_valueSet = false;
 } // NimBLEUUID

--- a/src/NimBLEUUID.h
+++ b/src/NimBLEUUID.h
@@ -35,6 +35,7 @@ public:
     NimBLEUUID(uint32_t uuid);
     NimBLEUUID(ble_uuid128_t* uuid);
     NimBLEUUID(uint8_t* pData, size_t size, bool msbFirst);
+    NimBLEUUID(uint32_t first, uint16_t second, uint16_t third, uint64_t fourth);
     NimBLEUUID();
     uint8_t        bitSize();   // Get the number of bits in this uuid.
     bool           equals(NimBLEUUID uuid);


### PR DESCRIPTION
Adding to NimBLEUUID.h:

    NimBLEUUID(uint32_t first, uint16_t second, uint16_t third, uint64_t fourth);

and to NimBLEUUID.cpp:

```
NimBLEUUID::NimBLEUUID(uint32_t first, uint16_t second, uint16_t third, uint64_t fourth) {
    m_uuid.u.type        = BLE_UUID_TYPE_128;
    memcpy(m_uuid.u128.value + 12, &first,  4);
    memcpy(m_uuid.u128.value + 10, &second, 2);
    memcpy(m_uuid.u128.value + 8,  &third,  2);
    memcpy(m_uuid.u128.value,      &fourth, 8);
    m_valueSet = true;
}

```
This does not save any library memory, but is does save sketch memory. In stead of

`BLEUUID("ebe0ccb0-7a0a-4b0c-8a1a-6ff2997da3a6")`

you can do

`BLEUUID(0xebe0ccb0, 0x7a0a, 0x4b0c, 0x8a1a6ff2997da3a6)`

thus trading 37 bytes of the string literal for 16 bytes uint literals, saving 21 bytes per UUID literal!