### PR TITLE
NimBLEScan results are incomplete!

### DIFF
--- a/src/NimBLEAdvertisedDevice.cpp
+++ b/src/NimBLEAdvertisedDevice.cpp
@@ -50,6 +50,37 @@ NimBLEAdvertisedDevice::NimBLEAdvertisedDevice() {
 
 
 /**
+ * @brief Copy constructor
+ */
+NimBLEAdvertisedDevice::NimBLEAdvertisedDevice(const NimBLEAdvertisedDevice &rhs) {
+    m_address          = rhs.m_address;
+    m_advType          = rhs.m_advType;
+    m_appearance       = rhs.m_appearance;
+    m_deviceType       = rhs.m_deviceType;
+    m_manufacturerData = rhs.m_manufacturerData;
+    m_name             = rhs.m_name;
+    m_pScan            = rhs.m_pScan;
+    m_rssi             = rhs.m_rssi;
+    m_serviceUUIDs     = rhs.m_serviceUUIDs;
+    m_txPower          = rhs.m_txPower;
+    m_serviceData      = rhs.m_serviceData;
+    m_serviceDataUUID  = rhs.m_serviceDataUUID;
+    m_payload          = rhs.m_payload;
+    m_payloadLength    = rhs.m_payloadLength;
+    m_addressType      = rhs.m_addressType;
+
+    m_haveAppearance       = rhs.m_haveAppearance;
+    m_haveManufacturerData = rhs.m_haveManufacturerData;
+    m_haveName             = rhs.m_haveName;
+    m_haveRSSI             = rhs.m_haveRSSI;
+    m_haveServiceData      = rhs.m_haveServiceData;
+    m_haveServiceUUID      = rhs.m_haveServiceUUID;
+    m_haveTXPower          = rhs.m_haveTXPower;
+
+} // NimBLEAdvertisedDevice
+
+
+/**
  * @brief Get the address.
  *
  * Every %BLE device exposes an address that is used to identify it and subsequently connect to it.

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -41,6 +41,8 @@ class NimBLEAdvertisedDevice {
 public:
     NimBLEAdvertisedDevice();
 
+    NimBLEAdvertisedDevice(const NimBLEAdvertisedDevice &rhs);
+
     NimBLEAddress   getAddress();
     uint16_t        getAppearance();
     std::string     getManufacturerData();

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -400,7 +400,7 @@ NimBLEAdvertisedDevice NimBLEScanResults::getDevice(uint32_t i) {
         if (x==i)   break;
         x++;
     }
-    return dev;
+    return NimBLEAdvertisedDevice(dev);
 }
 
 #endif // #if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)


### PR DESCRIPTION
Add `NimBLEAdvertisedDevice` copy constructor and use it in `NimBLEScanResults::getDevice()`, because otherwise the `std::string` class member variables of the advertisedDevice is not returned correctly by `NimBLEScan::getResults()` and `NimBLEScan::start()`. Only the data from the `BLEAdvertisedDeviceCallbacks` (so on a per device basis) is correct. 
I _think_ (but I am not a 100% sure) the root cause is because `std::map<std::string, NimBLEAdvertisedDevice*> m_advertisedDevicesMap` in `NimBLEScanResults` is pointer based, and thus the `NimBLEAdvertisedDevice*` pointers are _copied_ and not _constructed_.

The `uint8_t *payload` pointer may still be dangling!