### PR TITLE
EXPERIMENTAL: Making remote object class member functions 'const'

### DIFF
--- a/src/NimBLEAdvertisedDevice.cpp
+++ b/src/NimBLEAdvertisedDevice.cpp
@@ -54,7 +54,7 @@ NimBLEAdvertisedDevice::NimBLEAdvertisedDevice() {
  *
  * @return The address of the advertised device.
  */
-NimBLEAddress NimBLEAdvertisedDevice::getAddress() {
+const NimBLEAddress &NimBLEAdvertisedDevice::getAddress() const {
     return m_address;
 } // getAddress
 
@@ -67,7 +67,7 @@ NimBLEAddress NimBLEAdvertisedDevice::getAddress() {
  *
  * @return The appearance of the advertised device.
  */
-uint16_t NimBLEAdvertisedDevice::getAppearance() {
+uint16_t NimBLEAdvertisedDevice::getAppearance() const {
     return m_appearance;
 } // getAppearance
 
@@ -76,7 +76,7 @@ uint16_t NimBLEAdvertisedDevice::getAppearance() {
  * @brief Get the manufacturer data.
  * @return The manufacturer data of the advertised device.
  */
-std::string NimBLEAdvertisedDevice::getManufacturerData() {
+const std::string &NimBLEAdvertisedDevice::getManufacturerData() const {
     return m_manufacturerData;
 } // getManufacturerData
 
@@ -85,7 +85,7 @@ std::string NimBLEAdvertisedDevice::getManufacturerData() {
  * @brief Get the name.
  * @return The name of the advertised device.
  */
-std::string NimBLEAdvertisedDevice::getName() {
+const std::string &NimBLEAdvertisedDevice::getName() const {
     return m_name;
 } // getName
 
@@ -94,7 +94,7 @@ std::string NimBLEAdvertisedDevice::getName() {
  * @brief Get the RSSI.
  * @return The RSSI of the advertised device.
  */
-int NimBLEAdvertisedDevice::getRSSI() {
+int NimBLEAdvertisedDevice::getRSSI() const {
     return m_rssi;
 } // getRSSI
 
@@ -103,7 +103,7 @@ int NimBLEAdvertisedDevice::getRSSI() {
  * @brief Get the scan object that created this advertisement.
  * @return The scan object.
  */
-NimBLEScan* NimBLEAdvertisedDevice::getScan() {
+const NimBLEScan* NimBLEAdvertisedDevice::getScan() const {
     return m_pScan;
 } // getScan
 
@@ -112,7 +112,7 @@ NimBLEScan* NimBLEAdvertisedDevice::getScan() {
  * @brief Get the service data.
  * @return The ServiceData of the advertised device.
  */
-std::string NimBLEAdvertisedDevice::getServiceData() {
+const std::string &NimBLEAdvertisedDevice::getServiceData() const {
     return m_serviceData;
 } //getServiceData
 
@@ -122,7 +122,7 @@ std::string NimBLEAdvertisedDevice::getServiceData() {
  * @return The service data UUID.
  */
  
-NimBLEUUID NimBLEAdvertisedDevice::getServiceDataUUID() {
+const NimBLEUUID &NimBLEAdvertisedDevice::getServiceDataUUID() const {
     return m_serviceDataUUID;
 } // getServiceDataUUID
 
@@ -132,7 +132,7 @@ NimBLEUUID NimBLEAdvertisedDevice::getServiceDataUUID() {
  * @return The Service UUID of the advertised device.
  */
  
-NimBLEUUID NimBLEAdvertisedDevice::getServiceUUID() {  //TODO Remove it eventually, is no longer useful
+const NimBLEUUID &NimBLEAdvertisedDevice::getServiceUUID() const {  //TODO Remove it eventually, is no longer useful
     return m_serviceUUIDs[0];
 } // getServiceUUID
 
@@ -141,10 +141,10 @@ NimBLEUUID NimBLEAdvertisedDevice::getServiceUUID() {  //TODO Remove it eventual
  * @brief Check advertised serviced for existence required UUID
  * @return Return true if service is advertised
  */
-bool NimBLEAdvertisedDevice::isAdvertisingService(const NimBLEUUID &uuid){
+bool NimBLEAdvertisedDevice::isAdvertisingService(const NimBLEUUID &uuid) const {
     for (int i = 0; i < m_serviceUUIDs.size(); i++) {
         NIMBLE_LOGI(LOG_TAG, "Comparing UUIDS: %s %s", m_serviceUUIDs[i].toString().c_str(), uuid.toString().c_str());
-        if (m_serviceUUIDs[i].equals(uuid)) return true;
+        if (m_serviceUUIDs[i] == uuid) return true;
     }
     return false;
 }
@@ -154,7 +154,7 @@ bool NimBLEAdvertisedDevice::isAdvertisingService(const NimBLEUUID &uuid){
  * @brief Get the TX Power.
  * @return The TX Power of the advertised device.
  */
-int8_t NimBLEAdvertisedDevice::getTXPower() {
+int8_t NimBLEAdvertisedDevice::getTXPower() const {
     return m_txPower;
 } // getTXPower
 
@@ -163,7 +163,7 @@ int8_t NimBLEAdvertisedDevice::getTXPower() {
  * @brief Does this advertisement have an appearance value?
  * @return True if there is an appearance value present.
  */
-bool NimBLEAdvertisedDevice::haveAppearance() {
+bool NimBLEAdvertisedDevice::haveAppearance() const {
     return m_haveAppearance;
 } // haveAppearance
 
@@ -172,7 +172,7 @@ bool NimBLEAdvertisedDevice::haveAppearance() {
  * @brief Does this advertisement have manufacturer data?
  * @return True if there is manufacturer data present.
  */
-bool NimBLEAdvertisedDevice::haveManufacturerData() {
+bool NimBLEAdvertisedDevice::haveManufacturerData() const {
     return m_haveManufacturerData;
 } // haveManufacturerData
 
@@ -181,7 +181,7 @@ bool NimBLEAdvertisedDevice::haveManufacturerData() {
  * @brief Does this advertisement have a name value?
  * @return True if there is a name value present.
  */
-bool NimBLEAdvertisedDevice::haveName() {
+bool NimBLEAdvertisedDevice::haveName() const {
     return m_haveName;
 } // haveName
 
@@ -190,7 +190,7 @@ bool NimBLEAdvertisedDevice::haveName() {
  * @brief Does this advertisement have a signal strength value?
  * @return True if there is a signal strength value present.
  */
-bool NimBLEAdvertisedDevice::haveRSSI() {
+bool NimBLEAdvertisedDevice::haveRSSI() const {
     return m_haveRSSI;
 } // haveRSSI
 
@@ -199,7 +199,7 @@ bool NimBLEAdvertisedDevice::haveRSSI() {
  * @brief Does this advertisement have a service data value?
  * @return True if there is a service data value present.
  */
-bool NimBLEAdvertisedDevice::haveServiceData() {
+bool NimBLEAdvertisedDevice::haveServiceData() const {
     return m_haveServiceData;
 } // haveServiceData
 
@@ -208,7 +208,7 @@ bool NimBLEAdvertisedDevice::haveServiceData() {
  * @brief Does this advertisement have a service UUID value?
  * @return True if there is a service UUID value present.
  */
-bool NimBLEAdvertisedDevice::haveServiceUUID() {
+bool NimBLEAdvertisedDevice::haveServiceUUID() const {
     return m_haveServiceUUID;
 } // haveServiceUUID
 
@@ -217,7 +217,7 @@ bool NimBLEAdvertisedDevice::haveServiceUUID() {
  * @brief Does this advertisement have a transmission power value?
  * @return True if there is a transmission power value present.
  */
-bool NimBLEAdvertisedDevice::haveTXPower() {
+bool NimBLEAdvertisedDevice::haveTXPower() const {
     return m_haveTXPower;
 } // haveTXPower
 
@@ -234,7 +234,7 @@ bool NimBLEAdvertisedDevice::haveTXPower() {
  *
  * https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile
  */
- void NimBLEAdvertisedDevice::parseAdvertisement(ble_hs_adv_fields *fields) {
+ void NimBLEAdvertisedDevice::parseAdvertisement(const ble_hs_adv_fields *fields) {
     //char s[BLE_HS_ADV_MAX_SZ];
     uint8_t *u8p;
     uint8_t length;
@@ -356,7 +356,7 @@ bool NimBLEAdvertisedDevice::haveTXPower() {
  * @brief Set the address of the advertised device.
  * @param [in] address The address of the advertised device.
  */
-void NimBLEAdvertisedDevice::setAddress(NimBLEAddress address) {
+void NimBLEAdvertisedDevice::setAddress(const NimBLEAddress &address) {
     m_address = address;
 } // setAddress
 
@@ -385,7 +385,7 @@ void NimBLEAdvertisedDevice::setAppearance(uint16_t appearance) {
  * @brief Set the manufacturer data for this device.
  * @param [in] The discovered manufacturer data.
  */
-void NimBLEAdvertisedDevice::setManufacturerData(std::string manufacturerData) {
+void NimBLEAdvertisedDevice::setManufacturerData(const std::string &manufacturerData) {
     m_manufacturerData     = manufacturerData;
     m_haveManufacturerData = true;
 
@@ -399,7 +399,7 @@ void NimBLEAdvertisedDevice::setManufacturerData(std::string manufacturerData) {
  * @brief Set the name for this device.
  * @param [in] name The discovered name.
  */
-void NimBLEAdvertisedDevice::setName(std::string name) {
+void NimBLEAdvertisedDevice::setName(const std::string &name) {
     m_name     = name;
     m_haveName = true;
     NIMBLE_LOGD(LOG_TAG,"- setName(): name: %s", m_name.c_str());
@@ -440,10 +440,10 @@ void NimBLEAdvertisedDevice::setServiceUUID(const char* serviceUUID) {
  * @brief Set the Service UUID for this device.
  * @param [in] serviceUUID The discovered serviceUUID
  */
-void NimBLEAdvertisedDevice::setServiceUUID(NimBLEUUID serviceUUID) {
+void NimBLEAdvertisedDevice::setServiceUUID(const NimBLEUUID &serviceUUID) {
     // Don't add duplicates
     for (int i = 0; i < m_serviceUUIDs.size(); i++) {
-        if (m_serviceUUIDs[i].equals(serviceUUID)) {
+        if (m_serviceUUIDs[i] == serviceUUID) {
             return;
         }
     }
@@ -457,7 +457,7 @@ void NimBLEAdvertisedDevice::setServiceUUID(NimBLEUUID serviceUUID) {
  * @brief Set the ServiceData value.
  * @param [in] data ServiceData value.
  */
-void NimBLEAdvertisedDevice::setServiceData(std::string serviceData) {
+void NimBLEAdvertisedDevice::setServiceData(const std::string &serviceData) {
     m_haveServiceData = true;         // Set the flag that indicates we have service data.
     m_serviceData     = serviceData;  // Save the service data that we received.
 } //setServiceData
@@ -467,7 +467,7 @@ void NimBLEAdvertisedDevice::setServiceData(std::string serviceData) {
  * @brief Set the ServiceDataUUID value.
  * @param [in] data ServiceDataUUID value.
  */
-void NimBLEAdvertisedDevice::setServiceDataUUID(NimBLEUUID uuid) {
+void NimBLEAdvertisedDevice::setServiceDataUUID(const NimBLEUUID &uuid) {
     m_haveServiceData = true;         // Set the flag that indicates we have service data.
     m_serviceDataUUID = uuid;
 } // setServiceDataUUID
@@ -488,7 +488,7 @@ void NimBLEAdvertisedDevice::setTXPower(int8_t txPower) {
  * @brief Create a string representation of this device.
  * @return A string representation of this device.
  */
-std::string NimBLEAdvertisedDevice::toString() {    
+const std::string &NimBLEAdvertisedDevice::toString() const {    
     std::string res = "Name: " + getName() + ", Address: " + getAddress().toString();
     
     if (haveAppearance()) {
@@ -523,12 +523,12 @@ std::string NimBLEAdvertisedDevice::toString() {
 } // toString
 
 
-uint8_t* NimBLEAdvertisedDevice::getPayload() {
+const uint8_t* NimBLEAdvertisedDevice::getPayload() const {
     return m_payload;
 }
 
 
-uint8_t NimBLEAdvertisedDevice::getAddressType() {
+uint8_t NimBLEAdvertisedDevice::getAddressType() const {
     return m_addressType;
 }
 
@@ -538,7 +538,7 @@ void NimBLEAdvertisedDevice::setAddressType(uint8_t type) {
 }
 
 
-size_t NimBLEAdvertisedDevice::getPayloadLength() {
+size_t NimBLEAdvertisedDevice::getPayloadLength() const {
     return m_payloadLength;
 }
 

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -38,50 +38,50 @@ class NimBLEAdvertisedDevice {
 public:
     NimBLEAdvertisedDevice();
 
-    NimBLEAddress   getAddress();
-    uint16_t        getAppearance();
-    std::string     getManufacturerData();
-    std::string     getName();
-    int             getRSSI();
-    NimBLEScan*     getScan();
-    std::string     getServiceData();
-    NimBLEUUID      getServiceDataUUID();
-    NimBLEUUID      getServiceUUID();
-    int8_t          getTXPower();
-    uint8_t*        getPayload();
-    size_t          getPayloadLength();
-    uint8_t         getAddressType();
-    void setAddressType(uint8_t type);
+    const NimBLEAddress   &getAddress() const;
+    uint16_t              getAppearance() const;
+    const std::string     &getManufacturerData() const;
+    const std::string     &getName() const;
+    int                   getRSSI() const;
+    const NimBLEScan*     getScan() const;
+    const std::string     &getServiceData() const;
+    const NimBLEUUID      &getServiceDataUUID() const;
+    const NimBLEUUID      &getServiceUUID() const;
+    int8_t                getTXPower() const;
+    const uint8_t*        getPayload() const;
+    size_t                getPayloadLength() const;
+    uint8_t               getAddressType() const;	// What is the purpose of this function?
+    void                  setAddressType(uint8_t type);	// What is the purpose of this function?
 
 
-    bool        isAdvertisingService(const NimBLEUUID &uuid);
-    bool        haveAppearance();
-    bool        haveManufacturerData();
-    bool        haveName();
-    bool        haveRSSI();
-    bool        haveServiceData();
-    bool        haveServiceUUID();
-    bool        haveTXPower();
+    bool                  isAdvertisingService(const NimBLEUUID &uuid) const;
+    bool                  haveAppearance() const;
+    bool                  haveManufacturerData() const;
+    bool                  haveName() const;
+    bool                  haveRSSI() const;
+    bool                  haveServiceData() const;
+    bool                  haveServiceUUID() const;
+    bool                  haveTXPower() const;
 
-    std::string toString();
+    const std::string     &toString() const;
 
 private:
     friend class NimBLEScan;
 
-    void parseAdvertisement(ble_hs_adv_fields *fields);
-    void setAddress(NimBLEAddress address);
-    void setAdvType(uint8_t advType);
+    void parseAdvertisement(const ble_hs_adv_fields *fields);
+    void setAddress(const NimBLEAddress &address);
+    void setAdvType(const uint8_t advType);
     void setAdvertisementResult(uint8_t* payload, uint8_t length);
-    void setAppearance(uint16_t appearance);
-    void setManufacturerData(std::string manufacturerData);
-    void setName(std::string name);
-    void setRSSI(int rssi);
+    void setAppearance(const uint16_t appearance);
+    void setManufacturerData(const std::string &manufacturerData);
+    void setName(const std::string &name);
+    void setRSSI(const int rssi);
     void setScan(NimBLEScan* pScan);
-    void setServiceData(std::string data);
-    void setServiceDataUUID(NimBLEUUID uuid);
+    void setServiceData(const std::string &data);
+    void setServiceDataUUID(const NimBLEUUID &uuid);
     void setServiceUUID(const char* serviceUUID);
-    void setServiceUUID(NimBLEUUID serviceUUID);
-    void setTXPower(int8_t txPower);
+    void setServiceUUID(const NimBLEUUID &serviceUUID);
+    void setTXPower(const int8_t txPower);
 
     bool m_haveAppearance;
     bool m_haveManufacturerData;

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -33,28 +33,28 @@ class NimBLEAdvertisedDevice;
  */
 class NimBLEClient {
 public:
-    bool                                       connect(NimBLEAdvertisedDevice* device, bool refreshServices = true);
+    bool                                       connect(const NimBLEAdvertisedDevice* device, bool refreshServices = true);
     bool                                       connect(const NimBLEAddress &address, uint8_t type = BLE_ADDR_PUBLIC, bool refreshServices = true);   // Connect to the remote BLE Server
-    int                                        disconnect(uint8_t reason = BLE_ERR_REM_USER_CONN_TERM);                  // Disconnect from the remote BLE Server
-    NimBLEAddress                              getPeerAddress();              // Get the address of the remote BLE Server
-    int                                        getRssi();                     // Get the RSSI of the remote BLE Server
-    std::map<std::string, NimBLERemoteService*>*  getServices();                 // Get a map of the services offered by the remote BLE Server
-    NimBLERemoteService*                          getService(const char* uuid);  // Get a reference to a specified service offered by the remote BLE server.
-    NimBLERemoteService*                          getService(const NimBLEUUID &uuid);   // Get a reference to a specified service offered by the remote BLE server.
+    int                                        disconnect(uint8_t reason = BLE_ERR_REM_USER_CONN_TERM); // Disconnect from the remote BLE Server
+    const NimBLEAddress                        &getPeerAddress() const;             // Get the address of the remote BLE Server
+    int                                        getRssi() const;                     // Get the RSSI of the remote BLE Server
+    std::map<std::string, NimBLERemoteService*>*  getServices();                    // Get a map of the services offered by the remote BLE Server
+    const NimBLERemoteService*                 getService(const char* uuid) const;  // Get a reference to a specified service offered by the remote BLE server.
+    const NimBLERemoteService*                 getService(const NimBLEUUID &uuid) const; // Get a reference to a specified service offered by the remote BLE server.
     std::string                                getValue(const NimBLEUUID &serviceUUID, const NimBLEUUID &characteristicUUID);   // Get the value of a given characteristic at a given service.
     bool                                       setValue(const NimBLEUUID &serviceUUID, const NimBLEUUID &characteristicUUID, const std::string &value);   // Set the value of a given characteristic at a given service.
-    bool                                       isConnected();                 // Return true if we are connected.
+    bool                                       isConnected() const;                 // Return true if we are connected.
     void                                       setClientCallbacks(NimBLEClientCallbacks *pClientCallbacks, bool deleteCallbacks = true);
-    std::string                                toString();                    // Return a string representation of this client.
-    uint16_t                                   getConnId();
-    uint16_t                                   getMTU();
-    bool                                       secureConnection();
+    std::string                                toString() const;              // Return a string representation of this client.
+    uint16_t                                   getConnId() const;
+    uint16_t                                   getMTU() const;
+    bool                                       secureConnection() const;
     void                                       setConnectTimeout(uint8_t timeout);
-	void 									   setConnectionParams(uint16_t minInterval, uint16_t maxInterval,
-															uint16_t latency, uint16_t timeout,
-                                                            uint16_t scanInterval=16, uint16_t scanWindow=16); // NimBLE default scan settings
-	void 									   updateConnParams(uint16_t minInterval, uint16_t maxInterval, 
-															uint16_t latency, uint16_t timeout);
+    void                                       setConnectionParams(uint16_t minInterval, uint16_t maxInterval, 
+                                               uint16_t latency, uint16_t timeout, uint16_t scanInterval=16, 
+                                               uint16_t scanWindow=16); // NimBLE default scan settings
+    void                                       updateConnParams(uint16_t minInterval, uint16_t maxInterval,
+                                               uint16_t latency, uint16_t timeout);
  
                                               
 private:

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -76,38 +76,38 @@ extern "C" void ble_store_config_init(void);
 
 class NimBLEDevice {
 public:
-    static void             init(const std::string &deviceName);   // Initialize the local BLE environment.
-    static void             deinit();
-    static bool             getInitialized();
-    static NimBLEAddress    getAddress();
-    static std::string      toString();
-    static NimBLEScan*      getScan();                     // Get the scan object
-    static NimBLEClient*    createClient();
-	static NimBLEServer*    createServer();
-    static bool             deleteClient(NimBLEClient* pClient);
-    static void             setPower(esp_power_level_t powerLevel, esp_ble_power_type_t powerType=ESP_BLE_PWR_TYPE_DEFAULT);
-	static int              getPower(esp_ble_power_type_t powerType=ESP_BLE_PWR_TYPE_DEFAULT);
-    static void             setCustomGapHandler(gap_event_handler handler);
-    static void             setSecurityAuth(bool bonding, bool mitm, bool sc);
-    static void             setSecurityAuth(uint8_t auth_req);
-    static void             setSecurityIOCap(uint8_t iocap);
-    static void             setSecurityInitKey(uint8_t init_key);
-    static void             setSecurityRespKey(uint8_t init_key);
-    static void             setSecurityPasskey(uint32_t pin);
-    static uint32_t         getSecurityPasskey();
-    static void             setSecurityCallbacks(NimBLESecurityCallbacks* pCallbacks);
-    static int              setMTU(uint16_t mtu);
-    static uint16_t         getMTU();
-    static bool             isIgnored(const NimBLEAddress &address);
-    static void             addIgnored(const NimBLEAddress &address);
-    static void             removeIgnored(const NimBLEAddress &address);
-    static NimBLEAdvertising* getAdvertising();
-	static void		   		startAdvertising();
-	static void		   		stopAdvertising();
-    static NimBLEClient*    getClientByID(uint16_t conn_id);
-    static NimBLEClient*    getClientByPeerAddress(const NimBLEAddress &peer_addr);
-    static NimBLEClient*    getDisconnectedClient();
-    static size_t           getClientListSize(); 
+    static void                 init(const std::string &deviceName);   // Initialize the local BLE environment.
+    static void                 deinit();
+    static bool                 getInitialized();
+    static NimBLEAddress        getAddress();
+    static std::string          toString();
+    static NimBLEScan*          getScan();                     // Get the scan object
+    static NimBLEClient*        createClient();
+    static NimBLEServer*        createServer();
+    static bool                 deleteClient(NimBLEClient* pClient);
+    static void                 setPower(esp_power_level_t powerLevel, esp_ble_power_type_t powerType=ESP_BLE_PWR_TYPE_DEFAULT);
+    static int                  getPower(esp_ble_power_type_t powerType=ESP_BLE_PWR_TYPE_DEFAULT);
+    static void                 setCustomGapHandler(gap_event_handler handler);
+    static void                 setSecurityAuth(bool bonding, bool mitm, bool sc);
+    static void                 setSecurityAuth(uint8_t auth_req);
+    static void                 setSecurityIOCap(uint8_t iocap);
+    static void                 setSecurityInitKey(uint8_t init_key);
+    static void                 setSecurityRespKey(uint8_t init_key);
+    static void                 setSecurityPasskey(uint32_t pin);
+    static uint32_t             getSecurityPasskey();
+    static void                 setSecurityCallbacks(NimBLESecurityCallbacks* pCallbacks);
+    static int                  setMTU(uint16_t mtu);
+    static uint16_t             getMTU();
+    static bool                 isIgnored(const NimBLEAddress &address);
+    static void                 addIgnored(const NimBLEAddress &address);
+    static void                 removeIgnored(const NimBLEAddress &address);
+    static NimBLEAdvertising*   getAdvertising();
+    static void                 startAdvertising();
+    static void	                stopAdvertising();
+    static NimBLEClient*        getClientByID(uint16_t conn_id);
+    static NimBLEClient*        getClientByPeerAddress(const NimBLEAddress &peer_addr);
+    static NimBLEClient*        getDisconnectedClient();
+    static size_t               getClientListSize(); 
     static std::list<NimBLEClient*>* getClientList(); 
         
 private:

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -83,7 +83,7 @@ NimBLERemoteCharacteristic::~NimBLERemoteCharacteristic() {
  * @brief Does the characteristic support broadcasting?
  * @return True if the characteristic supports broadcasting.
  */
-bool NimBLERemoteCharacteristic::canBroadcast() {
+bool NimBLERemoteCharacteristic::canBroadcast() const {
     return (m_charProp & BLE_GATT_CHR_PROP_BROADCAST) != 0;
 } // canBroadcast
 
@@ -92,7 +92,7 @@ bool NimBLERemoteCharacteristic::canBroadcast() {
  * @brief Does the characteristic support indications?
  * @return True if the characteristic supports indications.
  */
-bool NimBLERemoteCharacteristic::canIndicate() {
+bool NimBLERemoteCharacteristic::canIndicate() const {
     return (m_charProp & BLE_GATT_CHR_PROP_INDICATE) != 0;
 } // canIndicate
 
@@ -101,7 +101,7 @@ bool NimBLERemoteCharacteristic::canIndicate() {
  * @brief Does the characteristic support notifications?
  * @return True if the characteristic supports notifications.
  */
-bool NimBLERemoteCharacteristic::canNotify() {
+bool NimBLERemoteCharacteristic::canNotify() const {
     return (m_charProp & BLE_GATT_CHR_PROP_NOTIFY) != 0;
 } // canNotify
 
@@ -110,7 +110,7 @@ bool NimBLERemoteCharacteristic::canNotify() {
  * @brief Does the characteristic support reading?
  * @return True if the characteristic supports reading.
  */
-bool NimBLERemoteCharacteristic::canRead() {
+bool NimBLERemoteCharacteristic::canRead() const {
     return (m_charProp & BLE_GATT_CHR_PROP_READ) != 0;
 } // canRead
 
@@ -119,7 +119,7 @@ bool NimBLERemoteCharacteristic::canRead() {
  * @brief Does the characteristic support writing?
  * @return True if the characteristic supports writing.
  */
-bool NimBLERemoteCharacteristic::canWrite() {
+bool NimBLERemoteCharacteristic::canWrite() const {
     return (m_charProp & BLE_GATT_CHR_PROP_WRITE) != 0;
 } // canWrite
 
@@ -128,7 +128,7 @@ bool NimBLERemoteCharacteristic::canWrite() {
  * @brief Does the characteristic support writing with no response?
  * @return True if the characteristic supports writing with no response.
  */
-bool NimBLERemoteCharacteristic::canWriteNoResponse() {
+bool NimBLERemoteCharacteristic::canWriteNoResponse() const {
     return (m_charProp & BLE_GATT_CHR_PROP_WRITE_NO_RSP) != 0;
 } // canWriteNoResponse
 
@@ -225,7 +225,7 @@ std::map<std::string, NimBLERemoteDescriptor*>* NimBLERemoteCharacteristic::getD
  * @brief Get the handle for this characteristic.
  * @return The handle for this characteristic.
  */
-uint16_t NimBLERemoteCharacteristic::getHandle() {
+uint16_t NimBLERemoteCharacteristic::getHandle() const {
     return m_handle;
 } // getHandle
 
@@ -233,7 +233,7 @@ uint16_t NimBLERemoteCharacteristic::getHandle() {
  * @brief Get the handle for this characteristics definition.
  * @return The handle for this characteristic definition.
  */
-uint16_t NimBLERemoteCharacteristic::getDefHandle() {
+uint16_t NimBLERemoteCharacteristic::getDefHandle() const {
     return m_defHandle;
 } // getDefHandle
 
@@ -243,7 +243,7 @@ uint16_t NimBLERemoteCharacteristic::getDefHandle() {
  * @param [in] uuid The UUID of the descriptor to find.
  * @return The Remote descriptor (if present) or null if not present.
  */
-NimBLERemoteDescriptor* NimBLERemoteCharacteristic::getDescriptor(const NimBLEUUID &uuid) {
+const NimBLERemoteDescriptor* NimBLERemoteCharacteristic::getDescriptor(const NimBLEUUID &uuid) const {
     NIMBLE_LOGD(LOG_TAG, ">> getDescriptor: uuid: %s", uuid.toString().c_str());
     std::string v = uuid.toString();
     for (auto &myPair : m_descriptorMap) {
@@ -261,7 +261,7 @@ NimBLERemoteDescriptor* NimBLERemoteCharacteristic::getDescriptor(const NimBLEUU
  * @brief Get the remote service associated with this characteristic.
  * @return The remote service associated with this characteristic.
  */
-NimBLERemoteService* NimBLERemoteCharacteristic::getRemoteService() {
+const NimBLERemoteService* NimBLERemoteCharacteristic::getRemoteService() const {
     return m_pRemoteService;
 } // getRemoteService
 
@@ -270,7 +270,7 @@ NimBLERemoteService* NimBLERemoteCharacteristic::getRemoteService() {
  * @brief Get the UUID for this characteristic.
  * @return The UUID for this characteristic.
  */
-NimBLEUUID NimBLERemoteCharacteristic::getUUID() {
+const NimBLEUUID &NimBLERemoteCharacteristic::getUUID() const {
     return m_uuid;
 } // getUUID
 
@@ -279,7 +279,7 @@ NimBLEUUID NimBLERemoteCharacteristic::getUUID() {
  * @brief Read an unsigned 16 bit value
  * @return The unsigned 16 bit value.
  */
-uint16_t NimBLERemoteCharacteristic::readUInt16() {
+uint16_t NimBLERemoteCharacteristic::readUInt16() const {
     std::string value = readValue();
     if (value.length() >= 2) {
         return *(uint16_t*)(value.data());
@@ -292,7 +292,7 @@ uint16_t NimBLERemoteCharacteristic::readUInt16() {
  * @brief Read an unsigned 32 bit value.
  * @return the unsigned 32 bit value.
  */
-uint32_t NimBLERemoteCharacteristic::readUInt32() {
+uint32_t NimBLERemoteCharacteristic::readUInt32() const {
     std::string value = readValue();
     if (value.length() >= 4) {
         return *(uint32_t*)(value.data());
@@ -305,7 +305,7 @@ uint32_t NimBLERemoteCharacteristic::readUInt32() {
  * @brief Read a byte value
  * @return The value as a byte
  */
-uint8_t NimBLERemoteCharacteristic::readUInt8() {
+uint8_t NimBLERemoteCharacteristic::readUInt8() const {
     std::string value = readValue();
     if (value.length() >= 1) {
         return (uint8_t)value[0];
@@ -318,15 +318,16 @@ uint8_t NimBLERemoteCharacteristic::readUInt8() {
  * @brief Read the value of the remote characteristic.
  * @return The value of the remote characteristic.
  */
-std::string NimBLERemoteCharacteristic::readValue() {
+std::string NimBLERemoteCharacteristic::readValue() const {
     NIMBLE_LOGD(LOG_TAG, ">> readValue(): uuid: %s, handle: %d 0x%.2x", getUUID().toString().c_str(), getHandle(), getHandle());
 
     int rc = 0;
     int retryCount = 1;
     // Clear the value before reading.
-    m_value = "";
+//    m_value = "";
+    const_cast<NimBLERemoteCharacteristic *>(this)->m_value = ""; // Override const this pointer
 
-    NimBLEClient* pClient = getRemoteService()->getClient();
+    const NimBLEClient* pClient = getRemoteService()->getClient();
 
     // Check to see that we are connected.
     if (!pClient->isConnected()) {
@@ -335,19 +336,19 @@ std::string NimBLERemoteCharacteristic::readValue() {
     }
 
     do {
-        m_semaphoreReadCharEvt.take("readValue");
+        const_cast<NimBLERemoteCharacteristic *>(this)->m_semaphoreReadCharEvt.take("readValue");
 
         rc = ble_gattc_read_long(pClient->getConnId(), m_handle, 0,
                                  NimBLERemoteCharacteristic::onReadCB,
-                                 this);
+                                 const_cast<NimBLERemoteCharacteristic *>(this));
         if (rc != 0) {
             NIMBLE_LOGE(LOG_TAG, "Error: Failed to read characteristic; rc=%d, %s",
                                   rc, NimBLEUtils::returnCodeToString(rc));
-            m_semaphoreReadCharEvt.give(0);
+            const_cast<NimBLERemoteCharacteristic *>(this)->m_semaphoreReadCharEvt.give(0);
             return "";
         }
         
-        rc = m_semaphoreReadCharEvt.wait("readValue");
+        rc = const_cast<NimBLERemoteCharacteristic *>(this)->m_semaphoreReadCharEvt.wait("readValue");
         switch(rc){
             case 0:
             case BLE_HS_EDONE:
@@ -420,7 +421,7 @@ bool NimBLERemoteCharacteristic::registerForNotify(notify_callback notifyCallbac
 
     uint8_t val[] = {0x01, 0x00};
 
-    NimBLERemoteDescriptor* desc = getDescriptor(NimBLEUUID((uint16_t)0x2902));
+    const NimBLERemoteDescriptor* desc = getDescriptor(NimBLEUUID((uint16_t)0x2902));
     if(desc == nullptr) 
         return false;
 
@@ -461,7 +462,7 @@ void NimBLERemoteCharacteristic::removeDescriptors() {
  * @brief Convert a BLERemoteCharacteristic to a string representation;
  * @return a String representation.
  */
-std::string NimBLERemoteCharacteristic::toString() {
+std::string NimBLERemoteCharacteristic::toString() const {
     std::string res = "Characteristic: uuid: " + m_uuid.toString();
     char val[6];
     res += ", handle: ";
@@ -489,7 +490,7 @@ std::string NimBLERemoteCharacteristic::toString() {
  * @param [in] response Do we expect a response?
  * @return false if not connected or cant perform write for some reason.
  */
-bool NimBLERemoteCharacteristic::writeValue(const std::string &newValue, bool response) {
+bool NimBLERemoteCharacteristic::writeValue(const std::string &newValue, bool response) const {
     return writeValue((uint8_t*)newValue.c_str(), strlen(newValue.c_str()), response);
 } // writeValue
 
@@ -502,7 +503,7 @@ bool NimBLERemoteCharacteristic::writeValue(const std::string &newValue, bool re
  * @param [in] response Whether we require a response from the write.
  * @return false if not connected or cant perform write for some reason.
  */
-bool NimBLERemoteCharacteristic::writeValue(uint8_t newValue, bool response) {
+bool NimBLERemoteCharacteristic::writeValue(uint8_t newValue, bool response) const {
     return writeValue(&newValue, 1, response);
 } // writeValue
 
@@ -514,11 +515,11 @@ bool NimBLERemoteCharacteristic::writeValue(uint8_t newValue, bool response) {
  * @param [in] response Whether we require a response from the write.
  * @return false if not connected or cant perform write for some reason.
  */
-bool NimBLERemoteCharacteristic::writeValue(const uint8_t* data, size_t length, bool response) {
+bool NimBLERemoteCharacteristic::writeValue(const uint8_t* data, size_t length, bool response) const {
     
     NIMBLE_LOGD(LOG_TAG, ">> writeValue(), length: %d", length);
     
-    NimBLEClient* pClient = getRemoteService()->getClient();
+    const NimBLEClient* pClient = getRemoteService()->getClient();
     int rc = 0;
     int retryCount = 1;
     uint16_t mtu;
@@ -537,29 +538,29 @@ bool NimBLERemoteCharacteristic::writeValue(const uint8_t* data, size_t length, 
         rc =  ble_gattc_write_no_rsp_flat(pClient->getConnId(), m_handle, data, length);
         return (rc==0);
     }
-    
+
     do {
-        m_semaphoreWriteCharEvt.take("writeValue");
+        const_cast<NimBLERemoteCharacteristic *>(this)->m_semaphoreWriteCharEvt.take("writeValue");
 
         if(length > mtu) {
             NIMBLE_LOGI(LOG_TAG,"long write %d bytes", length);
             os_mbuf *om = ble_hs_mbuf_from_flat(data, length);
             rc = ble_gattc_write_long(pClient->getConnId(), m_handle, 0, om,
                                       NimBLERemoteCharacteristic::onWriteCB,
-                                      this);
+                                      const_cast<NimBLERemoteCharacteristic *>(this));
         } else {
             rc = ble_gattc_write_flat(pClient->getConnId(), m_handle,
                                       data, length,
                                       NimBLERemoteCharacteristic::onWriteCB,
-                                      this);
+                                      const_cast<NimBLERemoteCharacteristic *>(this));
         }
         if (rc != 0) {
             NIMBLE_LOGE(LOG_TAG, "Error: Failed to write characteristic; rc=%d", rc);
-            m_semaphoreWriteCharEvt.give();
+            const_cast<NimBLERemoteCharacteristic *>(this)->m_semaphoreWriteCharEvt.give();
             return false;
         }
         
-        rc = m_semaphoreWriteCharEvt.wait("writeValue");
+        rc = const_cast<NimBLERemoteCharacteristic *>(this)->m_semaphoreWriteCharEvt.wait("writeValue");
 
         switch(rc){
             case 0:
@@ -636,7 +637,7 @@ uint8_t* NimBLERemoteCharacteristic::readRawData() {
  * @brief Get the length of the data read from the remote characteristic.
  * @return size_t length of the data in bytes.
  */
-size_t NimBLERemoteCharacteristic::getDataLength() {
+size_t NimBLERemoteCharacteristic::getDataLength() const {
     return m_value.length();
 }
 

--- a/src/NimBLERemoteCharacteristic.h
+++ b/src/NimBLERemoteCharacteristic.h
@@ -39,29 +39,29 @@ public:
     ~NimBLERemoteCharacteristic();
 
     // Public member functions
-    bool        canBroadcast();
-    bool        canIndicate();
-    bool        canNotify();
-    bool        canRead();
-    bool        canWrite();
-    bool        canWriteNoResponse();
-    NimBLERemoteDescriptor* getDescriptor(const NimBLEUUID &uuid);
+    bool                       canBroadcast() const;
+    bool                       canIndicate() const;
+    bool                       canNotify() const;
+    bool                       canRead() const;
+    bool                       canWrite() const;
+    bool                       canWriteNoResponse() const;
+    const NimBLERemoteDescriptor* getDescriptor(const NimBLEUUID &uuid) const;
     std::map<std::string, NimBLERemoteDescriptor*>* getDescriptors();
-    uint16_t    getHandle();
-    uint16_t    getDefHandle();
-    NimBLEUUID  getUUID();
-    std::string readValue();
-    uint8_t     readUInt8();
-    uint16_t    readUInt16();
-    uint32_t    readUInt32();
-    bool        registerForNotify(notify_callback _callback, bool notifications = true, bool response = true);
-    bool        writeValue(const uint8_t* data, size_t length, bool response = false);
-    bool        writeValue(const std::string &newValue, bool response = false);
-    bool        writeValue(uint8_t newValue, bool response = false);
-    std::string toString();
-    uint8_t*    readRawData();
-    size_t      getDataLength();
-    NimBLERemoteService* getRemoteService();
+    uint16_t                   getHandle() const;
+    uint16_t                   getDefHandle() const;
+    const NimBLEUUID           &getUUID() const;
+    std::string                readValue() const;
+    uint8_t                    readUInt8() const;
+    uint16_t                   readUInt16() const;
+    uint32_t                   readUInt32() const;
+    bool                       registerForNotify(notify_callback _callback, bool notifications = true, bool response = true);
+    bool                       writeValue(const uint8_t* data, size_t length, bool response = false) const;
+    bool                       writeValue(const std::string &newValue, bool response = false) const;
+    bool                       writeValue(uint8_t newValue, bool response = false) const;
+    std::string                toString() const;
+    uint8_t*                   readRawData();
+    size_t                     getDataLength() const;
+    const NimBLERemoteService* getRemoteService() const;
 
 private:
 

--- a/src/NimBLERemoteDescriptor.h
+++ b/src/NimBLERemoteDescriptor.h
@@ -25,17 +25,17 @@ class NimBLERemoteCharacteristic;
  */
 class NimBLERemoteDescriptor {
 public:
-    uint16_t    getHandle();
-    NimBLERemoteCharacteristic* getRemoteCharacteristic();
-    NimBLEUUID     getUUID();
-    std::string readValue(void);
-    uint8_t     readUInt8(void);
-    uint16_t    readUInt16(void);
-    uint32_t    readUInt32(void);
-    std::string toString(void);
-    bool        writeValue(const uint8_t* data, size_t length, bool response = false);
-    bool        writeValue(const std::string &newValue, bool response = false);
-    bool        writeValue(uint8_t newValue, bool response = false);
+    uint16_t                          getHandle() const;
+    const NimBLERemoteCharacteristic* getRemoteCharacteristic() const;
+    const NimBLEUUID                  &getUUID() const;
+    std::string                       readValue(void);
+    uint8_t                           readUInt8(void);
+    uint16_t                          readUInt16(void);
+    uint32_t                          readUInt32(void);
+    std::string                       toString(void) const;
+    bool                              writeValue(const uint8_t* data, size_t length, bool response = false) const;
+    bool                              writeValue(const std::string &newValue, bool response = false) const;
+    bool                              writeValue(uint8_t newValue, bool response = false) const;
 
 
 private:

--- a/src/NimBLERemoteService.cpp
+++ b/src/NimBLERemoteService.cpp
@@ -66,7 +66,7 @@ NimBLERemoteService::~NimBLERemoteService() {
  * @param [in] uuid Remote characteristic uuid.
  * @return Reference to the remote characteristic object.
  */ 
-NimBLERemoteCharacteristic* NimBLERemoteService::getCharacteristic(const char* uuid) {
+const NimBLERemoteCharacteristic* NimBLERemoteService::getCharacteristic(const char* uuid) const {
     return getCharacteristic(NimBLEUUID(uuid));
 } // getCharacteristic
 
@@ -76,7 +76,7 @@ NimBLERemoteCharacteristic* NimBLERemoteService::getCharacteristic(const char* u
  * @param [in] uuid Characteristic uuid.
  * @return Reference to the characteristic object, or nullptr if not found.
  */
-NimBLERemoteCharacteristic* NimBLERemoteService::getCharacteristic(const NimBLEUUID &uuid) {
+const NimBLERemoteCharacteristic* NimBLERemoteService::getCharacteristic(const NimBLEUUID &uuid) const {
     if (m_haveCharacteristics) {
         std::string v = uuid.toString();
         for (auto &myPair : m_characteristicMap) {
@@ -227,7 +227,7 @@ std::map<uint16_t, NimBLERemoteCharacteristic*>* NimBLERemoteService::getCharact
  * @brief Get the client associated with this service.
  * @return A reference to the client associated with this service.
  */
-NimBLEClient* NimBLERemoteService::getClient() {
+const NimBLEClient* NimBLERemoteService::getClient() const {
     return m_pClient;
 } // getClient
 
@@ -235,7 +235,7 @@ NimBLEClient* NimBLERemoteService::getClient() {
 /**
  * @brief Get the service end handle.
  */
-uint16_t NimBLERemoteService::getEndHandle() {
+uint16_t NimBLERemoteService::getEndHandle() const {
     return m_endHandle;
 } // getEndHandle
 
@@ -243,7 +243,7 @@ uint16_t NimBLERemoteService::getEndHandle() {
 /**
  * @brief Get the service start handle.
  */
-uint16_t NimBLERemoteService::getStartHandle() {
+uint16_t NimBLERemoteService::getStartHandle() const {
     return m_startHandle;
 } // getStartHandle
 
@@ -251,7 +251,7 @@ uint16_t NimBLERemoteService::getStartHandle() {
 /**
  * @brief Get the service UUID.
  */
-NimBLEUUID NimBLERemoteService::getUUID() {
+const NimBLEUUID &NimBLERemoteService::getUUID() const {
     return m_uuid;
 }
 
@@ -261,11 +261,11 @@ NimBLEUUID NimBLERemoteService::getUUID() {
  * @param [in] characteristicUuid The characteristic to read.
  * @returns a string containing the value or an empty string if not found or error.
  */
-std::string NimBLERemoteService::getValue(const NimBLEUUID &characteristicUuid) {
+std::string NimBLERemoteService::getValue(const NimBLEUUID &characteristicUuid) const {
     NIMBLE_LOGD(LOG_TAG, ">> readValue: uuid: %s", characteristicUuid.toString().c_str());
     
     std::string ret = "";
-    NimBLERemoteCharacteristic* pChar = getCharacteristic(characteristicUuid);
+    const NimBLERemoteCharacteristic* pChar = getCharacteristic(characteristicUuid);
     
     if(pChar != nullptr) {
         ret =  pChar->readValue();
@@ -282,11 +282,11 @@ std::string NimBLERemoteService::getValue(const NimBLEUUID &characteristicUuid) 
  * @param [in] value The value to set.
  * @returns true on success, false if not found or error
  */
-bool NimBLERemoteService::setValue(const NimBLEUUID &characteristicUuid, const std::string &value) {
+bool NimBLERemoteService::setValue(const NimBLEUUID &characteristicUuid, const std::string &value) const {
     NIMBLE_LOGD(LOG_TAG, ">> setValue: uuid: %s", characteristicUuid.toString().c_str());
     
     bool ret = false;
-    NimBLERemoteCharacteristic* pChar = getCharacteristic(characteristicUuid);
+    const NimBLERemoteCharacteristic* pChar = getCharacteristic(characteristicUuid);
     
     if(pChar != nullptr) {
          ret =  pChar->writeValue(value);
@@ -319,7 +319,7 @@ void NimBLERemoteService::removeCharacteristics() {
  * @brief Create a string representation of this remote service.
  * @return A string representation of this remote service.
  */
-std::string NimBLERemoteService::toString() {
+std::string NimBLERemoteService::toString() const {
     std::string res = "Service: uuid: " + m_uuid.toString();
     char val[6];
     res += ", start_handle: ";

--- a/src/NimBLERemoteService.h
+++ b/src/NimBLERemoteService.h
@@ -36,19 +36,19 @@ public:
     virtual ~NimBLERemoteService();
 
     // Public methods
-    NimBLERemoteCharacteristic* getCharacteristic(const char* uuid);      // Get the specified characteristic reference.
-    NimBLERemoteCharacteristic* getCharacteristic(const NimBLEUUID &uuid);       // Get the specified characteristic reference.
+    const NimBLERemoteCharacteristic* getCharacteristic(const char* uuid) const; // Get the specified characteristic reference.
+    const NimBLERemoteCharacteristic* getCharacteristic(const NimBLEUUID &uuid) const; // Get the specified characteristic reference.
 //  BLERemoteCharacteristic* getCharacteristic(uint16_t uuid);      // Get the specified characteristic reference.
     std::map<std::string, NimBLERemoteCharacteristic*>* getCharacteristics();
     std::map<uint16_t, NimBLERemoteCharacteristic*>* getCharacteristicsByHandle();  // Get the characteristics map.
 //  void getCharacteristics(std::map<uint16_t, BLERemoteCharacteristic*>* pCharacteristicMap);
 
-    NimBLEClient*            getClient(void);                                           // Get a reference to the client associated with this service.
-    uint16_t                 getHandle();                                               // Get the handle of this service.
-    NimBLEUUID               getUUID(void);                                             // Get the UUID of this service.
-    std::string              getValue(const NimBLEUUID &characteristicUuid);                      // Get the value of a characteristic.
-    bool                     setValue(const NimBLEUUID &characteristicUuid, const std::string &value);   // Set the value of a characteristic.
-    std::string              toString(void);
+    const NimBLEClient*               getClient(void) const;                    // Get a reference to the client associated with this service.
+    uint16_t                          getHandle() const;                        // Get the handle of this service.
+    const NimBLEUUID                  &getUUID(void) const;                     // Get the UUID of this service.
+    std::string                       getValue(const NimBLEUUID &characteristicUuid) const; // Get the value of a characteristic.
+    bool                              setValue(const NimBLEUUID &characteristicUuid, const std::string &value) const; // Set the value of a characteristic.
+    std::string                       toString(void) const;
 
 private:
     // Private constructor ... never meant to be created by a user application.
@@ -64,8 +64,8 @@ private:
                                 const struct ble_gatt_error *error,
                                 const struct ble_gatt_chr *chr, void *arg);
 
-    uint16_t            getStartHandle();                // Get the start handle for this service.
-    uint16_t            getEndHandle();                  // Get the end handle for this service.
+    uint16_t            getStartHandle() const;          // Get the start handle for this service.
+    uint16_t            getEndHandle() const;            // Get the end handle for this service.
     void                releaseSemaphores();
     void                removeCharacteristics();
 


### PR DESCRIPTION
Making remote object functions const. With this PR pointers to intermediate objects in the chain to the (remote) characteristic or (remote) descriptor can be created and maintained to be used several times:

```
void demo() {
  BLEClient * pClient = BLEDevice::createClient();
  bool success = pClient->connect(BLEAddress("a4:c1:38:5d:ef:16"));
  if(!success) {
    BLEDevice::deleteClient(pClient);
    Serial.println("Failed to connect");
    return;
  }
  const BLERemoteService * pRemoteService = pClient->getService(BLEUUID(0xebe0ccb0, 0x7a0a, 0x4b0c, 0x8a1a6ff2997da3a6));
  if(pRemoteService == nullptr) {
    Serial.print("Failed to find our service UUID: ");
  } else {
    Serial.println(" - Found our service");
    // Obtain a reference to the characteristic in the service of the remote BLE server.
    const BLERemoteCharacteristic * pRemoteCharacteristic = pRemoteService->getCharacteristic(BLEUUID(0xebe0ccc1, 0x7a0a, 0x4b0c, 0x8a1a6ff2997da3a6));
    if(pRemoteCharacteristic == nullptr) {
      Serial.println("Failed to find our characteristic UUID");
    } else {
      Serial.println(" - Found our characteristic");
      if(pRemoteCharacteristic->canRead()) {
        Serial.println("Can read");
        const uint8_t * pData = (const uint8_t *)pRemoteCharacteristic->readValue().data();
        float temperature = (pData[0] | (pData[1] << 8)) * 0.01;
        uint8_t humidity = pData[2];
        Serial.printf("LYWSD03MMC temperature = %.2f : humidity = %u\n", temperature, humidity);
      }
      if(pRemoteCharacteristic->canNotify()) {
        Serial.println("Can notify");
      }
    }
  }
  pClient->disconnect();
  BLEDevice::deleteClient(pClient);
}
```

**Warning**:
- This PR isn't thoroughly tested
- some `this` pointers needed const_cast, mostly because they modify m_value. Since m_value's are always returned by value, I think this is acceptable

By-catch, my example program is ~800 program bytes smaller. Because more values are passed as a reference, the performance should also be better, but Idid not time it.

This PR is done for 'central' only, 'peripheral' needs to be done.