### PR TITLE
Correct error in creation of NimBLEAddress from six bytes in a std::string

### DIFF
--- a/src/NimBLEAddress.cpp
+++ b/src/NimBLEAddress.cpp
@@ -53,7 +53,7 @@ NimBLEAddress::NimBLEAddress(const std::string &stringAddress) {
         return;
     }
 
-    if (stringAddress.length() -= 6) {
+    if (stringAddress.length() == 6) {
         std::reverse_copy(stringAddress.data(), stringAddress.data() + 6, m_address);
         return;
     }

--- a/src/NimBLEAddress.cpp
+++ b/src/NimBLEAddress.cpp
@@ -48,6 +48,16 @@ NimBLEAddress::NimBLEAddress(ble_addr_t address) {
  * @param [in] stringAddress The hex representation of the address.
  */
 NimBLEAddress::NimBLEAddress(const std::string &stringAddress) {
+    if (stringAddress.length() == 0) {
+        memset(m_address, 0, 6);
+        return;
+    }
+
+    if (stringAddress.length() -= 6) {
+        std::reverse_copy(stringAddress.data(), stringAddress.data() + 6, m_address);
+        return;
+    }
+
     if (stringAddress.length() != 17) {
         memset(m_address, 0, sizeof m_address); // "00:00:00:00:00:00" represents an invalid address
         NIMBLE_LOGD(LOG_TAG, "Invalid address '%s'", stringAddress.c_str());

--- a/src/NimBLEAddress.h
+++ b/src/NimBLEAddress.h
@@ -24,6 +24,7 @@
 /**************************/
 
 #include <string>
+#include <algorithm>
 
 /**
  * @brief A %BLE device address.

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -95,7 +95,7 @@ private:
     bool m_haveTXPower;
 
 
-    NimBLEAddress  m_address = NimBLEAddress("\0\0\0\0\0\0");
+    NimBLEAddress  m_address = NimBLEAddress("\0\0\0\0\0\0", 6);
     uint8_t         m_advType;
     uint16_t        m_appearance;
     int             m_deviceType;

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -95,7 +95,7 @@ private:
     bool m_haveTXPower;
 
 
-    NimBLEAddress  m_address = NimBLEAddress("\0\0\0\0\0\0", 6);
+    NimBLEAddress  m_address = NimBLEAddress("");
     uint8_t         m_advType;
     uint16_t        m_appearance;
     int             m_deviceType;

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -73,7 +73,7 @@ private:
     bool                retrieveServices();  //Retrieve services from the server
 //    void                onHostReset();
 
-    NimBLEAddress    m_peerAddress = NimBLEAddress("\0\0\0\0\0\0", 6);   // The BD address of the remote server.
+    NimBLEAddress    m_peerAddress = NimBLEAddress("");   // The BD address of the remote server.
     uint16_t         m_conn_id;
     bool             m_haveServices = false;    // Have we previously obtain the set of services from the remote server.
     bool             m_isConnected = false;     // Are we currently connected.

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -72,7 +72,7 @@ private:
     bool                retrieveServices();  //Retrieve services from the server
 //    void                onHostReset();
 
-    NimBLEAddress    m_peerAddress = NimBLEAddress("\0\0\0\0\0\0");   // The BD address of the remote server.
+    NimBLEAddress    m_peerAddress = NimBLEAddress("\0\0\0\0\0\0", 6);   // The BD address of the remote server.
     uint16_t         m_conn_id;
     bool             m_haveServices = false;    // Have we previously obtain the set of services from the remote server.
     bool             m_isConnected = false;     // Are we currently connected.


### PR DESCRIPTION
Add creation of a NimBLEAddress from a std::string of 6 exactly bytes (no leading or trailing zeroes allowed). Add creation of a NimBLEAddress from an empty string, also because this is used in error (without purpose I think) in the library in the form of an address with six zeroes `NimBLEAddress("\0\0\0\0\0\0")`, which in fact leads to a string of length zero and the log text `Invalid address ''`.