### PR TITLE
NimBLEUUID: Add operator == and != + correct equals() to test if values are set.

### DIFF
--- a/src/NimBLEUUID.cpp
+++ b/src/NimBLEUUID.cpp
@@ -198,12 +198,12 @@ uint8_t NimBLEUUID::bitSize() {
  * @return True if the UUIDs are equal and false otherwise.
  */
 bool NimBLEUUID::equals(NimBLEUUID uuid) {
-    if(m_valueSet && rhs.m_valueSet) {
+    if(m_valueSet && uuid.m_valueSet) {
         if(ble_uuid_cmp(&m_uuid.u, &uuid.getNative()->u) == 0){
             return true;
         }
     }
-    return m_valueSet == rhs.m_valueSet;
+    return m_valueSet == uuid.m_valueSet;
 }
 
 

--- a/src/NimBLEUUID.cpp
+++ b/src/NimBLEUUID.cpp
@@ -229,47 +229,21 @@ ble_uuid_any_t* NimBLEUUID::getNative() {
  * A UUID can be internally represented as 16bit, 32bit or the full 128bit.  This method
  * will convert 16 or 32 bit representations to the full 128bit.
  */
-NimBLEUUID NimBLEUUID::to128() {
+NimBLEUUID &NimBLEUUID::to128() {
     // If we either don't have a value or are already a 128 bit UUID, nothing further to do.
     if (!m_valueSet || m_uuid.u.type == BLE_UUID_TYPE_128) {
         return *this;
     }
 
-    // If we are 16 bit or 32 bit, then set the 4 bytes of the variable part of the UUID.
+    // If we are 16 bit or 32 bit, then set the other bytes of the UUID.
     if (m_uuid.u.type == BLE_UUID_TYPE_16) {
-        uint16_t temp = m_uuid.u16.value;
-        m_uuid.u128.value[15] = 0;
-        m_uuid.u128.value[14] = 0;
-        m_uuid.u128.value[13] = (temp >> 8) & 0xff;
-        m_uuid.u128.value[12] = temp & 0xff;
-
+        *this = NimBLEUUID(m_uuid.u16.value, 0x0000, 0x1000, 0x800000805f9b34fb);
     }
     else if (m_uuid.u.type == BLE_UUID_TYPE_32) {
-        uint32_t temp = m_uuid.u32.value;
-        m_uuid.u128.value[15] = (temp >> 24) & 0xff;
-        m_uuid.u128.value[14] = (temp >> 16) & 0xff;
-        m_uuid.u128.value[13] = (temp >> 8) & 0xff;
-        m_uuid.u128.value[12] = temp & 0xff;
+        *this = NimBLEUUID(m_uuid.u32.value, 0x0000, 0x1000, 0x800000805f9b34fb);
     }
 
-    // Set the fixed parts of the UUID.
-    m_uuid.u128.value[11] = 0x00;
-    m_uuid.u128.value[10] = 0x00;
-
-    m_uuid.u128.value[9]  = 0x10;
-    m_uuid.u128.value[8]  = 0x00;
-
-    m_uuid.u128.value[7]  = 0x80;
-    m_uuid.u128.value[6]  = 0x00;
-
-    m_uuid.u128.value[5]  = 0x00;
-    m_uuid.u128.value[4]  = 0x80;
-    m_uuid.u128.value[3]  = 0x5f;
-    m_uuid.u128.value[2]  = 0x9b;
-    m_uuid.u128.value[1]  = 0x34;
-    m_uuid.u128.value[0]  = 0xfb;
-
-    m_uuid.u.type = BLE_UUID_TYPE_128;
+    m_uuid.u.type == BLE_UUID_TYPE_128;
     return *this;
 } // to128
 

--- a/src/NimBLEUUID.cpp
+++ b/src/NimBLEUUID.cpp
@@ -244,7 +244,6 @@ NimBLEUUID &NimBLEUUID::to128() {
         *this = NimBLEUUID(m_uuid.u32.value, 0x0000, 0x1000, 0x800000805f9b34fb);
     }
 
-    m_uuid.u.type == BLE_UUID_TYPE_128;
     return *this;
 } // to128
 

--- a/src/NimBLEUUID.cpp
+++ b/src/NimBLEUUID.cpp
@@ -89,7 +89,6 @@ NimBLEUUID::NimBLEUUID(uint8_t* pData, size_t size, bool msbFirst) {
     m_uuid.u.type = BLE_UUID_TYPE_128;
 
     if (msbFirst) {
-//        std::reverse(m_uuid.u128.value, m_uuid.u128.value + 16);
         std::reverse_copy(pData, pData + 16, m_uuid.u128.value);
     } else {
         memcpy(m_uuid.u128.value, pData, 16);

--- a/src/NimBLEUUID.cpp
+++ b/src/NimBLEUUID.cpp
@@ -88,9 +88,11 @@ NimBLEUUID::NimBLEUUID(uint8_t* pData, size_t size, bool msbFirst) {
     }
     m_uuid.u.type = BLE_UUID_TYPE_128;
 
-    memcpy(m_uuid.u128.value, pData, 16);
     if (msbFirst) {
-        std::reverse(m_uuid.u128.value, m_uuid.u128.value + 16);
+//        std::reverse(m_uuid.u128.value, m_uuid.u128.value + 16);
+        std::reverse_copy(pData, pData + 16, m_uuid.u128.value);
+    } else {
+        memcpy(m_uuid.u128.value, pData, 16);
     }
     m_valueSet = true;
 } // NimBLEUUID

--- a/src/NimBLEUUID.cpp
+++ b/src/NimBLEUUID.cpp
@@ -198,10 +198,12 @@ uint8_t NimBLEUUID::bitSize() {
  * @return True if the UUIDs are equal and false otherwise.
  */
 bool NimBLEUUID::equals(NimBLEUUID uuid) {
-    if(ble_uuid_cmp(&m_uuid.u, &uuid.getNative()->u) == 0){
-        return true;
+    if(m_valueSet && rhs.m_valueSet) {
+        if(ble_uuid_cmp(&m_uuid.u, &uuid.getNative()->u) == 0){
+            return true;
+        }
     }
-    return false;
+    return m_valueSet == rhs.m_valueSet;
 }
 
 
@@ -317,5 +319,35 @@ std::string NimBLEUUID::toString() {
 
     return ble_uuid_to_str(&m_uuid.u, buf);
 } // toString
+
+
+NimBLEUUID & NimBLEUUID::operator=(const NimBLEUUID & other) {
+    m_uuid.u.type = other.m_uuid.u.type;
+    if(other.m_valueSet) {
+        memcpy(m_uuid.u128.value, other.m_uuid.u128.value, 16);
+    }
+    m_valueSet = other.m_valueSet;
+}
+
+bool NimBLEUUID::operator ==(const NimBLEUUID & rhs) {
+    if(m_valueSet && rhs.m_valueSet) {
+        return ble_uuid_cmp(&m_uuid.u, &rhs.m_uuid.u) == 0;
+    }
+
+    return m_valueSet == rhs.m_valueSet;
+}
+
+bool NimBLEUUID::operator !=(const NimBLEUUID & rhs) {
+    return !this->operator==(rhs);
+}
+
+NimBLEUUID::operator std::string() const {
+    if (!m_valueSet) return std::string();   // If we have no value, nothing to format.
+
+    char buf[BLE_UUID_STR_LEN];
+
+    return ble_uuid_to_str(&m_uuid.u, buf);
+}
+
 
 #endif /* CONFIG_BT_ENABLED */

--- a/src/NimBLEUUID.h
+++ b/src/NimBLEUUID.h
@@ -44,6 +44,11 @@ public:
     std::string    toString();
     static NimBLEUUID fromString(std::string uuid);  // Create a NimBLEUUID from a string
 
+    NimBLEUUID & operator=(const NimBLEUUID & other);
+    bool operator ==(const NimBLEUUID & rhs);
+    bool operator !=(const NimBLEUUID & rhs);
+    operator std::string() const;
+
 private:
     ble_uuid_any_t m_uuid;              // The underlying UUID structure that this class wraps.
     bool           m_valueSet = false;   // Is there a value set for this instance.

--- a/src/NimBLEUUID.h
+++ b/src/NimBLEUUID.h
@@ -40,7 +40,7 @@ public:
     uint8_t        bitSize();   // Get the number of bits in this uuid.
     bool           equals(NimBLEUUID uuid);
     ble_uuid_any_t* getNative();
-    NimBLEUUID        to128();
+    NimBLEUUID &     to128();
     std::string    toString();
     static NimBLEUUID fromString(std::string uuid);  // Create a NimBLEUUID from a string
 

--- a/src/NimBLEUUID.h
+++ b/src/NimBLEUUID.h
@@ -44,7 +44,6 @@ public:
     std::string    toString();
     static NimBLEUUID fromString(std::string uuid);  // Create a NimBLEUUID from a string
 
-    NimBLEUUID & operator=(const NimBLEUUID & other);
     bool operator ==(const NimBLEUUID & rhs);
     bool operator !=(const NimBLEUUID & rhs);
     operator std::string() const;


### PR DESCRIPTION
With these operators you now can do:

```
BLEUUID first = BLEUUID(0xebe0ccb0, 0x7a0a, 0x4b0c, 0x8a1a6ff2997da3a6);
BLEUUID second = first;
if(first == second) ....
if(first != BLEUID("180f")) ...
std::string stringValue = std::string(first);
```

Also, ::equals() did not test if the values were set. So two uninitialized values where likely not to be equal, while in my opinion they are. If one or both values to compare were unset, then initialized memory was compared. Although not harmful, this is incorrect.

This may be inspiration to add these operators to a lot more classes defined in this library.