### PR TITLE
Pass parameters as const &

### DIFF
--- a/src/NimBLEAddress.cpp
+++ b/src/NimBLEAddress.cpp
@@ -43,7 +43,7 @@ NimBLEAddress::NimBLEAddress(ble_addr_t address) {
  *
  * @param [in] stringAddress The hex representation of the address.
  */
-NimBLEAddress::NimBLEAddress(std::string stringAddress) {
+NimBLEAddress::NimBLEAddress(const std::string &stringAddress) {
     if (stringAddress.length() != 17) return;
 
     int data[6];
@@ -71,7 +71,7 @@ NimBLEAddress::NimBLEAddress(uint8_t address[6]) {
  * @param [in] otherAddress The other address to compare against.
  * @return True if the addresses are equal.
  */
-bool NimBLEAddress::equals(NimBLEAddress otherAddress) {
+bool NimBLEAddress::equals(const NimBLEAddress &otherAddress) const {
     return memcmp(otherAddress.getNative(), m_address, 6) == 0;
 } // equals
 
@@ -80,7 +80,7 @@ bool NimBLEAddress::equals(NimBLEAddress otherAddress) {
  * @brief Return the native representation of the address.
  * @return The native representation of the address.
  */
-uint8_t *NimBLEAddress::getNative() {
+const uint8_t *NimBLEAddress::getNative() const {
     return m_address;
 } // getNative
 
@@ -96,7 +96,7 @@ uint8_t *NimBLEAddress::getNative() {
  *
  * @return The string representation of the address.
  */
-std::string NimBLEAddress::toString() {
+std::string NimBLEAddress::toString() const {
     auto size = 18;
     char *res = (char*)malloc(size);
     snprintf(res, size, "%02x:%02x:%02x:%02x:%02x:%02x", m_address[5], m_address[4], m_address[3], m_address[2], m_address[1], m_address[0]);

--- a/src/NimBLEAddress.h
+++ b/src/NimBLEAddress.h
@@ -34,10 +34,10 @@ class NimBLEAddress {
 public:
     NimBLEAddress(ble_addr_t address);
     NimBLEAddress(uint8_t address[6]);
-    NimBLEAddress(std::string stringAddress);
-    bool           equals(NimBLEAddress otherAddress);
-    uint8_t*       getNative();
-    std::string    toString();
+    NimBLEAddress(const std::string &stringAddress);
+    bool           equals(const NimBLEAddress &otherAddress) const;
+    const uint8_t* getNative() const;
+    std::string    toString() const;
 
 private:
     uint8_t        m_address[6];

--- a/src/NimBLEAdvertisedDevice.cpp
+++ b/src/NimBLEAdvertisedDevice.cpp
@@ -141,7 +141,7 @@ NimBLEUUID NimBLEAdvertisedDevice::getServiceUUID() {  //TODO Remove it eventual
  * @brief Check advertised serviced for existence required UUID
  * @return Return true if service is advertised
  */
-bool NimBLEAdvertisedDevice::isAdvertisingService(NimBLEUUID uuid){
+bool NimBLEAdvertisedDevice::isAdvertisingService(const NimBLEUUID &uuid){
     for (int i = 0; i < m_serviceUUIDs.size(); i++) {
         NIMBLE_LOGI(LOG_TAG, "Comparing UUIDS: %s %s", m_serviceUUIDs[i].toString().c_str(), uuid.toString().c_str());
         if (m_serviceUUIDs[i].equals(uuid)) return true;

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -54,7 +54,7 @@ public:
     void setAddressType(uint8_t type);
 
 
-    bool        isAdvertisingService(NimBLEUUID uuid);
+    bool        isAdvertisingService(const NimBLEUUID &uuid);
     bool        haveAppearance();
     bool        haveManufacturerData();
     bool        haveName();

--- a/src/NimBLEAdvertising.cpp
+++ b/src/NimBLEAdvertising.cpp
@@ -58,7 +58,7 @@ NimBLEAdvertising::NimBLEAdvertising() {
  * @brief Add a service uuid to exposed list of services.
  * @param [in] serviceUUID The UUID of the service to expose.
  */
-void NimBLEAdvertising::addServiceUUID(NimBLEUUID serviceUUID) {
+void NimBLEAdvertising::addServiceUUID(const NimBLEUUID &serviceUUID) {
 	m_serviceUUIDs.push_back(serviceUUID);
 } // addServiceUUID
 
@@ -393,7 +393,7 @@ void NimBLEAdvertising::onHostReset() {
  * @brief Add data to the payload to be advertised.
  * @param [in] data The data to be added to the payload.
  */
-void NimBLEAdvertisementData::addData(std::string data) {
+void NimBLEAdvertisementData::addData(const std::string &data) {
 	if ((m_payload.length() + data.length()) > BLE_HS_ADV_MAX_SZ) {
 		return;
 	}
@@ -420,7 +420,7 @@ void NimBLEAdvertisementData::setAppearance(uint16_t appearance) {
  * @brief Set the complete services.
  * @param [in] uuid The single service to advertise.
  */
-void NimBLEAdvertisementData::setCompleteServices(NimBLEUUID uuid) {
+void NimBLEAdvertisementData::setCompleteServices(const NimBLEUUID &uuid) {
 	char cdata[2];
 	switch (uuid.bitSize()) {
 		case 16: {
@@ -482,7 +482,7 @@ void NimBLEAdvertisementData::setFlags(uint8_t flag) {
  * @brief Set manufacturer specific data.
  * @param [in] data Manufacturer data.
  */
-void NimBLEAdvertisementData::setManufacturerData(std::string data) {
+void NimBLEAdvertisementData::setManufacturerData(const std::string &data) {
 	NIMBLE_LOGD("NimBLEAdvertisementData", ">> setManufacturerData");
 	char cdata[2];
 	cdata[0] = data.length() + 1;
@@ -496,7 +496,7 @@ void NimBLEAdvertisementData::setManufacturerData(std::string data) {
  * @brief Set the name.
  * @param [in] The complete name of the device.
  */
-void NimBLEAdvertisementData::setName(std::string name) {
+void NimBLEAdvertisementData::setName(const std::string &name) {
 	NIMBLE_LOGD("NimBLEAdvertisementData", ">> setName: %s", name.c_str());
 	char cdata[2];
 	cdata[0] = name.length() + 1;
@@ -510,7 +510,7 @@ void NimBLEAdvertisementData::setName(std::string name) {
  * @brief Set the partial services.
  * @param [in] uuid The single service to advertise.
  */
-void NimBLEAdvertisementData::setPartialServices(NimBLEUUID uuid) {
+void NimBLEAdvertisementData::setPartialServices(const NimBLEUUID &uuid) {
 	char cdata[2];
 	switch (uuid.bitSize()) {
 		case 16: {
@@ -548,7 +548,7 @@ void NimBLEAdvertisementData::setPartialServices(NimBLEUUID uuid) {
  * @param [in] uuid The UUID to set with the service data.  Size of UUID will be used.
  * @param [in] data The data to be associated with the service data advert.
  */
-void NimBLEAdvertisementData::setServiceData(NimBLEUUID uuid, std::string data) {
+void NimBLEAdvertisementData::setServiceData(const NimBLEUUID &uuid, const std::string &data) {
 	char cdata[2];
 	switch (uuid.bitSize()) {
 		case 16: {
@@ -585,7 +585,7 @@ void NimBLEAdvertisementData::setServiceData(NimBLEUUID uuid, std::string data) 
  * @brief Set the short name.
  * @param [in] The short name of the device.
  */
-void NimBLEAdvertisementData::setShortName(std::string name) {
+void NimBLEAdvertisementData::setShortName(const std::string &name) {
 	NIMBLE_LOGD("NimBLEAdvertisementData", ">> setShortName: %s", name.c_str());
 	char cdata[2];
 	cdata[0] = name.length() + 1;

--- a/src/NimBLEAdvertising.h
+++ b/src/NimBLEAdvertising.h
@@ -47,14 +47,14 @@ class NimBLEAdvertisementData {
 	//
 public:
 	void setAppearance(uint16_t appearance);
-	void setCompleteServices(NimBLEUUID uuid);
+	void setCompleteServices(const NimBLEUUID &uuid);
 	void setFlags(uint8_t);
-	void setManufacturerData(std::string data);
-	void setName(std::string name);
-	void setPartialServices(NimBLEUUID uuid);
-	void setServiceData(NimBLEUUID uuid, std::string data);
-	void setShortName(std::string name);
-	void addData(std::string data);  // Add data to the payload.
+	void setManufacturerData(const std::string &data);
+	void setName(const std::string &name);
+	void setPartialServices(const NimBLEUUID &uuid);
+	void setServiceData(const NimBLEUUID &uuid, const std::string &data);
+	void setShortName(const std::string &name);
+	void addData(const std::string &data);  // Add data to the payload.
 	std::string getPayload();               // Retrieve the current advert payload.
 
 private:
@@ -71,7 +71,7 @@ private:
 class NimBLEAdvertising {
 public:
 	NimBLEAdvertising();
-	void addServiceUUID(NimBLEUUID serviceUUID);
+	void addServiceUUID(const NimBLEUUID &serviceUUID);
 	void addServiceUUID(const char* serviceUUID);
 	void start();
 	void stop();

--- a/src/NimBLEBeacon.cpp
+++ b/src/NimBLEBeacon.cpp
@@ -58,7 +58,7 @@ int8_t NimBLEBeacon::getSignalPower() {
 /**
  * Set the raw data for the beacon record.
  */
-void NimBLEBeacon::setData(std::string data) {
+void NimBLEBeacon::setData(const std::string &data) {
 	if (data.length() != sizeof(m_beaconData)) {
 		NIMBLE_LOGE(LOG_TAG, "Unable to set the data ... length passed in was %d and expected %d", 
                                                         data.length(), sizeof(m_beaconData));
@@ -79,9 +79,10 @@ void NimBLEBeacon::setMinor(uint16_t minor) {
 	m_beaconData.minor = ENDIAN_CHANGE_U16(minor);
 } // setMinior
 
-void NimBLEBeacon::setProximityUUID(NimBLEUUID uuid) {
-	uuid = uuid.to128();
-	memcpy(m_beaconData.proximityUUID, uuid.getNative()->u128.value, 16);
+void NimBLEBeacon::setProximityUUID(const NimBLEUUID &uuid) {
+	NimBLEUUID temp_uuid = uuid;
+	temp_uuid.to128();
+	memcpy(m_beaconData.proximityUUID, temp_uuid.getNative()->u128.value, 16);
 } // setProximityUUID
 
 void NimBLEBeacon::setSignalPower(int8_t signalPower) {

--- a/src/NimBLEBeacon.h
+++ b/src/NimBLEBeacon.h
@@ -39,11 +39,11 @@ public:
 	uint16_t    getManufacturerId();
 	NimBLEUUID     getProximityUUID();
 	int8_t      getSignalPower();
-	void        setData(std::string data);
+	void        setData(const std::string &data);
 	void        setMajor(uint16_t major);
 	void        setMinor(uint16_t minor);
 	void        setManufacturerId(uint16_t manufacturerId);
-	void        setProximityUUID(NimBLEUUID uuid);
+	void        setProximityUUID(const NimBLEUUID &uuid);
 	void        setSignalPower(int8_t signalPower);
 }; // NimBLEBeacon
 

--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -41,7 +41,7 @@ NimBLECharacteristic::NimBLECharacteristic(const char* uuid, uint16_t properties
  * @param [in] uuid - UUID for the characteristic.
  * @param [in] properties - Properties for the characteristic.
  */
-NimBLECharacteristic::NimBLECharacteristic(NimBLEUUID uuid, uint16_t properties, NimBLEService* pService) {
+NimBLECharacteristic::NimBLECharacteristic(const NimBLEUUID &uuid, uint16_t properties, NimBLEService* pService) {
 	m_uuid       = uuid;
 	m_handle     = NULL_HANDLE;
 	m_properties = properties;
@@ -99,7 +99,7 @@ NimBLEDescriptor* NimBLECharacteristic::createDescriptor(const char* uuid, uint3
  * @param [in] properties - The properties of the descriptor.
  * @return The new BLE descriptor.
  */
-NimBLEDescriptor* NimBLECharacteristic::createDescriptor(NimBLEUUID uuid, uint32_t properties, uint16_t max_len) {
+NimBLEDescriptor* NimBLECharacteristic::createDescriptor(const NimBLEUUID &uuid, uint32_t properties, uint16_t max_len) {
 	NimBLEDescriptor* pDescriptor = nullptr;
 	if(uuid.equals(NimBLEUUID((uint16_t)0x2902))) {
         if(!(m_properties & BLE_GATT_CHR_F_NOTIFY) && !(m_properties & BLE_GATT_CHR_F_INDICATE)) {
@@ -139,7 +139,7 @@ NimBLEDescriptor* NimBLECharacteristic::getDescriptorByUUID(const char* descript
  * @param [in] descriptorUUID The UUID of the descriptor that we wish to retrieve.
  * @return The BLE Descriptor.  If no such descriptor is associated with the characteristic, nullptr is returned.
  */
-NimBLEDescriptor* NimBLECharacteristic::getDescriptorByUUID(NimBLEUUID descriptorUUID) {
+NimBLEDescriptor* NimBLECharacteristic::getDescriptorByUUID(const NimBLEUUID &descriptorUUID) {
 	return m_descriptorMap.getByUUID(descriptorUUID);
 } // getDescriptorByUUID
 
@@ -518,7 +518,7 @@ void NimBLECharacteristic::setWriteProperty(bool value) {
  * @param [in] data The data to set for the characteristic.
  * @param [in] length The length of the data in bytes.
  */
-void NimBLECharacteristic::setValue(uint8_t* data, size_t length) {
+void NimBLECharacteristic::setValue(const uint8_t* data, size_t length) {
 	char* pHex = NimBLEUtils::buildHexData(nullptr, data, length);
 	NIMBLE_LOGD(LOG_TAG, ">> setValue: length=%d, data=%s, characteristic UUID=%s", length, pHex, getUUID().toString().c_str());
 	free(pHex);
@@ -546,7 +546,7 @@ void NimBLECharacteristic::setValue(uint8_t* data, size_t length) {
  * @param [in] Set the value of the characteristic.
  * @return N/A.
  */
-void NimBLECharacteristic::setValue(std::string value) {
+void NimBLECharacteristic::setValue(const std::string &value) {
 	setValue((uint8_t*)(value.data()), value.length());
 } // setValue
 

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -58,10 +58,10 @@ class NimBLECharacteristicCallbacks;
 class NimBLEDescriptorMap {
 public:
 	void setByUUID(const char* uuid, NimBLEDescriptor* pDescriptor);
-	void setByUUID(NimBLEUUID uuid, NimBLEDescriptor* pDescriptor);
+	void setByUUID(const NimBLEUUID &uuid, NimBLEDescriptor* pDescriptor);
 //	void setByHandle(uint16_t handle, NimBLEDescriptor* pDescriptor);
 	NimBLEDescriptor* getByUUID(const char* uuid);
-	NimBLEDescriptor* getByUUID(NimBLEUUID uuid);
+	NimBLEDescriptor* getByUUID(const NimBLEUUID &uuid);
 //	NimBLEDescriptor* getByHandle(uint16_t handle);
 	std::string	toString();
 	NimBLEDescriptor* getFirst();
@@ -87,13 +87,13 @@ public:
 						uint32_t properties = NIMBLE_PROPERTY::READ | 
 											  NIMBLE_PROPERTY::WRITE,
                                      uint16_t max_len = 100);
-	NimBLEDescriptor* createDescriptor(NimBLEUUID uuid,
+	NimBLEDescriptor* createDescriptor(const NimBLEUUID &uuid,
 						uint32_t properties = NIMBLE_PROPERTY::READ | 
 											  NIMBLE_PROPERTY::WRITE,
                                      uint16_t max_len = 100);
 											  
 	NimBLEDescriptor* getDescriptorByUUID(const char* descriptorUUID);
-	NimBLEDescriptor* getDescriptorByUUID(NimBLEUUID descriptorUUID);
+	NimBLEDescriptor* getDescriptorByUUID(const NimBLEUUID &descriptorUUID);
 	NimBLEUUID        getUUID();
 	std::string       getValue();
 	uint8_t*          getData();
@@ -110,8 +110,8 @@ public:
     void setWriteProperty(bool value);
 	void setWriteNoResponseProperty(bool value);
 //////////////////////////////////////////////////////    
-	void setValue(uint8_t* data, size_t size);
-	void setValue(std::string value);
+	void setValue(const uint8_t* data, size_t size);
+	void setValue(const std::string &value);
 	void setValue(uint16_t& data16);
 	void setValue(uint32_t& data32);
 	void setValue(int& data32);
@@ -141,7 +141,7 @@ private:
 
 	NimBLECharacteristic(const char* uuid, uint16_t properties = NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE,
 														NimBLEService* pService = nullptr);
-	NimBLECharacteristic(NimBLEUUID uuid, uint16_t properties = NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE,
+	NimBLECharacteristic(const NimBLEUUID &uuid, uint16_t properties = NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE,
 														NimBLEService* pService = nullptr);
 	virtual ~NimBLECharacteristic();
 

--- a/src/NimBLECharacteristicMap.cpp
+++ b/src/NimBLECharacteristicMap.cpp
@@ -41,7 +41,7 @@ NimBLECharacteristic* NimBLECharacteristicMap::getByUUID(const char* uuid) {
  * @param [in] UUID The UUID to look up the characteristic.
  * @return The characteristic.
  */
-NimBLECharacteristic* NimBLECharacteristicMap::getByUUID(NimBLEUUID uuid) {
+NimBLECharacteristic* NimBLECharacteristicMap::getByUUID(const NimBLEUUID &uuid) {
 	for (auto &myPair : m_uuidMap) {
 		if (myPair.first->getUUID().equals(uuid)) {
 			return myPair.first;
@@ -100,7 +100,7 @@ void NimBLECharacteristicMap::setByHandle(uint16_t handle, NimBLECharacteristic*
  * @param [in] characteristic The characteristic to cache.
  * @return N/A.
  */
-void NimBLECharacteristicMap::setByUUID(NimBLECharacteristic* pCharacteristic, NimBLEUUID uuid) {
+void NimBLECharacteristicMap::setByUUID(NimBLECharacteristic* pCharacteristic, const NimBLEUUID &uuid) {
 	m_uuidMap.insert(std::pair<NimBLECharacteristic*, std::string>(pCharacteristic, uuid.toString()));
 } // setByUUID
 

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -120,7 +120,7 @@ bool NimBLEClient::connect(NimBLEAdvertisedDevice* device, bool refreshServices)
  * @param [in] address The address of the partner.
  * @return True on success.
  */
-bool NimBLEClient::connect(NimBLEAddress address, uint8_t type, bool refreshServices) {
+bool NimBLEClient::connect(const NimBLEAddress &address, uint8_t type, bool refreshServices) {
     NIMBLE_LOGD(LOG_TAG, ">> connect(%s)", address.toString().c_str());
     
     if(!NimBLEDevice::m_synced) {
@@ -359,7 +359,7 @@ NimBLERemoteService* NimBLEClient::getService(const char* uuid) {
  * @param [in] uuid The UUID of the service being sought.
  * @return A reference to the Service or nullptr if don't know about it.
  */
-NimBLERemoteService* NimBLEClient::getService(NimBLEUUID uuid) {
+NimBLERemoteService* NimBLEClient::getService(const NimBLEUUID &uuid) {
     NIMBLE_LOGD(LOG_TAG, ">> getService: uuid: %s", uuid.toString().c_str());
 
     if (!m_haveServices) {
@@ -494,7 +494,7 @@ int NimBLEClient::serviceDiscoveredCB(
  * @param [in] characteristicUUID The characteristic whose value we wish to read.
  * @returns characteristic value or an empty string if not found
  */
-std::string NimBLEClient::getValue(NimBLEUUID serviceUUID, NimBLEUUID characteristicUUID) {
+std::string NimBLEClient::getValue(const NimBLEUUID &serviceUUID, const NimBLEUUID &characteristicUUID) {
     NIMBLE_LOGD(LOG_TAG, ">> getValue: serviceUUID: %s, characteristicUUID: %s", serviceUUID.toString().c_str(), characteristicUUID.toString().c_str());
     
     std::string ret = "";
@@ -518,7 +518,7 @@ std::string NimBLEClient::getValue(NimBLEUUID serviceUUID, NimBLEUUID characteri
  * @param [in] characteristicUUID The characteristic whose value we wish to write.
  * @returns true if successful otherwise false
  */
-bool NimBLEClient::setValue(NimBLEUUID serviceUUID, NimBLEUUID characteristicUUID, std::string value) {
+bool NimBLEClient::setValue(const NimBLEUUID &serviceUUID, const NimBLEUUID &characteristicUUID, const std::string &value) {
     NIMBLE_LOGD(LOG_TAG, ">> setValue: serviceUUID: %s, characteristicUUID: %s", serviceUUID.toString().c_str(), characteristicUUID.toString().c_str());
     
     bool ret = false;

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -34,15 +34,15 @@ class NimBLEAdvertisedDevice;
 class NimBLEClient {
 public:
     bool                                       connect(NimBLEAdvertisedDevice* device, bool refreshServices = true);
-    bool                                       connect(NimBLEAddress address, uint8_t type = BLE_ADDR_PUBLIC, bool refreshServices = true);   // Connect to the remote BLE Server
+    bool                                       connect(const NimBLEAddress &address, uint8_t type = BLE_ADDR_PUBLIC, bool refreshServices = true);   // Connect to the remote BLE Server
     int                                        disconnect(uint8_t reason = BLE_ERR_REM_USER_CONN_TERM);                  // Disconnect from the remote BLE Server
     NimBLEAddress                              getPeerAddress();              // Get the address of the remote BLE Server
     int                                        getRssi();                     // Get the RSSI of the remote BLE Server
     std::map<std::string, NimBLERemoteService*>*  getServices();                 // Get a map of the services offered by the remote BLE Server
     NimBLERemoteService*                          getService(const char* uuid);  // Get a reference to a specified service offered by the remote BLE server.
-    NimBLERemoteService*                          getService(NimBLEUUID uuid);   // Get a reference to a specified service offered by the remote BLE server.
-    std::string                                getValue(NimBLEUUID serviceUUID, NimBLEUUID characteristicUUID);   // Get the value of a given characteristic at a given service.
-    bool                                       setValue(NimBLEUUID serviceUUID, NimBLEUUID characteristicUUID, std::string value);   // Set the value of a given characteristic at a given service.
+    NimBLERemoteService*                          getService(const NimBLEUUID &uuid);   // Get a reference to a specified service offered by the remote BLE server.
+    std::string                                getValue(const NimBLEUUID &serviceUUID, const NimBLEUUID &characteristicUUID);   // Get the value of a given characteristic at a given service.
+    bool                                       setValue(const NimBLEUUID &serviceUUID, const NimBLEUUID &characteristicUUID, const std::string &value);   // Set the value of a given characteristic at a given service.
     bool                                       isConnected();                 // Return true if we are connected.
     void                                       setClientCallbacks(NimBLEClientCallbacks *pClientCallbacks, bool deleteCallbacks = true);
     std::string                                toString();                    // Return a string representation of this client.

--- a/src/NimBLEDescriptor.cpp
+++ b/src/NimBLEDescriptor.cpp
@@ -187,7 +187,7 @@ void NimBLEDescriptor::setHandle(uint16_t handle) {
  * @param [in] data The data to set for the descriptor.
  * @param [in] length The length of the data in bytes.
  */
-void NimBLEDescriptor::setValue(uint8_t* data, size_t length) {
+void NimBLEDescriptor::setValue(const uint8_t* data, size_t length) {
 	if (length > BLE_ATT_ATTR_MAX_LEN) {
 		NIMBLE_LOGE(LOG_TAG, "Size %d too large, must be no bigger than %d", length, BLE_ATT_ATTR_MAX_LEN);
 		return;
@@ -201,7 +201,7 @@ void NimBLEDescriptor::setValue(uint8_t* data, size_t length) {
  * @brief Set the value of the descriptor.
  * @param [in] value The value of the descriptor in string form.
  */
-void NimBLEDescriptor::setValue(std::string value) {
+void NimBLEDescriptor::setValue(const std::string &value) {
 	setValue((uint8_t*) value.data(), value.length());
 } // setValue
 

--- a/src/NimBLEDescriptor.h
+++ b/src/NimBLEDescriptor.h
@@ -50,8 +50,8 @@ public:
 	uint8_t* getValue();                                    // Get a pointer to the value of the descriptor.
 //	void setAccessPermissions(uint8_t perm);	      // Set the permissions of the descriptor.
 	void setCallbacks(NimBLEDescriptorCallbacks* pCallbacks);  // Set callbacks to be invoked for the descriptor.
-	void setValue(uint8_t* data, size_t size);              // Set the value of the descriptor as a pointer to data.
-	void setValue(std::string value);                       // Set the value of the descriptor as a data buffer.
+	void setValue(const uint8_t* data, size_t size);              // Set the value of the descriptor as a pointer to data.
+	void setValue(const std::string &value);                       // Set the value of the descriptor as a data buffer.
 
 	std::string toString();                                 // Convert the descriptor to a string representation.
 

--- a/src/NimBLEDescriptorMap.cpp
+++ b/src/NimBLEDescriptorMap.cpp
@@ -32,7 +32,7 @@ NimBLEDescriptor* NimBLEDescriptorMap::getByUUID(const char* uuid) {
  * @param [in] UUID The UUID to look up the descriptor.
  * @return The descriptor.  If not present, then nullptr is returned.
  */
-NimBLEDescriptor* NimBLEDescriptorMap::getByUUID(NimBLEUUID uuid) {
+NimBLEDescriptor* NimBLEDescriptorMap::getByUUID(const NimBLEUUID &uuid) {
 	for (auto &myPair : m_uuidMap) {
 		if (myPair.first->getUUID().equals(uuid)) {
 			return myPair.first;
@@ -71,7 +71,7 @@ void NimBLEDescriptorMap::setByUUID(const char* uuid, NimBLEDescriptor* pDescrip
  * @param [in] characteristic The descriptor to cache.
  * @return N/A.
  */
-void NimBLEDescriptorMap::setByUUID(NimBLEUUID uuid, NimBLEDescriptor* pDescriptor) {
+void NimBLEDescriptorMap::setByUUID(const NimBLEUUID &uuid, NimBLEDescriptor* pDescriptor) {
 	m_uuidMap.insert(std::pair<NimBLEDescriptor*, std::string>(pDescriptor, uuid.toString()));
 } // setByUUID
 

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -202,7 +202,7 @@ void NimBLEDevice::stopAdvertising() {
  * @param [in] a NimBLEAddress of the peer to search for.
  * @return A reference pointer to the client with the peer address.
  */
-/* STATIC */NimBLEClient* NimBLEDevice::getClientByPeerAddress(NimBLEAddress peer_addr) {
+/* STATIC */NimBLEClient* NimBLEDevice::getClientByPeerAddress(const NimBLEAddress &peer_addr) {
     for(auto it = m_cList.cbegin(); it != m_cList.cend(); ++it) {
         if((*it)->getPeerAddress().equals(peer_addr)) {
             return (*it);
@@ -410,7 +410,7 @@ void NimBLEDevice::stopAdvertising() {
  * @brief Initialize the %BLE environment.
  * @param deviceName The device name of the device.
  */
-/* STATIC */ void NimBLEDevice::init(std::string deviceName) {
+/* STATIC */ void NimBLEDevice::init(const std::string &deviceName) {
     if(!initialized){
         int rc=0;
         esp_err_t errRc = ESP_OK;
@@ -612,7 +612,7 @@ void NimBLEDevice::setSecurityCallbacks(NimBLESecurityCallbacks* callbacks) {
  * @brief Check if the device address is on our ignore list.
  * @return True if ignoring.
  */
-/*STATIC*/ bool NimBLEDevice::isIgnored(NimBLEAddress address) {
+/*STATIC*/ bool NimBLEDevice::isIgnored(const NimBLEAddress &address) {
     for(auto &it : m_ignoreList) {
         if(it.equals(address)){
             return true;
@@ -627,7 +627,7 @@ void NimBLEDevice::setSecurityCallbacks(NimBLESecurityCallbacks* callbacks) {
  * @brief Add a device to the ignore list.
  * @param Address of the device we want to ignore.
  */
-/*STATIC*/ void NimBLEDevice::addIgnored(NimBLEAddress address) {
+/*STATIC*/ void NimBLEDevice::addIgnored(const NimBLEAddress &address) {
     m_ignoreList.push_back(address);
 }
 
@@ -636,7 +636,7 @@ void NimBLEDevice::setSecurityCallbacks(NimBLESecurityCallbacks* callbacks) {
  * @brief Remove a device from the ignore list.
  * @param Address of the device we want to remove from the list.
  */
-/*STATIC*/void  NimBLEDevice::removeIgnored(NimBLEAddress address) {
+/*STATIC*/void  NimBLEDevice::removeIgnored(const NimBLEAddress &address) {
     for(auto it = m_ignoreList.begin(); it != m_ignoreList.end(); ++it) {
         if((*it).equals(address)){
             m_ignoreList.erase(it);

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -76,7 +76,7 @@ extern "C" void ble_store_config_init(void);
 
 class NimBLEDevice {
 public:
-    static void             init(std::string deviceName);   // Initialize the local BLE environment.
+    static void             init(const std::string &deviceName);   // Initialize the local BLE environment.
     static void             deinit();
     static bool             getInitialized();
     static NimBLEAddress    getAddress();
@@ -98,14 +98,14 @@ public:
     static void             setSecurityCallbacks(NimBLESecurityCallbacks* pCallbacks);
     static int              setMTU(uint16_t mtu);
     static uint16_t         getMTU();
-    static bool             isIgnored(NimBLEAddress address);
-    static void             addIgnored(NimBLEAddress address);
-    static void             removeIgnored(NimBLEAddress address);
+    static bool             isIgnored(const NimBLEAddress &address);
+    static void             addIgnored(const NimBLEAddress &address);
+    static void             removeIgnored(const NimBLEAddress &address);
     static NimBLEAdvertising* getAdvertising();
 	static void		   		startAdvertising();
 	static void		   		stopAdvertising();
     static NimBLEClient*    getClientByID(uint16_t conn_id);
-    static NimBLEClient*    getClientByPeerAddress(NimBLEAddress peer_addr);
+    static NimBLEClient*    getClientByPeerAddress(const NimBLEAddress &peer_addr);
     static NimBLEClient*    getDisconnectedClient();
     static size_t           getClientListSize(); 
     static std::list<NimBLEClient*>* getClientList(); 

--- a/src/NimBLEEddystoneTLM.cpp
+++ b/src/NimBLEEddystoneTLM.cpp
@@ -116,7 +116,7 @@ std::string NimBLEEddystoneTLM::toString() {
 /**
  * Set the raw data for the beacon record.
  */
-void NimBLEEddystoneTLM::setData(std::string data) {
+void NimBLEEddystoneTLM::setData(const std::string &data) {
 	if (data.length() != sizeof(m_eddystoneData)) {
 		NIMBLE_LOGE(LOG_TAG, "Unable to set the data ... length passed in was %d and expected %d", 
                                                 data.length(), sizeof(m_eddystoneData));
@@ -125,7 +125,7 @@ void NimBLEEddystoneTLM::setData(std::string data) {
   memcpy(&m_eddystoneData, data.data(), data.length());
 } // setData
 
-void NimBLEEddystoneTLM::setUUID(NimBLEUUID l_uuid) {
+void NimBLEEddystoneTLM::setUUID(const NimBLEUUID &l_uuid) {
 	beaconUUID = l_uuid.getNative()->u16.value;
 } // setUUID
 

--- a/src/NimBLEEddystoneTLM.h
+++ b/src/NimBLEEddystoneTLM.h
@@ -36,8 +36,8 @@ public:
 	uint32_t	getCount();
 	uint32_t	getTime();
 	std::string toString();
-	void		setData(std::string data);
-	void		setUUID(NimBLEUUID l_uuid);
+	void		setData(const std::string &data);
+	void		setUUID(const NimBLEUUID &l_uuid);
 	void		setVersion(uint8_t version);
 	void		setVolt(uint16_t volt);
 	void		setTemp(float temp);

--- a/src/NimBLEEddystoneURL.cpp
+++ b/src/NimBLEEddystoneURL.cpp
@@ -125,7 +125,7 @@ std::string NimBLEEddystoneURL::getDecodedURL() {
 /**
  * Set the raw data for the beacon record.
  */
-void NimBLEEddystoneURL::setData(std::string data) {
+void NimBLEEddystoneURL::setData(const std::string &data) {
 	if (data.length() > sizeof(m_eddystoneData)) {
 		NIMBLE_LOGE(LOG_TAG, "Unable to set the data ... length passed in was %d and max expected %d",
                                                     data.length(), sizeof(m_eddystoneData));
@@ -136,7 +136,7 @@ void NimBLEEddystoneURL::setData(std::string data) {
 	lengthURL = data.length() - (sizeof(m_eddystoneData) - sizeof(m_eddystoneData.url));
 } // setData
 
-void NimBLEEddystoneURL::setUUID(NimBLEUUID l_uuid) {
+void NimBLEEddystoneURL::setUUID(const NimBLEUUID &l_uuid) {
 	beaconUUID = l_uuid.getNative()->u16.value;
 } // setUUID
 
@@ -144,7 +144,7 @@ void NimBLEEddystoneURL::setPower(int8_t advertisedTxPower) {
 	m_eddystoneData.advertisedTxPower = advertisedTxPower;
 } // setPower
 
-void NimBLEEddystoneURL::setURL(std::string url) {
+void NimBLEEddystoneURL::setURL(const std::string &url) {
   if (url.length() > sizeof(m_eddystoneData.url)) {
 	NIMBLE_LOGE(LOG_TAG, "Unable to set the url ... length passed in was %d and max expected %d", 
                                                     url.length(), sizeof(m_eddystoneData.url));

--- a/src/NimBLEEddystoneURL.h
+++ b/src/NimBLEEddystoneURL.h
@@ -33,10 +33,10 @@ public:
 	int8_t	  getPower();
 	std::string getURL();
 	std::string getDecodedURL();
-	void		setData(std::string data);
-	void		setUUID(NimBLEUUID l_uuid);
+	void		setData(const std::string &data);
+	void		setUUID(const NimBLEUUID &l_uuid);
 	void		setPower(int8_t advertisedTxPower);
-	void		setURL(std::string url);
+	void		setURL(const std::string &url);
 
 private:
 	uint16_t beaconUUID;

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -239,7 +239,7 @@ uint16_t NimBLERemoteCharacteristic::getDefHandle() {
  * @param [in] uuid The UUID of the descriptor to find.
  * @return The Remote descriptor (if present) or null if not present.
  */
-NimBLERemoteDescriptor* NimBLERemoteCharacteristic::getDescriptor(NimBLEUUID uuid) {
+NimBLERemoteDescriptor* NimBLERemoteCharacteristic::getDescriptor(const NimBLEUUID &uuid) {
     NIMBLE_LOGD(LOG_TAG, ">> getDescriptor: uuid: %s", uuid.toString().c_str());
     std::string v = uuid.toString();
     for (auto &myPair : m_descriptorMap) {
@@ -491,7 +491,7 @@ std::string NimBLERemoteCharacteristic::toString() {
  * @param [in] response Do we expect a response?
  * @return false if not connected or cant perform write for some reason.
  */
-bool NimBLERemoteCharacteristic::writeValue(std::string newValue, bool response) {
+bool NimBLERemoteCharacteristic::writeValue(const std::string &newValue, bool response) {
     return writeValue((uint8_t*)newValue.c_str(), strlen(newValue.c_str()), response);
 } // writeValue
 
@@ -516,7 +516,7 @@ bool NimBLERemoteCharacteristic::writeValue(uint8_t newValue, bool response) {
  * @param [in] response Whether we require a response from the write.
  * @return false if not connected or cant perform write for some reason.
  */
-bool NimBLERemoteCharacteristic::writeValue(uint8_t* data, size_t length, bool response) {
+bool NimBLERemoteCharacteristic::writeValue(const uint8_t* data, size_t length, bool response) {
     
     NIMBLE_LOGD(LOG_TAG, ">> writeValue(), length: %d", length);
     

--- a/src/NimBLERemoteCharacteristic.h
+++ b/src/NimBLERemoteCharacteristic.h
@@ -45,7 +45,7 @@ public:
     bool        canRead();
     bool        canWrite();
     bool        canWriteNoResponse();
-    NimBLERemoteDescriptor* getDescriptor(NimBLEUUID uuid);
+    NimBLERemoteDescriptor* getDescriptor(const NimBLEUUID &uuid);
     std::map<std::string, NimBLERemoteDescriptor*>* getDescriptors();
     uint16_t    getHandle();
     uint16_t    getDefHandle();
@@ -55,8 +55,8 @@ public:
     uint16_t    readUInt16();
     uint32_t    readUInt32();
     bool        registerForNotify(notify_callback _callback, bool notifications = true, bool response = true);
-    bool        writeValue(uint8_t* data, size_t length, bool response = false);
-    bool        writeValue(std::string newValue, bool response = false);
+    bool        writeValue(const uint8_t* data, size_t length, bool response = false);
+    bool        writeValue(const std::string &newValue, bool response = false);
     bool        writeValue(uint8_t newValue, bool response = false);
     std::string toString();
     uint8_t*    readRawData();

--- a/src/NimBLERemoteDescriptor.cpp
+++ b/src/NimBLERemoteDescriptor.cpp
@@ -227,7 +227,7 @@ int NimBLERemoteDescriptor::onWriteCB(uint16_t conn_handle,
  * @param [in] length The length of the data to send.
  * @param [in] response True if we expect a response.
  */
-bool NimBLERemoteDescriptor::writeValue(uint8_t* data, size_t length, bool response) {
+bool NimBLERemoteDescriptor::writeValue(const uint8_t* data, size_t length, bool response) {
 
     NIMBLE_LOGD(LOG_TAG, ">> Descriptor writeValue: %s", toString().c_str());
     
@@ -287,7 +287,7 @@ bool NimBLERemoteDescriptor::writeValue(uint8_t* data, size_t length, bool respo
  * @param [in] newValue The data to send to the remote descriptor.
  * @param [in] response True if we expect a response.
  */
-bool NimBLERemoteDescriptor::writeValue(std::string newValue, bool response) {
+bool NimBLERemoteDescriptor::writeValue(const std::string &newValue, bool response) {
     return writeValue((uint8_t*) newValue.data(), newValue.length(), response);
 } // writeValue
 

--- a/src/NimBLERemoteDescriptor.h
+++ b/src/NimBLERemoteDescriptor.h
@@ -33,8 +33,8 @@ public:
     uint16_t    readUInt16(void);
     uint32_t    readUInt32(void);
     std::string toString(void);
-    bool        writeValue(uint8_t* data, size_t length, bool response = false);
-    bool        writeValue(std::string newValue, bool response = false);
+    bool        writeValue(const uint8_t* data, size_t length, bool response = false);
+    bool        writeValue(const std::string &newValue, bool response = false);
     bool        writeValue(uint8_t newValue, bool response = false);
 
 

--- a/src/NimBLERemoteService.cpp
+++ b/src/NimBLERemoteService.cpp
@@ -76,7 +76,7 @@ NimBLERemoteCharacteristic* NimBLERemoteService::getCharacteristic(const char* u
  * @param [in] uuid Characteristic uuid.
  * @return Reference to the characteristic object, or nullptr if not found.
  */
-NimBLERemoteCharacteristic* NimBLERemoteService::getCharacteristic(NimBLEUUID uuid) {
+NimBLERemoteCharacteristic* NimBLERemoteService::getCharacteristic(const NimBLEUUID &uuid) {
     if (m_haveCharacteristics) {
         std::string v = uuid.toString();
         for (auto &myPair : m_characteristicMap) {
@@ -261,7 +261,7 @@ NimBLEUUID NimBLERemoteService::getUUID() {
  * @param [in] characteristicUuid The characteristic to read.
  * @returns a string containing the value or an empty string if not found or error.
  */
-std::string NimBLERemoteService::getValue(NimBLEUUID characteristicUuid) {
+std::string NimBLERemoteService::getValue(const NimBLEUUID &characteristicUuid) {
     NIMBLE_LOGD(LOG_TAG, ">> readValue: uuid: %s", characteristicUuid.toString().c_str());
     
     std::string ret = "";
@@ -282,7 +282,7 @@ std::string NimBLERemoteService::getValue(NimBLEUUID characteristicUuid) {
  * @param [in] value The value to set.
  * @returns true on success, false if not found or error
  */
-bool NimBLERemoteService::setValue(NimBLEUUID characteristicUuid, std::string value) {
+bool NimBLERemoteService::setValue(const NimBLEUUID &characteristicUuid, const std::string &value) {
     NIMBLE_LOGD(LOG_TAG, ">> setValue: uuid: %s", characteristicUuid.toString().c_str());
     
     bool ret = false;

--- a/src/NimBLERemoteService.h
+++ b/src/NimBLERemoteService.h
@@ -37,7 +37,7 @@ public:
 
     // Public methods
     NimBLERemoteCharacteristic* getCharacteristic(const char* uuid);      // Get the specified characteristic reference.
-    NimBLERemoteCharacteristic* getCharacteristic(NimBLEUUID uuid);       // Get the specified characteristic reference.
+    NimBLERemoteCharacteristic* getCharacteristic(const NimBLEUUID &uuid);       // Get the specified characteristic reference.
 //  BLERemoteCharacteristic* getCharacteristic(uint16_t uuid);      // Get the specified characteristic reference.
     std::map<std::string, NimBLERemoteCharacteristic*>* getCharacteristics();
     std::map<uint16_t, NimBLERemoteCharacteristic*>* getCharacteristicsByHandle();  // Get the characteristics map.
@@ -46,8 +46,8 @@ public:
     NimBLEClient*            getClient(void);                                           // Get a reference to the client associated with this service.
     uint16_t                 getHandle();                                               // Get the handle of this service.
     NimBLEUUID               getUUID(void);                                             // Get the UUID of this service.
-    std::string              getValue(NimBLEUUID characteristicUuid);                      // Get the value of a characteristic.
-    bool                     setValue(NimBLEUUID characteristicUuid, std::string value);   // Set the value of a characteristic.
+    std::string              getValue(const NimBLEUUID &characteristicUuid);                      // Get the value of a characteristic.
+    bool                     setValue(const NimBLEUUID &characteristicUuid, const std::string &value);   // Set the value of a characteristic.
     std::string              toString(void);
 
 private:

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -325,7 +325,7 @@ void NimBLEScan::stop() {
 
 
 // delete peer device from cache after disconnecting, it is required in case we are connecting to devices with not public address
-void NimBLEScan::erase(NimBLEAddress address) {
+void NimBLEScan::erase(const NimBLEAddress &address) {
     NIMBLE_LOGI(LOG_TAG, "erase device: %s", address.toString().c_str());
     NimBLEAdvertisedDevice *advertisedDevice = m_scanResults.m_advertisedDevicesMap.find(address.toString())->second;
     m_scanResults.m_advertisedDevicesMap.erase(address.toString());

--- a/src/NimBLEScan.h
+++ b/src/NimBLEScan.h
@@ -62,7 +62,7 @@ public:
     void                stop();
     void                clearResults();
     NimBLEScanResults   getResults();
-    void                erase(NimBLEAddress address);
+    void                erase(const NimBLEAddress &address);
     
     
 private:

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -62,7 +62,7 @@ NimBLEService* NimBLEServer::createService(const char* uuid) {
  * @param [in] inst_id With multiple services with the same UUID we need to provide inst_id value different for each service.
  * @return A reference to the new service object.
  */
-NimBLEService* NimBLEServer::createService(NimBLEUUID uuid, uint32_t numHandles, uint8_t inst_id) {
+NimBLEService* NimBLEServer::createService(const NimBLEUUID &uuid, uint32_t numHandles, uint8_t inst_id) {
 	NIMBLE_LOGD(LOG_TAG, ">> createService - %s", uuid.toString().c_str());
 
 	// Check that a service with the supplied UUID does not already exist.
@@ -95,7 +95,7 @@ NimBLEService* NimBLEServer::getServiceByUUID(const char* uuid) {
  * @param [in] uuid The UUID of the new service.
  * @return A reference to the service object.
  */
-NimBLEService* NimBLEServer::getServiceByUUID(NimBLEUUID uuid) {
+NimBLEService* NimBLEServer::getServiceByUUID(const NimBLEUUID &uuid) {
 	return m_serviceMap.getByUUID(uuid);
 }
 

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -46,10 +46,10 @@ class NimBLEServiceMap {
 public:
 //    NimBLEService* getByHandle(uint16_t handle);
     NimBLEService* getByUUID(const char* uuid);    
-    NimBLEService* getByUUID(NimBLEUUID uuid, uint8_t inst_id = 0);
+    NimBLEService* getByUUID(const NimBLEUUID &uuid, uint8_t inst_id = 0);
 //    void           setByHandle(uint16_t handle, NimBLEService* service);
     void           setByUUID(const char* uuid, NimBLEService* service);
-    void           setByUUID(NimBLEUUID uuid, NimBLEService* service);
+    void           setByUUID(const NimBLEUUID &uuid, NimBLEService* service);
     std::string    toString();
     NimBLEService* getFirst();
     NimBLEService* getNext();
@@ -70,7 +70,7 @@ class NimBLEServer {
 public:
     uint32_t              getConnectedCount();
     NimBLEService*        createService(const char* uuid);    
-    NimBLEService*        createService(NimBLEUUID uuid, uint32_t numHandles=15, uint8_t inst_id=0);
+    NimBLEService*        createService(const NimBLEUUID &uuid, uint32_t numHandles=15, uint8_t inst_id=0);
     NimBLEAdvertising*    getAdvertising();
     void                  setCallbacks(NimBLEServerCallbacks* pCallbacks);
     void                  startAdvertising();
@@ -78,7 +78,7 @@ public:
     void                  start();
 //    void                  removeService(BLEService* service);
     NimBLEService*        getServiceByUUID(const char* uuid);
-    NimBLEService*        getServiceByUUID(NimBLEUUID uuid);
+    NimBLEService*        getServiceByUUID(const NimBLEUUID &uuid);
     int                   disconnect(uint16_t connID, uint8_t reason = BLE_ERR_REM_USER_CONN_TERM);
 //    bool                connect(BLEAddress address);
     void                  updateConnParams(uint16_t conn_handle, 

--- a/src/NimBLEService.cpp
+++ b/src/NimBLEService.cpp
@@ -43,7 +43,7 @@ NimBLEService::NimBLEService(const char* uuid, uint16_t numHandles, NimBLEServer
  * @param [in] uuid The UUID of the service.
  * @param [in] numHandles The maximum number of handles associated with the service.
  */
-NimBLEService::NimBLEService(NimBLEUUID uuid, uint16_t numHandles, NimBLEServer* pServer) {
+NimBLEService::NimBLEService(const NimBLEUUID &uuid, uint16_t numHandles, NimBLEServer* pServer) {
 	m_uuid      = uuid;
 	m_handle    = NULL_HANDLE;
 	m_pServer   = pServer;
@@ -247,7 +247,7 @@ NimBLECharacteristic* NimBLEService::createCharacteristic(const char* uuid, uint
  * @param [in] properties - The properties of the characteristic.
  * @return The new BLE characteristic.
  */
-NimBLECharacteristic* NimBLEService::createCharacteristic(NimBLEUUID uuid, uint32_t properties) {
+NimBLECharacteristic* NimBLEService::createCharacteristic(const NimBLEUUID &uuid, uint32_t properties) {
 	NimBLECharacteristic* pCharacteristic = new NimBLECharacteristic(uuid, properties, this);
 	addCharacteristic(pCharacteristic);
     //pCharacteristic->executeCreate(this);
@@ -260,7 +260,7 @@ NimBLECharacteristic* NimBLEService::getCharacteristic(const char* uuid) {
 }
 
 
-NimBLECharacteristic* NimBLEService::getCharacteristic(NimBLEUUID uuid) {
+NimBLECharacteristic* NimBLEService::getCharacteristic(const NimBLEUUID &uuid) {
 	return m_characteristicMap.getByUUID(uuid);
 }
 

--- a/src/NimBLEService.h
+++ b/src/NimBLEService.h
@@ -32,10 +32,10 @@ class NimBLECharacteristic;
 class NimBLECharacteristicMap {
 public:
 	void setByUUID(NimBLECharacteristic* pCharacteristic, const char* uuid);
-	void setByUUID(NimBLECharacteristic* pCharacteristic, NimBLEUUID uuid);
+	void setByUUID(NimBLECharacteristic* pCharacteristic, const NimBLEUUID &uuid);
 	void setByHandle(uint16_t handle, NimBLECharacteristic* pCharacteristic);
 	NimBLECharacteristic* getByUUID(const char* uuid);	
-	NimBLECharacteristic* getByUUID(NimBLEUUID uuid);
+	NimBLECharacteristic* getByUUID(const NimBLEUUID &uuid);
 	NimBLECharacteristic* getByHandle(uint16_t handle);
 	NimBLECharacteristic* getFirst();
 	NimBLECharacteristic* getNext();
@@ -59,13 +59,13 @@ public:
 					    uint32_t properties = NIMBLE_PROPERTY::READ | 
 											  NIMBLE_PROPERTY::WRITE);
 											  
-	NimBLECharacteristic* createCharacteristic(NimBLEUUID uuid,
+	NimBLECharacteristic* createCharacteristic(const NimBLEUUID &uuid,
 					    uint32_t properties = NIMBLE_PROPERTY::READ | 
 											  NIMBLE_PROPERTY::WRITE);
 											  
 	void               dump();
 	NimBLECharacteristic* getCharacteristic(const char* uuid);
-	NimBLECharacteristic* getCharacteristic(NimBLEUUID uuid);
+	NimBLECharacteristic* getCharacteristic(const NimBLEUUID &uuid);
 	NimBLEUUID            getUUID();
 	NimBLEServer*         getServer();
 	bool               start();
@@ -76,7 +76,7 @@ public:
 
 private:
 	NimBLEService(const char* uuid, uint16_t numHandles, NimBLEServer* pServer);
-	NimBLEService(NimBLEUUID uuid, uint16_t numHandles, NimBLEServer* pServer);
+	NimBLEService(const NimBLEUUID &uuid, uint16_t numHandles, NimBLEServer* pServer);
 	friend class NimBLEServer;
 	friend class NimBLEDevice;
 	

--- a/src/NimBLEServiceMap.cpp
+++ b/src/NimBLEServiceMap.cpp
@@ -31,7 +31,7 @@ NimBLEService* NimBLEServiceMap::getByUUID(const char* uuid) {
  * @param [in] UUID The UUID to look up the service.
  * @return The characteristic.
  */
-NimBLEService* NimBLEServiceMap::getByUUID(NimBLEUUID uuid, uint8_t inst_id) {
+NimBLEService* NimBLEServiceMap::getByUUID(const NimBLEUUID &uuid, uint8_t inst_id) {
 	for (auto &myPair : m_uuidMap) {
 		if (myPair.first->getUUID().equals(uuid)) {
 			return myPair.first;
@@ -59,7 +59,7 @@ NimBLEService* NimBLEServiceMap::getByHandle(uint16_t handle) {
  * @param [in] characteristic The service to cache.
  * @return N/A.
  */
-void NimBLEServiceMap::setByUUID(NimBLEUUID uuid, NimBLEService* service) {
+void NimBLEServiceMap::setByUUID(const NimBLEUUID &uuid, NimBLEService* service) {
 	m_uuidMap.insert(std::pair<NimBLEService*, std::string>(service, uuid.toString()));
 } // setByUUID
 

--- a/src/NimBLEUUID.cpp
+++ b/src/NimBLEUUID.cpp
@@ -40,7 +40,7 @@ static const char* LOG_TAG = "NimBLEUUID";
  *
  * @param [in] value The string to build a UUID from.
  */
- NimBLEUUID::NimBLEUUID(std::string value) {
+ NimBLEUUID::NimBLEUUID(const std::string &value) {
     m_valueSet = true;
     if (value.length() == 4) {
         m_uuid.u.type         = BLE_UUID_TYPE_16;
@@ -78,7 +78,7 @@ static const char* LOG_TAG = "NimBLEUUID";
  * @param [in] size The size of the data.
  * @param [in] msbFirst Is the MSB first in pData memory?
  */
-NimBLEUUID::NimBLEUUID(uint8_t* pData, size_t size, bool msbFirst) {
+NimBLEUUID::NimBLEUUID(const uint8_t* pData, size_t size, bool msbFirst) {
 /*** TODO: change this to use the Nimble function for various lenght UUIDs:
     int ble_uuid_init_from_buf(ble_uuid_any_t *uuid, const void *buf, size_t len);
 ***/
@@ -127,7 +127,7 @@ NimBLEUUID::NimBLEUUID(uint32_t uuid) {
  * @param [in] uuid The native UUID.
  */
  
-NimBLEUUID::NimBLEUUID(ble_uuid128_t* uuid) {
+NimBLEUUID::NimBLEUUID(const ble_uuid128_t* uuid) {
     m_uuid.u.type        = BLE_UUID_TYPE_128;
     memcpy(m_uuid.u128.value, uuid->value, 16);
     m_valueSet = true;
@@ -163,7 +163,7 @@ NimBLEUUID::NimBLEUUID() {
  * @brief Get the number of bits in this uuid.
  * @return The number of bits in the UUID.  One of 16, 32 or 128.
  */
-uint8_t NimBLEUUID::bitSize() {
+uint8_t NimBLEUUID::bitSize() const {
     if (!m_valueSet) return 0;
     return m_uuid.u.type;
 } // bitSize
@@ -175,7 +175,7 @@ uint8_t NimBLEUUID::bitSize() {
  * @param [in] uuid The UUID to compare against.
  * @return True if the UUIDs are equal and false otherwise.
  */
-bool NimBLEUUID::equals(NimBLEUUID uuid) {
+bool NimBLEUUID::equals(const NimBLEUUID &uuid) const {
     return *this == uuid;
 }
 
@@ -190,7 +190,7 @@ bool NimBLEUUID::equals(NimBLEUUID uuid) {
  * <UUID>
  */
  
-NimBLEUUID NimBLEUUID::fromString(std::string _uuid) {
+NimBLEUUID NimBLEUUID::fromString(const std::string &_uuid) {
     uint8_t start = 0;
     if (strstr(_uuid.c_str(), "0x") != nullptr) { // If the string starts with 0x, skip those characters.
         start = 2;
@@ -215,7 +215,7 @@ NimBLEUUID NimBLEUUID::fromString(std::string _uuid) {
  *
  * @return The native UUID value or NULL if not set.
  */
-ble_uuid_any_t* NimBLEUUID::getNative() {
+const ble_uuid_any_t* NimBLEUUID::getNative() const {
     if (m_valueSet == false) {
         NIMBLE_LOGD(LOG_TAG,"<< Return of un-initialized UUID!");
         return nullptr;
@@ -230,7 +230,7 @@ ble_uuid_any_t* NimBLEUUID::getNative() {
  * A UUID can be internally represented as 16bit, 32bit or the full 128bit.  This method
  * will convert 16 or 32 bit representations to the full 128bit.
  */
-NimBLEUUID &NimBLEUUID::to128() {
+const NimBLEUUID &NimBLEUUID::to128() {
     // If we either don't have a value or are already a 128 bit UUID, nothing further to do.
     if (!m_valueSet || m_uuid.u.type == BLE_UUID_TYPE_128) {
         return *this;
@@ -258,11 +258,11 @@ NimBLEUUID &NimBLEUUID::to128() {
  *
  * @return A string representation of the UUID.
  */
-std::string NimBLEUUID::toString() {
+std::string NimBLEUUID::toString() const {
     return std::string(*this);
 } // toString
 
-bool NimBLEUUID::operator ==(const NimBLEUUID & rhs) {
+bool NimBLEUUID::operator ==(const NimBLEUUID & rhs) const {
     if(m_valueSet && rhs.m_valueSet) {
         return ble_uuid_cmp(&m_uuid.u, &rhs.m_uuid.u) == 0;
     }
@@ -270,7 +270,7 @@ bool NimBLEUUID::operator ==(const NimBLEUUID & rhs) {
     return m_valueSet == rhs.m_valueSet;
 }
 
-bool NimBLEUUID::operator !=(const NimBLEUUID & rhs) {
+bool NimBLEUUID::operator !=(const NimBLEUUID & rhs) const {
     return !this->operator==(rhs);
 }
 

--- a/src/NimBLEUUID.h
+++ b/src/NimBLEUUID.h
@@ -30,22 +30,22 @@
  */
 class NimBLEUUID {
 public:
-    NimBLEUUID(std::string uuid);
+    NimBLEUUID(const std::string &uuid);
     NimBLEUUID(uint16_t uuid);
     NimBLEUUID(uint32_t uuid);
-    NimBLEUUID(ble_uuid128_t* uuid);
-    NimBLEUUID(uint8_t* pData, size_t size, bool msbFirst);
+    NimBLEUUID(const ble_uuid128_t* uuid);
+    NimBLEUUID(const uint8_t* pData, size_t size, bool msbFirst);
     NimBLEUUID(uint32_t first, uint16_t second, uint16_t third, uint64_t fourth);
     NimBLEUUID();
-    uint8_t        bitSize();   // Get the number of bits in this uuid.
-    bool           equals(NimBLEUUID uuid);
-    ble_uuid_any_t* getNative();
-    NimBLEUUID &     to128();
-    std::string    toString();
-    static NimBLEUUID fromString(std::string uuid);  // Create a NimBLEUUID from a string
+    uint8_t        bitSize() const;   // Get the number of bits in this uuid.
+    bool           equals(const NimBLEUUID &uuid) const;
+    const ble_uuid_any_t* getNative() const;
+    const NimBLEUUID &     to128();
+    std::string    toString() const;
+    static NimBLEUUID fromString(const std::string &uuid);  // Create a NimBLEUUID from a string
 
-    bool operator ==(const NimBLEUUID & rhs);
-    bool operator !=(const NimBLEUUID & rhs);
+    bool operator ==(const NimBLEUUID & rhs) const;
+    bool operator !=(const NimBLEUUID & rhs) const;
     operator std::string() const;
 
 private:

--- a/src/NimBLEUtils.cpp
+++ b/src/NimBLEUtils.cpp
@@ -33,7 +33,7 @@ static const char* LOG_TAG = "NimBLEUtils";
  * @param [in] source The source of the copy
  * @param [in] size The number of bytes to copy
  */
-void NimBLEUtils::memrcpy(uint8_t* target, uint8_t* source, uint32_t size) {
+void NimBLEUtils::memrcpy(uint8_t* target, const uint8_t* source, uint32_t size) {
     assert(size > 0);
     target += (size - 1); // Point target to the last byte of the target data
     while (size > 0) {
@@ -394,7 +394,7 @@ const char* NimBLEUtils::advTypeToString(uint8_t advType) {
  * @param [in] length The length of the data to convert.
  * @return A pointer to the formatted buffer.
  */
-char* NimBLEUtils::buildHexData(uint8_t* target, uint8_t* source, uint8_t length) {
+char* NimBLEUtils::buildHexData(uint8_t* target, const uint8_t* source, uint8_t length) {
     // Guard against too much data.
     if (length > 100) length = 100;
 

--- a/src/NimBLEUtils.h
+++ b/src/NimBLEUtils.h
@@ -25,10 +25,10 @@ class NimBLEUtils {
 public:
     static void                 dumpGapEvent(ble_gap_event *event, void *arg);
     static const char*          gapEventToString(uint8_t eventType);
-    static char*                buildHexData(uint8_t* target, uint8_t* source, uint8_t length);
+    static char*                buildHexData(uint8_t* target, const uint8_t* source, uint8_t length);
     static const char*          advTypeToString(uint8_t advType);
     static const char*          returnCodeToString(int rc);
-    static void                 memrcpy(uint8_t* target, uint8_t* source, uint32_t size);
+    static void                 memrcpy(uint8_t* target, const uint8_t* source, uint32_t size);
     static int                  checkConnParams(ble_gap_conn_params* params);
 };
 

--- a/src/NimBLEValue.cpp
+++ b/src/NimBLEValue.cpp
@@ -31,7 +31,7 @@ NimBLEValue::NimBLEValue() {
  * The accumulation is a growing set of data that is added to until a commit or cancel.
  * @param [in] part A message part being added.
  */
-void NimBLEValue::addPart(std::string part) {
+void NimBLEValue::addPart(const std::string &part) {
 	NIMBLE_LOGD(LOG_TAG, ">> addPart: length=%d", part.length());
 	m_accumulation += part;
 } // addPart
@@ -43,7 +43,7 @@ void NimBLEValue::addPart(std::string part) {
  * @param [in] pData A message part being added.
  * @param [in] length The number of bytes being added.
  */
-void NimBLEValue::addPart(uint8_t* pData, size_t length) {
+void NimBLEValue::addPart(const uint8_t* pData, size_t length) {
 	NIMBLE_LOGD(LOG_TAG, ">> addPart: length=%d", length);
 	m_accumulation += std::string((char*) pData, length);
 } // addPart
@@ -122,7 +122,7 @@ void NimBLEValue::setReadOffset(uint16_t readOffset) {
 /**
  * @brief Set the current value.
  */
-void NimBLEValue::setValue(std::string value) {
+void NimBLEValue::setValue(const std::string &value) {
 	m_value = value;
 } // setValue
 
@@ -132,7 +132,7 @@ void NimBLEValue::setValue(std::string value) {
  * @param [in] pData The data for the current value.
  * @param [in] The length of the new current value.
  */
-void NimBLEValue::setValue(uint8_t* pData, size_t length) {
+void NimBLEValue::setValue(const uint8_t* pData, size_t length) {
 	m_value = std::string((char*) pData, length);
 } // setValue
 

--- a/src/NimBLEValue.h
+++ b/src/NimBLEValue.h
@@ -24,8 +24,8 @@
 class NimBLEValue {
 public:
 	NimBLEValue();
-	void		addPart(std::string part);
-	void		addPart(uint8_t* pData, size_t length);
+	void		addPart(const std::string &part);
+	void		addPart(const uint8_t* pData, size_t length);
 	void		cancel();
 	void		commit();
 	uint8_t*	getData();
@@ -33,8 +33,8 @@ public:
 	uint16_t	getReadOffset();
 	std::string getValue();
 	void        setReadOffset(uint16_t readOffset);
-	void        setValue(std::string value);
-	void        setValue(uint8_t* pData, size_t length);
+	void        setValue(const std::string &value);
+	void        setValue(const uint8_t* pData, size_t length);
 
 private:
 	std::string m_accumulation;


### PR DESCRIPTION
Pass each `NimBLEUUID`, `NimBLEAddress`, `std::string` and `uint8_t * parameter` as `const &` instead of by value. This leads to (a bit) smaller code and performance improvement.

@h2zero I could not stop myself ;)