### PR TITLE
Refactoring NimBLEAddress

### DIFF
--- a/src/NimBLEAddress.cpp
+++ b/src/NimBLEAddress.cpp
@@ -47,7 +47,7 @@ NimBLEAddress::NimBLEAddress(ble_addr_t address) {
  *
  * @param [in] stringAddress The hex representation of the address.
  */
-NimBLEAddress::NimBLEAddress(std::string stringAddress) {
+NimBLEAddress::NimBLEAddress(const std::string &stringAddress) {
     if (stringAddress.length() != 17) {
         memset(m_address, 0, sizeof m_address); // "00:00:00:00:00:00" represents an invalid address
         NIMBLE_LOGD(LOG_TAG, "Invalid address '%s'", stringAddress.c_str());
@@ -78,7 +78,7 @@ NimBLEAddress::NimBLEAddress(uint8_t address[6]) {
  * @brief Constructor for address using a hex value. Use the same byte order, so use 0xa4c1385def16 for "a4:c1:38:5d:ef:16"
  * @param [in] uint64_t containing the address.
  */
-NimBLEAddress::NimBLEAddress(uint64_t address) {
+NimBLEAddress::NimBLEAddress(const uint64_t &address) {
     memcpy(m_address, &address, sizeof m_address);
 } // NimBLEAddress
 
@@ -88,7 +88,7 @@ NimBLEAddress::NimBLEAddress(uint64_t address) {
  * @param [in] otherAddress The other address to compare against.
  * @return True if the addresses are equal.
  */
-bool NimBLEAddress::equals(NimBLEAddress otherAddress) {
+bool NimBLEAddress::equals(const NimBLEAddress &otherAddress) const {
     return *this == otherAddress;
 } // equals
 
@@ -97,7 +97,7 @@ bool NimBLEAddress::equals(NimBLEAddress otherAddress) {
  * @brief Return the native representation of the address.
  * @return The native representation of the address.
  */
-uint8_t *NimBLEAddress::getNative() {
+const uint8_t *NimBLEAddress::getNative() const {
     return m_address;
 } // getNative
 
@@ -113,16 +113,16 @@ uint8_t *NimBLEAddress::getNative() {
  *
  * @return The string representation of the address.
  */
-std::string NimBLEAddress::toString() {
+std::string NimBLEAddress::toString() const {
     return std::string(*this);
 } // toString
 
 
-bool NimBLEAddress::operator ==(const NimBLEAddress & rhs) {
+bool NimBLEAddress::operator ==(const NimBLEAddress & rhs) const {
     return memcmp(rhs.m_address, m_address, sizeof m_address) == 0;
 }
 
-bool NimBLEAddress::operator !=(const NimBLEAddress & rhs) {
+bool NimBLEAddress::operator !=(const NimBLEAddress & rhs) const {
     return !this->operator==(rhs);
 }
 

--- a/src/NimBLEAddress.cpp
+++ b/src/NimBLEAddress.cpp
@@ -70,8 +70,7 @@ NimBLEAddress::NimBLEAddress(std::string stringAddress) {
  * @param [in] uint8_t[6] or esp_bd_addr_t struct containing the address.
  */
 NimBLEAddress::NimBLEAddress(uint8_t address[6]) {
-    memcpy(m_address, address, sizeof m_address);
-    std::reverse(m_address, m_address + sizeof m_address);
+    std::reverse_copy(address, address + sizeof m_address, m_address);
 } // NimBLEAddress
 
 

--- a/src/NimBLEAddress.h
+++ b/src/NimBLEAddress.h
@@ -35,9 +35,14 @@ public:
     NimBLEAddress(ble_addr_t address);
     NimBLEAddress(uint8_t address[6]);
     NimBLEAddress(std::string stringAddress);
+    NimBLEAddress(uint64_t address);
     bool           equals(NimBLEAddress otherAddress);
     uint8_t*       getNative();
     std::string    toString();
+
+    bool operator 	==(const NimBLEAddress & rhs);
+    bool operator 	!=(const NimBLEAddress & rhs);
+    operator 		std::string() const;
 
 private:
     uint8_t        m_address[6];

--- a/src/NimBLEAddress.h
+++ b/src/NimBLEAddress.h
@@ -34,14 +34,14 @@ class NimBLEAddress {
 public:
     NimBLEAddress(ble_addr_t address);
     NimBLEAddress(uint8_t address[6]);
-    NimBLEAddress(std::string stringAddress);
-    NimBLEAddress(uint64_t address);
-    bool           equals(NimBLEAddress otherAddress);
-    uint8_t*       getNative();
-    std::string    toString();
+    NimBLEAddress(const std::string &stringAddress);
+    NimBLEAddress(const uint64_t &address);
+    bool           equals(const NimBLEAddress &otherAddress) const;
+    const uint8_t*       getNative() const;
+    std::string    toString() const;
 
-    bool operator 	==(const NimBLEAddress & rhs);
-    bool operator 	!=(const NimBLEAddress & rhs);
+    bool operator 	==(const NimBLEAddress & rhs) const;
+    bool operator 	!=(const NimBLEAddress & rhs) const;
     operator 		std::string() const;
 
 private:


### PR DESCRIPTION
- Add logging for malformed addresses
- Set invalid addresses to "00:00:00:00:00:00", so the main program can easily check if an address is correctly parsed (`if(NimBLEAddress("invalid address") == NimBLEAddress(0)) ...`)
- Add constructor directly from a (hex) uint64_t value. `NimBLEAddress(0xa4c1385def16)` yields the same address as `NimBLEAddress("a4:c1:38:5d:ef:16")`
- Remove `memrcpy()`, using standard cpp instead
- Add `operator ==`, `operator !=` and `operator std::string()` cast
- Use `operator ==` in `::equals()`
- Use `operator std::string()` in `::toString()` (also avoiding the `malloc` because the cast uses a local buffer that is declared on the stack)