### PR TITLE
Experimental: update a remote characteristic from a notification

### DIFF
--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -669,7 +669,9 @@ uint16_t NimBLEClient::getMTU() {
                 auto characteristic = cMap->find(event->notify_rx.attr_handle);
                 if(characteristic != cMap->end()) {
                     NIMBLE_LOGD(LOG_TAG, "Got Notification for characteristic %s", characteristic->second->toString().c_str());
-                    
+
+                    characteristic->second->m_value = std::string((char*) event->notify_rx.om->om_data, event->notify_rx.om->om_len);
+
                     if (characteristic->second->m_notifyCallback != nullptr) {
                         NIMBLE_LOGD(LOG_TAG, "Invoking callback for notification on characteristic %s", characteristic->second->toString().c_str());
                         characteristic->second->m_notifyCallback(characteristic->second, event->notify_rx.om->om_data, event->notify_rx.om->om_len, !event->notify_rx.indication);

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -319,6 +319,7 @@ std::string NimBLERemoteCharacteristic::readValue() {
 
     int rc = 0;
     int retryCount = 1;
+    m_value= "";
 
     NimBLEClient* pClient = getRemoteService()->getClient();
     
@@ -391,8 +392,10 @@ int NimBLERemoteCharacteristic::onReadCB(uint16_t conn_handle,
         free(characteristic->m_rawData);
     }
     
-    if (error->status == 0) {       
-        characteristic->m_value = std::string((char*) attr->om->om_data, attr->om->om_len);
+    if (error->status == 0) {   
+        if(characteristic->m_value.length() == 0) {
+            characteristic->m_value = std::string((char*) attr->om->om_data, attr->om->om_len);
+        }
         characteristic->m_rawData = (uint8_t*) calloc(attr->om->om_len, sizeof(uint8_t));
         memcpy(characteristic->m_rawData, attr->om->om_data, attr->om->om_len);
         characteristic->m_semaphoreReadCharEvt.give(0);


### PR DESCRIPTION
Experimental: some peripherals, like the Xiaomi LYWSD03MMC, update a remote characteristic with a notification (off spec). This PR takes the updated value from the _notification event_ to update the characteristic.

A few thought about this PR:
- NimBLERemoteCharacteristic::readValue() detects if it needs to update m_value by checking it's length. Because ::readValue() initiates m_value with the empty string, and the BLE_GAP_EVENT_NOTIFY_RX updates the value if the peripheral sends a notification, this is okay (though a bit shaky)
- It may be possible that the characteristic is registered for notify. I think it is possible that the notify updates the characteristic, thus preventing ::readValue() to update it through a regular call. This case is hypothetical I think: why should you try to get the same value through a ::readValue() and a notification? And if someone does so, it stays the value of the _same characteristic_ (although the two values could differ because of a small gap in time, but again, this time gap is also very small)

In conclusion, I think this PR is acceptable, depending mostly on if @h2zero wants to accept an off specification (but existing in the real world) case.