### PR TITLE
Stop copying read values in characteristic

### DIFF
--- a/src/NimBLERemoteCharacteristic.h
+++ b/src/NimBLERemoteCharacteristic.h
@@ -50,7 +50,7 @@ public:
     uint16_t    getHandle();
     uint16_t    getDefHandle();
     NimBLEUUID  getUUID();
-    std::string readValue();
+    std::string &readValue();
     uint8_t     readUInt8();
     uint16_t    readUInt16();
     uint32_t    readUInt32();
@@ -59,7 +59,7 @@ public:
     bool        writeValue(std::string newValue, bool response = false);
     bool        writeValue(uint8_t newValue, bool response = false);
     std::string toString();
-    uint8_t*    readRawData();
+    const uint8_t*    readRawData();
     NimBLERemoteService* getRemoteService();
 
 private:
@@ -90,7 +90,6 @@ private:
     FreeRTOS::Semaphore     m_semaphoreReadCharEvt      = FreeRTOS::Semaphore("ReadCharEvt");
     FreeRTOS::Semaphore     m_semaphoreWriteCharEvt     = FreeRTOS::Semaphore("WriteCharEvt");
     std::string             m_value;
-    uint8_t*                m_rawData = nullptr;
     notify_callback         m_notifyCallback;
 
     // We maintain a map of descriptors owned by this characteristic keyed by a string representation of the UUID.


### PR DESCRIPTION
readRawData() returns a pointer to m_value now, instead of keeping a second copy of the same data. Small API change, if no data is available, an empty string is returned instead of a NULL. Also readValue() returns a reference to m_value now, thus saving a copy constructor and a second copy of the same string in the sketch.

I am curious what you think of this improvement. There might be more locations in the library to do similar things.

In general though, I believe it is a bad habit to store temporary (read) values in the class instance. This PR is not ideal but an improvement of the current situation.