### PR TITLE
Create semaphores dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,29 @@ A fork of the NimBLE stack restructured for compilation in the Ardruino IDE with
 
 Why? Because the Bluedroid library is too bulky. 
 
-Initial client code testing has resulted in code size reduction of ~115k and reduced ram consumption of ~37k.
+Initial testing has resulted in code size reduction of ~50% and reduced ram consumption of ~100k.
 
-Server code testing results from @beegee-toyo [from the project here](https://github.com/beegee-tokyo/ESP32WiFiBLE-NimBLE):
+## BLE_client example comparison (Debug):
+#### Arduino BLE Library   
+Sketch uses 1214909 bytes (57%) of program storage space.   
+Memory after connection: Free Heap: 171308   
 
+#### NimBLE-Arduino library
+Sketch uses 622076 bytes (29%) of program storage space.   
+Memory after connection: Free Heap: 270408   
+  
+## BLE_notify (server) example comparison (Debug):   
+#### Arduino BLE Library
+Sketch uses 1208409 bytes (57%) of program storage space.   
+Memory after connection: Free Heap: 173300   
 
+#### NimBLE-Arduino library   
+Sketch uses 609044 bytes (29%) of program storage space.   
+Memory after connection: Free Heap: 269448  
+   
+   
+## Server code testing results from @beegee-toyo [from the project here](https://github.com/beegee-tokyo/ESP32WiFiBLE-NimBLE):
+   
 ### Memory usage (compilation output)
 #### Arduino BLE library
 ```log
@@ -35,9 +53,8 @@ Flash: [=======   ]  69.5% (used 911378 bytes from 1310720 bytes)
 #### Arduino BLE library
 **`Internal Total heap 259104, internal Free Heap 91660`**    
 #### NimBLE-Arduino library
-**`Internal Total heap 290288, internal Free Heap 182344`** 
-  
-  
+**`Internal Total heap 290288, internal Free Heap 182344`**   
+
 # Installation:
 
 Download as .zip and extract to Arduino/libraries folder, or in Arduino IDE from Sketch menu -> Include library -> Add .Zip library.

--- a/src/NimBLEAdvertising.h
+++ b/src/NimBLEAdvertising.h
@@ -27,7 +27,6 @@
 /**************************/
 
 #include "NimBLEUUID.h"
-#include "FreeRTOS.h"
 
 #include <vector>
 

--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -391,7 +391,7 @@ void NimBLECharacteristic::notify(bool is_notification) {
         om = ble_hs_mbuf_from_flat(data, length);
 
         if(!is_notification) {
-            m_semaphoreConfEvt.take("indicate");
+            m_semaphoreConfEvt.take();
             rc = ble_gattc_indicate_custom((*it).first, m_handle, om);
             if(rc != 0){
                 m_semaphoreConfEvt.give();

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -44,7 +44,7 @@ typedef enum {
 #include "NimBLEDescriptor.h"
 #include "NimBLEUUID.h"
 #include "NimBLEValue.h"
-#include "FreeRTOS.h"
+#include "NimBLESemaphore.h"
 
 #include <string>
 #include <map>
@@ -136,7 +136,6 @@ public:
 //////////////////////////////////////////////////////
 
 private:
-
     friend class NimBLEServer;
     friend class NimBLEService;
 //  friend class NimBLEDescriptor;
@@ -155,6 +154,7 @@ private:
     NimBLECharacteristicCallbacks* m_pCallbacks;
     NimBLEService*                 m_pService;
     NimBLEValue                    m_value;
+    NimBLESemaphore                m_semaphoreConfEvt = NimBLESemaphore("ConfEvt");
 //  uint16_t                       m_permissions;
 
     void            addDescriptor(NimBLEDescriptor* pDescriptor);
@@ -163,8 +163,6 @@ private:
     void            setSubscribe(struct ble_gap_event *event);
     static int      handleGapEvent(uint16_t conn_handle, uint16_t attr_handle,
                                 struct ble_gatt_access_ctxt *ctxt, void *arg);
-
-    FreeRTOS::Semaphore m_semaphoreConfEvt   = FreeRTOS::Semaphore("ConfEvt");
 }; // NimBLECharacteristic
 
 

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -60,12 +60,13 @@ public:
     void                                       updateConnParams(uint16_t minInterval, uint16_t maxInterval,
                                                             uint16_t latency, uint16_t timeout);
 
-
 private:
     NimBLEClient();
     ~NimBLEClient();
     friend class NimBLEDevice;
     friend class NimBLERemoteService;
+    friend class NimBLERemoteCharacteristic;
+    friend class NimBLERemoteDescriptor;
 
     static int          handleGapEvent(struct ble_gap_event *event, void *arg);
     static int          serviceDiscoveredCB(uint16_t conn_handle, const struct ble_gatt_error *error, const struct ble_gatt_svc *service, void *arg);
@@ -73,20 +74,15 @@ private:
     bool                retrieveServices();  //Retrieve services from the server
 //    void                onHostReset();
 
-    NimBLEAddress    m_peerAddress = NimBLEAddress("");   // The BD address of the remote server.
-    uint16_t         m_conn_id;
-    bool             m_haveServices = false;    // Have we previously obtain the set of services from the remote server.
-    bool             m_isConnected = false;     // Are we currently connected.
-    bool             m_waitingToConnect =false;
-    bool             m_deleteCallbacks = true;
-    int32_t          m_connectTimeout;
-    //uint16_t         m_mtu = 23;
-
-    NimBLEClientCallbacks*  m_pClientCallbacks = nullptr;
-
-    FreeRTOS::Semaphore     m_semaphoreOpenEvt       = FreeRTOS::Semaphore("OpenEvt");
-    FreeRTOS::Semaphore     m_semaphoreSearchCmplEvt = FreeRTOS::Semaphore("SearchCmplEvt");
-    FreeRTOS::Semaphore     m_semeaphoreSecEvt       = FreeRTOS::Semaphore("Security");
+    NimBLEAddress           m_peerAddress = NimBLEAddress("\0\0\0\0\0\0");   // The BD address of the remote server.
+    uint16_t                m_conn_id;
+    bool                    m_haveServices;    // Have we previously obtain the set of services from the remote server.
+    bool                    m_isConnected;     // Are we currently connected.
+    bool                    m_waitingToConnect;
+    bool                    m_deleteCallbacks;
+    int32_t                 m_connectTimeout;
+    NimBLESemaphore*        m_pSemaphore;
+    NimBLEClientCallbacks*  m_pClientCallbacks;
 
     std::vector<NimBLERemoteService*> m_servicesVector;
 

--- a/src/NimBLEDescriptor.h
+++ b/src/NimBLEDescriptor.h
@@ -22,7 +22,6 @@
 
 #include "NimBLECharacteristic.h"
 #include "NimBLEUUID.h"
-#include "FreeRTOS.h"
 
 #include <string>
 

--- a/src/NimBLERemoteCharacteristic.h
+++ b/src/NimBLERemoteCharacteristic.h
@@ -20,8 +20,6 @@
 #include "nimconfig.h"
 #if defined( CONFIG_BT_NIMBLE_ROLE_CENTRAL)
 
-//#include "NimBLEUUID.h"
-//#include "FreeRTOS.h"
 #include "NimBLERemoteService.h"
 #include "NimBLERemoteDescriptor.h"
 
@@ -79,10 +77,8 @@ private:
     bool              retrieveDescriptors(uint16_t endHdl);
     static int        onReadCB(uint16_t conn_handle, const struct ble_gatt_error *error, struct ble_gatt_attr *attr, void *arg);
     static int        onWriteCB(uint16_t conn_handle, const struct ble_gatt_error *error, struct ble_gatt_attr *attr, void *arg);
-    void              releaseSemaphores();
     static int        descriptorDiscCB(uint16_t conn_handle, const struct ble_gatt_error *error,
-                                uint16_t chr_val_handle, const struct ble_gatt_dsc *dsc,
-                                void *arg);
+                                       uint16_t chr_val_handle, const struct ble_gatt_dsc *dsc, void *arg);
 
     // Private properties
     NimBLEUUID              m_uuid;
@@ -90,13 +86,11 @@ private:
     uint16_t                m_handle;
     uint16_t                m_defHandle;
     NimBLERemoteService*    m_pRemoteService;
-    FreeRTOS::Semaphore     m_semaphoreGetDescEvt       = FreeRTOS::Semaphore("GetDescEvt");
-    FreeRTOS::Semaphore     m_semaphoreReadCharEvt      = FreeRTOS::Semaphore("ReadCharEvt");
-    FreeRTOS::Semaphore     m_semaphoreWriteCharEvt     = FreeRTOS::Semaphore("WriteCharEvt");
     std::string             m_value;
     uint8_t*                m_rawData;
     size_t                  m_dataLen;
     notify_callback         m_notifyCallback;
+    NimBLESemaphore*        m_pSemaphore;
 
     // We maintain a vector of descriptors owned by this characteristic.
     std::vector<NimBLERemoteDescriptor*> m_descriptorVector;

--- a/src/NimBLERemoteDescriptor.h
+++ b/src/NimBLERemoteDescriptor.h
@@ -52,10 +52,7 @@ private:
     NimBLEUUID                  m_uuid;                    // UUID of this descriptor.
     std::string                 m_value;                   // Last received value of the descriptor.
     NimBLERemoteCharacteristic* m_pRemoteCharacteristic;   // Reference to the Remote characteristic of which this descriptor is associated.
-    FreeRTOS::Semaphore         m_semaphoreReadDescrEvt  = FreeRTOS::Semaphore("ReadDescrEvt");
-    FreeRTOS::Semaphore         m_semaphoreDescWrite     = FreeRTOS::Semaphore("WriteDescEvt");
-
-
+    NimBLESemaphore*            m_pSemaphore;
 };
 
 #endif // #if defined( CONFIG_BT_NIMBLE_ROLE_CENTRAL)

--- a/src/NimBLERemoteService.h
+++ b/src/NimBLERemoteService.h
@@ -22,7 +22,7 @@
 
 #include "NimBLEClient.h"
 #include "NimBLEUUID.h"
-#include "FreeRTOS.h"
+#include "NimBLESemaphore.h"
 #include "NimBLERemoteCharacteristic.h"
 
 #include <vector>
@@ -39,11 +39,9 @@ public:
     virtual ~NimBLERemoteService();
 
     // Public methods
-    NimBLERemoteCharacteristic* getCharacteristic(const char* uuid);      // Get the specified characteristic reference.
-    NimBLERemoteCharacteristic* getCharacteristic(const NimBLEUUID &uuid);       // Get the specified characteristic reference.
-//  BLERemoteCharacteristic* getCharacteristic(uint16_t uuid);      // Get the specified characteristic reference.
-    std::vector<NimBLERemoteCharacteristic*>* getCharacteristics();
-//  void getCharacteristics(std::map<uint16_t, BLERemoteCharacteristic*>* pCharacteristicMap);
+    NimBLERemoteCharacteristic*                 getCharacteristic(const char* uuid);       // Get the specified characteristic reference.
+    NimBLERemoteCharacteristic*                 getCharacteristic(const NimBLEUUID &uuid); // Get the specified characteristic reference.
+    std::vector<NimBLERemoteCharacteristic*>*   getCharacteristics();
 
     NimBLEClient*            getClient(void);                                           // Get a reference to the client associated with this service.
     uint16_t                 getHandle();                                               // Get the handle of this service.
@@ -68,7 +66,6 @@ private:
 
     uint16_t            getStartHandle();                // Get the start handle for this service.
     uint16_t            getEndHandle();                  // Get the end handle for this service.
-    void                releaseSemaphores();
     void                removeCharacteristics();
 
     // Properties
@@ -78,10 +75,10 @@ private:
 
     bool                m_haveCharacteristics; // Have we previously obtained the characteristics.
     NimBLEClient*       m_pClient;
-    FreeRTOS::Semaphore m_semaphoreGetCharEvt = FreeRTOS::Semaphore("GetCharEvt");
     NimBLEUUID          m_uuid;             // The UUID of this service.
     uint16_t            m_startHandle;      // The starting handle of this service.
     uint16_t            m_endHandle;        // The ending handle of this service.
+    NimBLESemaphore*    m_pSemaphore;
 }; // BLERemoteService
 
 #endif // #if defined( CONFIG_BT_NIMBLE_ROLE_CENTRAL)

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -248,7 +248,8 @@ bool NimBLEScan::start(uint32_t duration, void (*scanCompleteCB)(NimBLEScanResul
     }
 
     m_stopped = false;
-    m_semaphoreScanEnd.take("start");
+
+    m_semaphoreScanEnd.take();
 
     // Save the callback to be invoked when the scan completes.
     m_scanCompleteCB = scanCompleteCB;
@@ -298,7 +299,7 @@ bool NimBLEScan::start(uint32_t duration, void (*scanCompleteCB)(NimBLEScanResul
  */
 NimBLEScanResults NimBLEScan::start(uint32_t duration, bool is_continue) {
     if(start(duration, nullptr, is_continue)) {
-        m_semaphoreScanEnd.wait("start");   // Wait for the semaphore to release.
+        m_semaphoreScanEnd.wait();   // Wait for the semaphore to release.
     }
     return m_scanResults;
 } // start

--- a/src/NimBLEScan.h
+++ b/src/NimBLEScan.h
@@ -20,7 +20,7 @@
 #if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)
 
 #include "NimBLEAdvertisedDevice.h"
-#include "FreeRTOS.h"
+#include "NimBLESemaphore.h"
 
 #include "host/ble_gap.h"
 
@@ -83,7 +83,7 @@ private:
     bool                                m_stopped;
     bool                                m_wantDuplicates;
     NimBLEScanResults                   m_scanResults;
-    FreeRTOS::Semaphore                 m_semaphoreScanEnd = FreeRTOS::Semaphore("ScanEnd");
+    NimBLESemaphore                     m_semaphoreScanEnd = NimBLESemaphore("ScanEnd");
     uint32_t                            m_duration;
 };
 

--- a/src/NimBLESemaphore.cpp
+++ b/src/NimBLESemaphore.cpp
@@ -1,0 +1,161 @@
+/*
+ * NimBLESemaphore.cpp
+ *
+ *  Created: on May 7 2020
+ *      Author H2zero
+ * 
+ * Originally:
+ * FreeRTOS.cpp
+ *
+ *  Created on: Feb 24, 2017
+ *      Author: kolban
+ */
+#include "sdkconfig.h"
+#include "NimBLESemaphore.h"
+#include "NimBLELog.h"
+
+static const char* LOG_TAG = "NimBLESemaphore";
+
+
+/**
+ * @brief Wait for a semaphore to be released by trying to take it and
+ * then releasing it again.
+ * @param [in] owner A debug tag.
+ * @return The value associated with the semaphore.
+ */
+uint32_t NimBLESemaphore::wait() {
+    NIMBLE_LOGD(LOG_TAG, ">> wait: Semaphore waiting: %s", toString().c_str());
+
+    xSemaphoreTake(m_semaphore, portMAX_DELAY);
+
+    xSemaphoreGive(m_semaphore);
+
+    NIMBLE_LOGD(LOG_TAG, "<< wait: Semaphore released: %s", toString().c_str());
+    return m_value;
+} // wait
+
+
+/**
+ * @brief Wait for a semaphore to be released in a given period of time by trying to take it and
+ * then releasing it again. The value associated with the semaphore can be taken by value() call after return
+ * @param [in] owner A debug tag.
+ * @param [in] timeoutMs timeout to wait in ms.
+ * @return True if we took the semaphore within timeframe.
+ */
+bool NimBLESemaphore::timedWait(uint32_t timeoutMs) {
+	NIMBLE_LOGD(LOG_TAG, ">> wait: Semaphore waiting: %s", toString().c_str());
+
+	auto ret = xSemaphoreTake(m_semaphore, timeoutMs);
+
+    xSemaphoreGive(m_semaphore);
+
+	NIMBLE_LOGD(LOG_TAG, "<< wait: Semaphore %s released: %d", toString().c_str(), ret);
+	return ret;
+} // timedWait
+
+
+NimBLESemaphore::NimBLESemaphore(const char *name) {
+    m_semaphore = xSemaphoreCreateBinary();
+    xSemaphoreGive(m_semaphore);
+    m_name      = name;
+    m_owner     = "";
+    m_value     = 0;
+}
+
+NimBLESemaphore::NimBLESemaphore() {
+    m_semaphore = xSemaphoreCreateBinary();
+    xSemaphoreGive(m_semaphore);
+    m_owner     = "";
+    m_value     = 0;
+}
+
+
+NimBLESemaphore::~NimBLESemaphore() {
+    vSemaphoreDelete(m_semaphore);
+}
+
+
+/**
+ * @brief Give a semaphore.
+ * The Semaphore is given.
+ */
+void NimBLESemaphore::give() {
+    NIMBLE_LOGD(LOG_TAG, "Semaphore giving: %s", toString().c_str());
+    xSemaphoreGive(m_semaphore);
+} // Semaphore::give
+
+
+/**
+ * @brief Give a semaphore.
+ * The Semaphore is given with an associated value.
+ * @param [in] value The value to associate with the semaphore.
+ */
+void NimBLESemaphore::give(uint32_t value) {
+    m_value = value;
+    give();
+} // give
+
+
+/**
+ * @brief Give a semaphore from an ISR.
+ */
+void NimBLESemaphore::giveFromISR() {
+    BaseType_t higherPriorityTaskWoken;
+    xSemaphoreGiveFromISR(m_semaphore, &higherPriorityTaskWoken);
+} // giveFromISR
+
+
+bool NimBLESemaphore::take() {
+    return take("");
+}
+/**
+ * @brief Take a semaphore.
+ * Take a semaphore and wait indefinitely.
+ * @param [in] owner The new owner (for debugging)
+ * @return True if we took the semaphore.
+ */
+bool NimBLESemaphore::take(const char* owner) {
+    m_owner = owner;
+    NIMBLE_LOGD(LOG_TAG, "Semaphore taking: %s", toString().c_str());
+    bool rc = xSemaphoreTake(m_semaphore, portMAX_DELAY) == pdTRUE;
+    if (rc) {
+        NIMBLE_LOGD(LOG_TAG, "Semaphore taken:  %s", toString().c_str());
+    } else {
+        NIMBLE_LOGE(LOG_TAG, "Semaphore NOT taken:  %s", toString().c_str());
+    }
+    return rc;
+} // Semaphore::take
+
+
+/**
+ * @brief Take a semaphore.
+ * Take a semaphore but return if we haven't obtained it in the given period of milliseconds.
+ * @param [in] timeoutMs Timeout in milliseconds.
+ * @param [in] owner The new owner (for debugging)
+ * @return True if we took the semaphore.
+ */
+bool NimBLESemaphore::take(uint32_t timeoutMs) {
+    NIMBLE_LOGD(LOG_TAG, "Semaphore taking: %s", toString().c_str());
+    bool rc = xSemaphoreTake(m_semaphore, timeoutMs / portTICK_PERIOD_MS) == pdTRUE;
+    if (rc) {
+        NIMBLE_LOGD(LOG_TAG, "Semaphore taken:  %s", toString().c_str());
+    } else {
+        NIMBLE_LOGE(LOG_TAG, "Semaphore NOT taken:  %s", toString().c_str());
+    }
+    return rc;
+} // Semaphore::take
+
+
+/**
+ * @brief Create a string representation of the semaphore.
+ * @return A string representation of the semaphore.
+ */
+std::string NimBLESemaphore::toString() {
+    char hex[14];
+    std::string res = "owner: ";
+    res += m_owner;
+    snprintf(hex, sizeof(hex), " (0x%08x)", (uint32_t)m_semaphore);
+    res += hex;
+    return res;
+} // toString
+

--- a/src/NimBLESemaphore.h
+++ b/src/NimBLESemaphore.h
@@ -1,0 +1,69 @@
+/*
+ * NimBLESemaphore.h
+ *
+ *  Created: on May 7 2020
+ *      Author H2zero
+ * 
+ * Originally:
+ * FreeRTOS.h
+ *
+ *  Created on: Feb 24, 2017
+ *      Author: kolban
+ */
+
+#ifndef MAIN_NIMBLE_SEMAPHORE_H_
+#define MAIN_NIMBLE_SEMAPHORE_H_
+
+#include <freertos/FreeRTOS.h>   // Include the base FreeRTOS definitions.
+#include <freertos/semphr.h>     // Include the semaphore definitions.
+
+#include <string>
+
+#define NIMBLE_SEMAPHORE_TAKE(pSemaphore, owner) \
+    if(pSemaphore == nullptr) { \
+        pSemaphore = new NimBLESemaphore(); \
+    } \
+    pSemaphore->take(owner);
+    
+#define NIMBLE_SEMAPHORE_GIVE(pSemaphore, value) \
+    if(pSemaphore != nullptr) { \
+        pSemaphore->give(value); \
+    }
+    
+#define NIMBLE_SEMAPHORE_WAIT(pSemaphore) \
+    pSemaphore->wait();
+    
+#define NIMBLE_SEMAPHORE_DELETE(pSemaphore) \
+    if(pSemaphore != nullptr) { \
+        pSemaphore->give(); \
+        delete(pSemaphore); \
+        pSemaphore = nullptr; \
+    }
+
+/**
+ * @brief Interface to %FreeRTOS functions.
+ */
+class NimBLESemaphore {
+public:
+    NimBLESemaphore(const char *name);
+    NimBLESemaphore();
+    ~NimBLESemaphore();
+    void        give();
+    void        give(uint32_t value);
+    void        giveFromISR();
+    bool        take();
+    bool        take(const char* owner);
+    bool        take(uint32_t timeoutMs);
+    std::string toString();
+    bool		timedWait(uint32_t timeoutMs = portMAX_DELAY);
+    uint32_t    wait();
+    uint32_t	value(){ return m_value; };
+
+private:
+    SemaphoreHandle_t m_semaphore;
+    const char        *m_name;
+    const char        *m_owner;
+    uint32_t          m_value;
+};
+
+#endif /* MAIN_NIMBLE_SEMAPHORE_H_ */

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -25,7 +25,6 @@
 #include "NimBLEAdvertising.h"
 #include "NimBLEService.h"
 #include "NimBLESecurity.h"
-#include "FreeRTOS.h"
 
 #include <map>
 

--- a/src/NimBLEService.h
+++ b/src/NimBLEService.h
@@ -23,8 +23,6 @@
 #include "NimBLECharacteristic.h"
 #include "NimBLEServer.h"
 #include "NimBLEUUID.h"
-#include "FreeRTOS.h"
-
 
 class NimBLEServer;
 class NimBLECharacteristic;


### PR DESCRIPTION
This introduces dynamic creation of the semaphores used internally by the library, most noticeably in the client code (server/scan to be done). The reason for this change is each semaphore used in each attribute that uses them consumes ~180 bytes of memory. 

On the client especially, this effect is dramatic when considering there are 2 semaphores per remote service, 3 per remote characteristic and 2 per remote descriptor. If the remote device has 1 service with 1 characteristic and 1 descriptor, when we connect and obtain the database it will use ~1260 bytes of heap memory before beginning any other operations. 

This PR will remove that and create the semaphores on an as required basis using new macros to help implement this procedure. Using this method has reduced heap use in my testing by ~700% per connection, depending on the number of attributes on the remote device.

This is not without a cost however, it requires careful and strict adherence to properly creating and making sure the semaphores are deleted when no longer needed. In other words increased maintenance and increased risk of memory leaks and bugs. 

So far I have been able to run this iteration for days with 3 threads accessing the semaphore protected resources with potentially conflicting timings in both debug and release configuration without issue.

I believe this to be overwhelmingly worth the cost, @Jeroen88 has seen a ~27k heap use reduction connecting to a peripheral with 72 attributes, that is incredible and worth the effort IMHO.

If you can find a way to break this please comment, so far so good for me!