### PR TITLE
Update NimBLERemoteCharacteristic value from a notification (replaces PR #27)

### DIFF
--- a/src/NimBLEAdvertisedDevice.cpp
+++ b/src/NimBLEAdvertisedDevice.cpp
@@ -50,38 +50,6 @@ NimBLEAdvertisedDevice::NimBLEAdvertisedDevice() {
 
 
 /**
- * @brief Copy constructor
- */
-NimBLEAdvertisedDevice::NimBLEAdvertisedDevice(const NimBLEAdvertisedDevice &rhs) {
-    m_address          = rhs.m_address;
-    m_advType          = rhs.m_advType;
-    m_appearance       = rhs.m_appearance;
-    m_deviceType       = rhs.m_deviceType;
-    m_manufacturerData = rhs.m_manufacturerData;
-    m_name             = rhs.m_name;
-    m_pScan            = rhs.m_pScan;
-    m_rssi             = rhs.m_rssi;
-    m_serviceUUIDs     = rhs.m_serviceUUIDs;
-    m_txPower          = rhs.m_txPower;
-    m_serviceData      = rhs.m_serviceData;
-    m_serviceDataUUID  = rhs.m_serviceDataUUID;
-    m_payload          = rhs.m_payload;
-    m_payloadLength    = rhs.m_payloadLength;
-    m_addressType      = rhs.m_addressType;
-    m_timestamp        = rhs.m_timestamp;
-
-    m_haveAppearance       = rhs.m_haveAppearance;
-    m_haveManufacturerData = rhs.m_haveManufacturerData;
-    m_haveName             = rhs.m_haveName;
-    m_haveRSSI             = rhs.m_haveRSSI;
-    m_haveServiceData      = rhs.m_haveServiceData;
-    m_haveServiceUUID      = rhs.m_haveServiceUUID;
-    m_haveTXPower          = rhs.m_haveTXPower;
-
-} // NimBLEAdvertisedDevice
-
-
-/**
  * @brief Get the address.
  *
  * Every %BLE device exposes an address that is used to identify it and subsequently connect to it.

--- a/src/NimBLEAdvertisedDevice.cpp
+++ b/src/NimBLEAdvertisedDevice.cpp
@@ -50,6 +50,38 @@ NimBLEAdvertisedDevice::NimBLEAdvertisedDevice() {
 
 
 /**
+ * @brief Copy constructor
+ */
+NimBLEAdvertisedDevice::NimBLEAdvertisedDevice(const NimBLEAdvertisedDevice &rhs) {
+    m_address          = rhs.m_address;
+    m_advType          = rhs.m_advType;
+    m_appearance       = rhs.m_appearance;
+    m_deviceType       = rhs.m_deviceType;
+    m_manufacturerData = rhs.m_manufacturerData;
+    m_name             = rhs.m_name;
+    m_pScan            = rhs.m_pScan;
+    m_rssi             = rhs.m_rssi;
+    m_serviceUUIDs     = rhs.m_serviceUUIDs;
+    m_txPower          = rhs.m_txPower;
+    m_serviceData      = rhs.m_serviceData;
+    m_serviceDataUUID  = rhs.m_serviceDataUUID;
+    m_payload          = rhs.m_payload;
+    m_payloadLength    = rhs.m_payloadLength;
+    m_addressType      = rhs.m_addressType;
+    m_timestamp        = rhs.m_timestamp;
+
+    m_haveAppearance       = rhs.m_haveAppearance;
+    m_haveManufacturerData = rhs.m_haveManufacturerData;
+    m_haveName             = rhs.m_haveName;
+    m_haveRSSI             = rhs.m_haveRSSI;
+    m_haveServiceData      = rhs.m_haveServiceData;
+    m_haveServiceUUID      = rhs.m_haveServiceUUID;
+    m_haveTXPower          = rhs.m_haveTXPower;
+
+} // NimBLEAdvertisedDevice
+
+
+/**
  * @brief Get the address.
  *
  * Every %BLE device exposes an address that is used to identify it and subsequently connect to it.
@@ -533,6 +565,11 @@ uint8_t* NimBLEAdvertisedDevice::getPayload() {
 
 uint8_t NimBLEAdvertisedDevice::getAddressType() {
     return m_addressType;
+}
+
+
+time_t NimBLEAdvertisedDevice::getTimestamp() {
+    return m_timestamp;
 }
 
 

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -41,8 +41,6 @@ class NimBLEAdvertisedDevice {
 public:
     NimBLEAdvertisedDevice();
 
-    NimBLEAdvertisedDevice(const NimBLEAdvertisedDevice &);
-
     NimBLEAddress   getAddress();
     uint16_t        getAppearance();
     std::string     getManufacturerData();

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -41,6 +41,8 @@ class NimBLEAdvertisedDevice {
 public:
     NimBLEAdvertisedDevice();
 
+    NimBLEAdvertisedDevice(const NimBLEAdvertisedDevice &);
+
     NimBLEAddress   getAddress();
     uint16_t        getAppearance();
     std::string     getManufacturerData();
@@ -54,7 +56,8 @@ public:
     uint8_t*        getPayload();
     size_t          getPayloadLength();
     uint8_t         getAddressType();
-    void setAddressType(uint8_t type);
+    time_t          getTimestamp();
+    void            setAddressType(uint8_t type);
 
 
     bool        isAdvertisingService(const NimBLEUUID &uuid);
@@ -95,7 +98,7 @@ private:
     bool m_haveTXPower;
 
 
-    NimBLEAddress  m_address = NimBLEAddress("\0\0\0\0\0\0");
+    NimBLEAddress   m_address = NimBLEAddress("\0\0\0\0\0\0");
     uint8_t         m_advType;
     uint16_t        m_appearance;
     int             m_deviceType;
@@ -110,6 +113,7 @@ private:
     uint8_t*        m_payload;
     size_t          m_payloadLength = 0;
     uint8_t         m_addressType;
+    time_t          m_timestamp;
 };
 
 /**

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -673,9 +673,16 @@ uint16_t NimBLEClient::getMTU() {
                 if(characteristic != cMap->end()) {
                     NIMBLE_LOGD(LOG_TAG, "Got Notification for characteristic %s", characteristic->second->toString().c_str());
 
+                    characteristic->second->m_value = std::string((char *)event->notify_rx.om->om_data, event->notify_rx.om->om_len);
+                    characteristic->second->m_timestamp = time(nullptr);
+
                     if (characteristic->second->m_notifyCallback != nullptr) {
                         NIMBLE_LOGD(LOG_TAG, "Invoking callback for notification on characteristic %s", characteristic->second->toString().c_str());
                         characteristic->second->m_notifyCallback(characteristic->second, event->notify_rx.om->om_data, event->notify_rx.om->om_len, !event->notify_rx.indication);
+                    }
+                    if (characteristic->second->m_notifyCallbackPlain != nullptr) {
+                        NIMBLE_LOGD(LOG_TAG, "Invoking callback for notification on characteristic %s", characteristic->second->toString().c_str());
+                        characteristic->second->m_notifyCallbackPlain(characteristic->second, !event->notify_rx.indication);
                     }
 
                     break;

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -684,7 +684,6 @@ uint16_t NimBLEClient::getMTU() {
                         NIMBLE_LOGD(LOG_TAG, "Invoking callback for notification on characteristic %s", characteristic->second->toString().c_str());
                         characteristic->second->m_notifyCallbackPlain(characteristic->second, !event->notify_rx.indication);
                     }
-
                     break;
                 }
             }

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -680,13 +680,15 @@ uint16_t NimBLEClient::getMTU() {
                 if(characteristic != cVector->cend()) {
                     NIMBLE_LOGD(LOG_TAG, "Got Notification for characteristic %s", (*characteristic)->toString().c_str());
 
+                    (*characteristic)->m_value = std::string((char *)event->notify_rx.om->om_data, event->notify_rx.om->om_len);
+                    (*characteristic)->m_timestamp = time(nullptr);
                     if ((*characteristic)->m_notifyCallback != nullptr) {
                         NIMBLE_LOGD(LOG_TAG, "Invoking callback for notification on characteristic %s", (*characteristic)->toString().c_str());
                         (*characteristic)->m_notifyCallback(*characteristic, event->notify_rx.om->om_data, event->notify_rx.om->om_len, !event->notify_rx.indication);
                     }
-                    if (characteristic->second->m_notifyCallbackPlain != nullptr) {
-                        NIMBLE_LOGD(LOG_TAG, "Invoking callback for notification on characteristic %s", characteristic->second->toString().c_str());
-                        characteristic->second->m_notifyCallbackPlain(characteristic->second, !event->notify_rx.indication);
+                    if ((*characteristic)->m_notifyCallbackPlain != nullptr) {
+                        NIMBLE_LOGD(LOG_TAG, "Invoking callback for notification on characteristic %s", (*characteristic)->toString().c_str());
+                        (*characteristic)->m_notifyCallbackPlain(*characteristic, !event->notify_rx.indication);
                     }
                     break;
                 }

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -720,8 +720,11 @@ uint16_t NimBLEClient::getMTU() {
                 if(characteristic != cVector->cend()) {
                     NIMBLE_LOGD(LOG_TAG, "Got Notification for characteristic %s", (*characteristic)->toString().c_str());
 
-                    (*characteristic)->m_value = std::string((char *)event->notify_rx.om->om_data, event->notify_rx.om->om_len);
-                    (*characteristic)->m_timestamp = time(nullptr);
+                    if((*characteristic)->m_semaphoreReadCharEvt.take(0, "notifyValue")) { 
+                        (*characteristic)->m_value = std::string((char *)event->notify_rx.om->om_data, event->notify_rx.om->om_len);
+                        (*characteristic)->m_timestamp = time(nullptr);
+                        (*characteristic)->m_semaphoreReadCharEvt.give();
+                    }
                     if ((*characteristic)->m_notifyCallback != nullptr) {
                         NIMBLE_LOGD(LOG_TAG, "Invoking callback for notification on characteristic %s",
                                              (*characteristic)->toString().c_str());

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -418,6 +418,7 @@ int NimBLERemoteCharacteristic::onReadCB(uint16_t conn_handle,
             NIMBLE_LOGD(LOG_TAG, "Got %d bytes", attr->om->om_len);
 
             characteristic->m_value += std::string((char*) attr->om->om_data, attr->om->om_len);
+            characteristic->m_timestamp = time(nullptr);
             return 0;
         }
     }

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -453,7 +453,7 @@ std::string NimBLERemoteCharacteristic::getValue(time_t *timestamp) {
     m_semaphoreReadCharEvt.take("readValue");
     std::string value = m_value;
     *timestamp = m_timestamp;
-    m_semaphoreReadCharEvt.give(1);
+    m_semaphoreReadCharEvt.give();
     return value;
 }
 

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -56,6 +56,7 @@ static const char* LOG_TAG = "NimBLERemoteCharacteristic";
     m_charProp       = chr->properties;
     m_pRemoteService = pRemoteService;
     m_notifyCallback = nullptr;
+    m_notifyCallbackPlain = nullptr;
     m_rawData        = nullptr;
     m_dataLen        = 0;
     m_timestamp      = 0;

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -390,8 +390,6 @@ std::string NimBLERemoteCharacteristic::readValue() {
 
     int rc = 0;
     int retryCount = 1;
-    // Clear the value before reading.
-    m_value = "";
 
     NimBLEClient* pClient = getRemoteService()->getClient();
 
@@ -403,6 +401,8 @@ std::string NimBLERemoteCharacteristic::readValue() {
 
     do {
         m_semaphoreReadCharEvt.take("readValue");
+        // Clear the value before reading.
+        m_value = "";
 
         rc = ble_gattc_read_long(pClient->getConnId(), m_handle, 0,
                                  NimBLERemoteCharacteristic::onReadCB,
@@ -446,13 +446,11 @@ std::string NimBLERemoteCharacteristic::readValue() {
  * @return The value of the remote characteristic.
  */
 std::string NimBLERemoteCharacteristic::getValue(time_t *timestamp) {
-    if(timestamp == nullptr) {
-        return m_value;
-    }
-
-    m_semaphoreReadCharEvt.take("readValue");
+    m_semaphoreReadCharEvt.take("getValue");
     std::string value = m_value;
-    *timestamp = m_timestamp;
+    if(timestamp != nullptr) {
+        *timestamp = m_timestamp;
+    }
     m_semaphoreReadCharEvt.give();
     return value;
 }

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -480,10 +480,10 @@ bool NimBLERemoteCharacteristic::registerForNotify(notify_callback notifyCallbac
 
 
 /**
- * @brief Delete the descriptors in the descriptor map.
- * We maintain a map called m_descriptorMap that contains pointers to BLERemoteDescriptors
- * object references.  Since we allocated these in this class, we are also responsible for deleteing
- * them.  This method does just that.
+ * @brief Delete the descriptors in the descriptor vector.
+ * We maintain a map called m_descriptorVector that contains pointers to BLERemoteDescriptors
+ * object references. Since we allocated these in this class, we are also responsible for deleting
+ * them. This method does just that.
  * @return N/A.
  */
 void NimBLERemoteCharacteristic::removeDescriptors() {

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -481,7 +481,7 @@ bool NimBLERemoteCharacteristic::registerForNotify(notify_callback notifyCallbac
 
 /**
  * @brief Delete the descriptors in the descriptor vector.
- * We maintain a map called m_descriptorVector that contains pointers to BLERemoteDescriptors
+ * We maintain a vector called m_descriptorVector that contains pointers to BLERemoteDescriptors
  * object references. Since we allocated these in this class, we are also responsible for deleting
  * them. This method does just that.
  * @return N/A.

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -58,6 +58,7 @@ static const char* LOG_TAG = "NimBLERemoteCharacteristic";
     m_notifyCallback = nullptr;
     m_rawData        = nullptr;
     m_dataLen        = 0;
+    m_timestamp      = 0;
  } // NimBLERemoteCharacteristic
 
 
@@ -378,6 +379,23 @@ std::string NimBLERemoteCharacteristic::readValue() {
 
 
 /**
+ * @brief Get the value of the remote characteristic.
+ * @return The value of the remote characteristic.
+ */
+std::string NimBLERemoteCharacteristic::getValue(time_t *timestamp) {
+    if(timestamp == nullptr) {
+        return m_value;
+    }
+
+    m_semaphoreReadCharEvt.take("readValue");
+    std::string value = m_value;
+    *timestamp = m_timestamp;
+    m_semaphoreReadCharEvt.give(1);
+    return value;
+}
+
+
+/**
  * @brief Callback for characteristic read operation.
  * @return 0 or error code.
  */
@@ -420,6 +438,41 @@ bool NimBLERemoteCharacteristic::registerForNotify(notify_callback notifyCallbac
     NIMBLE_LOGD(LOG_TAG, ">> registerForNotify(): %s", toString().c_str());
 
     m_notifyCallback = notifyCallback;   // Save the notification callback.
+
+    uint8_t val[] = {0x01, 0x00};
+
+    NimBLERemoteDescriptor* desc = getDescriptor(NimBLEUUID((uint16_t)0x2902));
+    if(desc == nullptr)
+        return false;
+
+    if(notifyCallback != nullptr){
+        if(!notifications){
+            val[0] = 0x02;
+        }
+    }
+
+    else if (notifyCallback == nullptr){
+        val[0] = 0x00;
+    }
+
+    NIMBLE_LOGD(LOG_TAG, "<< registerForNotify()");
+
+    return desc->writeValue(val, 2, response);
+} // registerForNotify
+
+
+/**
+ * @brief Register for notifications.
+ * @param [in] notifyCallback A callback to be invoked for a notification.  If NULL is provided then we are
+ * unregistering for notifications.
+ * @param [in] bool if true, register for notifications, false register for indications.
+ * @param [in] bool if true, require a write response from the descriptor write operation.
+ * @return true if successful.
+ */
+bool NimBLERemoteCharacteristic::registerForNotify(notify_callback_plain notifyCallback, bool notifications, bool response) {
+    NIMBLE_LOGD(LOG_TAG, ">> registerForNotify(): %s", toString().c_str());
+
+    m_notifyCallbackPlain = notifyCallback;   // Save the notification callback.
 
     uint8_t val[] = {0x01, 0x00};
 

--- a/src/NimBLERemoteCharacteristic.h
+++ b/src/NimBLERemoteCharacteristic.h
@@ -33,6 +33,7 @@ class NimBLERemoteDescriptor;
 
 
 typedef void (*notify_callback)(NimBLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify);
+typedef void (*notify_callback_plain)(NimBLERemoteCharacteristic* pBLERemoteCharacteristic, bool isNotify);
 
 /**
  * @brief A model of a remote %BLE characteristic.
@@ -57,7 +58,9 @@ public:
     uint8_t     readUInt8();
     uint16_t    readUInt16();
     uint32_t    readUInt32();
+    std::string getValue(time_t *timestamp = nullptr);
     bool        registerForNotify(notify_callback _callback, bool notifications = true, bool response = true);
+    bool        registerForNotify(notify_callback_plain _callback, bool notifications = true, bool response = true);
     bool        writeValue(const uint8_t* data, size_t length, bool response = false);
     bool        writeValue(const std::string &newValue, bool response = false);
     bool        writeValue(uint8_t newValue, bool response = false);
@@ -97,6 +100,8 @@ private:
     uint8_t*                m_rawData;
     size_t                  m_dataLen;
     notify_callback         m_notifyCallback;
+    notify_callback_plain   m_notifyCallbackPlain;
+    time_t                  m_timestamp;
 
     // We maintain a map of descriptors owned by this characteristic keyed by a string representation of the UUID.
     std::map<std::string, NimBLERemoteDescriptor*> m_descriptorMap;

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -412,9 +412,9 @@ NimBLEAdvertisedDevice NimBLEScanResults::getDevice(uint32_t i) {
  * @return A pointer to the device at the specified address.
  */
 NimBLEAdvertisedDevice *NimBLEScanResults::getDevice(const NimBLEAddress &address) {
-    for(size_t index = 0; index < m_advertisedDevicesVector.size(); index++) {
-        if(m_advertisedDevicesVector[index]->getAddress() == address) {
-            return m_advertisedDevicesVector[index];
+    for (auto it = m_advertisedDevicesMap.begin(); it != m_advertisedDevicesMap.end(); it++) {
+        if(it->second->getAddress() == address) {
+            return it->second;
         }
     }
 

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -421,22 +421,5 @@ NimBLEAdvertisedDevice *NimBLEScanResults::getDevice(const NimBLEAddress &addres
     return nullptr;
 }
 
-
-/**
- * @brief Return a pointer to the specified device at the given address.
- * If the address is not found a nullptr is returned.
- * @param [in] address The address of the device.
- * @return A pointer to the device at the specified address.
- */
-NimBLEAdvertisedDevice *NimBLEScanResults::getDevice(const NimBLEAddress &address) {
-    for (auto it = m_advertisedDevicesMap.begin(); it != m_advertisedDevicesMap.end(); it++) {
-        if(it->second->getAddress() == address) {
-            return it->second;
-        }
-    }
-
-    return nullptr;
-}
-
 #endif // #if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)
 #endif /* CONFIG_BT_ENABLED */

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -401,8 +401,7 @@ NimBLEAdvertisedDevice NimBLEScanResults::getDevice(uint32_t i) {
         if (x==i)   break;
         x++;
     }
-    return NimBLEAdvertisedDevice(dev);
-//    return dev;
+    return dev;
 }
 
 #endif // #if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -141,6 +141,7 @@ NimBLEScan::NimBLEScan() {
             advertisedDevice->parseAdvertisement(&fields);
             advertisedDevice->setScan(pScan);
             advertisedDevice->setAdvertisementResult(event->disc.data, event->disc.length_data);
+            advertisedDevice->m_timestamp = time(nullptr);
 
             if (pScan->m_pAdvertisedDeviceCallbacks) {
                 // If not active scanning report the result to the listener.
@@ -400,7 +401,8 @@ NimBLEAdvertisedDevice NimBLEScanResults::getDevice(uint32_t i) {
         if (x==i)   break;
         x++;
     }
-    return dev;
+    return NimBLEAdvertisedDevice(dev);
+//    return dev;
 }
 
 #endif // #if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -404,5 +404,22 @@ NimBLEAdvertisedDevice NimBLEScanResults::getDevice(uint32_t i) {
     return dev;
 }
 
+
+/**
+ * @brief Return a pointer to the specified device at the given address.
+ * If the address is not found a nullptr is returned.
+ * @param [in] address The address of the device.
+ * @return A pointer to the device at the specified address.
+ */
+NimBLEAdvertisedDevice *NimBLEScanResults::getDevice(const NimBLEAddress &address) {
+    for(size_t index = 0; index < m_advertisedDevicesVector.size(); index++) {
+        if(m_advertisedDevicesVector[index]->getAddress() == address) {
+            return m_advertisedDevicesVector[index];
+        }
+    }
+
+    return nullptr;
+}
+
 #endif // #if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)
 #endif /* CONFIG_BT_ENABLED */

--- a/src/NimBLEScan.h
+++ b/src/NimBLEScan.h
@@ -44,6 +44,7 @@ public:
     void                dump();
     int                 getCount();
     NimBLEAdvertisedDevice getDevice(uint32_t i);
+    NimBLEAdvertisedDevice *getDevice(const NimBLEAddress &address);
 
 private:
     friend NimBLEScan;

--- a/src/NimBLEScan.h
+++ b/src/NimBLEScan.h
@@ -40,6 +40,7 @@ class NimBLEAdvertisedDeviceCallbacks;
  */
 class NimBLEScanResults {
 public:
+//                        NimBLEScanResults(const NimBLEScanResults &);
     void                dump();
     int                 getCount();
     NimBLEAdvertisedDevice getDevice(uint32_t i);


### PR DESCRIPTION
This PR:
- Updates the `m_value` in the `NimBLERemoteCharacteristic` from the stack callback
- Adds `std::string NimBLERemoteCharacteristic::getValue(time_t *timestamp = nullptr)` to access the value that is present in the characteristic _without reading it again_ from the remote server!
- Adds a timestamp (epoch) to the `NimBLERemoteCharacteristic`. The timestamp is set after a `::readValue()` and after a notification.
- Adds a new callback `void notifyCallbackPlain(BLERemoteCharacteristic* pBLERemoteCharacteristic, bool isNotify)`. In this new callback the `uint8_t *` pointer to the data and the length parameters are omitted, because they can be read from the characteristic itself, by `pBLERemoteCharacteristic->getValue()`.
- Adds a timestamp (epoch) to `NimBLEadvertisedDevice`. The timestamp is set each time the device is encountered during a scan
- Adds `NimBLEadvertisedDevice::getTimestamp()` to access the last time the device was scanned

With this PR:
- It is possible to read the service data and / or the manufacturer data without setting up callbacks for it, and without waiting for a scan to complete. This is especially useful in an infinite scan (with `duration == 0`). The callback still keeps on having the same behavior.
- It is also possible to get the value from a notification, again without setting up callbacks for it. Still the callbacks work properly. Moreover: In the notify callback the value can (also) be accessed from the notification itself.
- The API stays backward compatible, `remoteCharacteristic::readValue()` (and the other read functions) keep their purpose and work like before. The new `::getValue()` returns the latest value set either by `::readValue()` or by notification

This PR replaces PR #27. As stated by @h2zero in that PR, the device for what I created that PR, the LYWSD03MMC temperature / moisture sensor, does not comply with the BLE standards: it starts sending notifications on service ebe0ccb0-7a0a-4b0c-8a1a-6ff2997da3a6 characteristic ebe0ccc1-7a0a-4b0c-8a1a-6ff2997da3a6 right after connecting with it, without asking for that notification. With this PR you can ask that device for a notification on the service and characteristic, and even read it, and register a callback for it. That will work conform BLE standard (although connecting to the device is enough to get the notifications). In the notification callback you can read the data from the `uint8_t *` pointer OR from the characteristic itself using `getValue()`. Or you can access the latest value at any time by getting a reference to the characteristic and issue a `getValue()`