### PR TITLE
Add iterators

### DIFF
--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -349,6 +349,24 @@ int NimBLEClient::getRssi() {
 
 
 /**
+ * @brief Get iterator to the beginning of the vector of remote service pointers.
+ * @return An iterator to the beginning of the vector of remote service pointers.
+ */
+std::vector<NimBLERemoteService*>::iterator NimBLEClient::begin() {
+    return m_servicesVector.begin();
+}
+
+
+/**
+ * @brief Get iterator to the end of the vector of remote service pointers.
+ * @return An iterator to the end of the vector of remote service pointers.
+ */
+std::vector<NimBLERemoteService*>::iterator NimBLEClient::end() {
+    return m_servicesVector.end();
+}
+
+
+/**
  * @brief Get the service BLE Remote Service instance corresponding to the uuid.
  * @param [in] uuid The UUID of the service being sought.
  * @return A reference to the Service or nullptr if don't know about it.

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -36,28 +36,30 @@ class NimBLEAdvertisedDevice;
  */
 class NimBLEClient {
 public:
-    bool                                       connect(NimBLEAdvertisedDevice* device, bool refreshServices = true);
-    bool                                       connect(const NimBLEAddress &address, uint8_t type = BLE_ADDR_PUBLIC, bool refreshServices = true);   // Connect to the remote BLE Server
-    int                                        disconnect(uint8_t reason = BLE_ERR_REM_USER_CONN_TERM);                  // Disconnect from the remote BLE Server
-    NimBLEAddress                              getPeerAddress();              // Get the address of the remote BLE Server
-    int                                        getRssi();                     // Get the RSSI of the remote BLE Server
+    bool                                        connect(NimBLEAdvertisedDevice* device, bool refreshServices = true);
+    bool                                        connect(const NimBLEAddress &address, uint8_t type = BLE_ADDR_PUBLIC, bool refreshServices = true);   // Connect to the remote BLE Server
+    int                                         disconnect(uint8_t reason = BLE_ERR_REM_USER_CONN_TERM);                  // Disconnect from the remote BLE Server
+    NimBLEAddress                               getPeerAddress();              // Get the address of the remote BLE Server
+    int                                         getRssi();                     // Get the RSSI of the remote BLE Server
 
-    std::vector<NimBLERemoteService*>*         getServices();                 // Get a vector of the services offered by the remote BLE Server
-    NimBLERemoteService*                       getService(const char* uuid);  // Get a reference to a specified service offered by the remote BLE server.
-    NimBLERemoteService*                       getService(const NimBLEUUID &uuid);   // Get a reference to a specified service offered by the remote BLE server.
-    std::string                                getValue(const NimBLEUUID &serviceUUID, const NimBLEUUID &characteristicUUID);   // Get the value of a given characteristic at a given service.
-    bool                                       setValue(const NimBLEUUID &serviceUUID, const NimBLEUUID &characteristicUUID, const std::string &value);   // Set the value of a given characteristic at a given service.
-    bool                                       isConnected();                 // Return true if we are connected.
-    void                                       setClientCallbacks(NimBLEClientCallbacks *pClientCallbacks, bool deleteCallbacks = true);
-    std::string                                toString();                    // Return a string representation of this client.
-    uint16_t                                   getConnId();
-    uint16_t                                   getMTU();
-    bool                                       secureConnection();
-    void                                       setConnectTimeout(uint8_t timeout);
-    void                                       setConnectionParams(uint16_t minInterval, uint16_t maxInterval,
+    std::vector<NimBLERemoteService*>*          getServices();                 // Get a vector of the services offered by the remote BLE Server
+    std::vector<NimBLERemoteService*>::iterator begin();
+    std::vector<NimBLERemoteService*>::iterator end();
+    NimBLERemoteService*                        getService(const char* uuid);  // Get a reference to a specified service offered by the remote BLE server.
+    NimBLERemoteService*                        getService(const NimBLEUUID &uuid);   // Get a reference to a specified service offered by the remote BLE server.
+    std::string                                 getValue(const NimBLEUUID &serviceUUID, const NimBLEUUID &characteristicUUID);   // Get the value of a given characteristic at a given service.
+    bool                                        setValue(const NimBLEUUID &serviceUUID, const NimBLEUUID &characteristicUUID, const std::string &value);   // Set the value of a given characteristic at a given service.
+    bool                                        isConnected();                 // Return true if we are connected.
+    void                                        setClientCallbacks(NimBLEClientCallbacks *pClientCallbacks, bool deleteCallbacks = true);
+    std::string                                 toString();                    // Return a string representation of this client.
+    uint16_t                                    getConnId();
+    uint16_t                                    getMTU();
+    bool                                        secureConnection();
+    void                                        setConnectTimeout(uint8_t timeout);
+    void                                        setConnectionParams(uint16_t minInterval, uint16_t maxInterval,
                                                             uint16_t latency, uint16_t timeout,
                                                             uint16_t scanInterval=16, uint16_t scanWindow=16); // NimBLE default scan settings
-    void                                       updateConnParams(uint16_t minInterval, uint16_t maxInterval,
+    void                                        updateConnParams(uint16_t minInterval, uint16_t maxInterval,
                                                             uint16_t latency, uint16_t timeout);
 
 

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -241,6 +241,24 @@ uint16_t NimBLERemoteCharacteristic::getDefHandle() {
 
 
 /**
+ * @brief Get iterator to the beginning of the vector of remote descriptor pointers.
+ * @return An iterator to the beginning of the vector of remote descriptor pointers.
+ */
+std::vector<NimBLERemoteDescriptor*>::iterator NimBLERemoteCharacteristic::begin() {
+    return m_descriptorVector.begin();
+}
+
+
+/**
+ * @brief Get iterator to the end of the vector of remote descriptor pointers.
+ * @return An iterator to the end of the vector of remote descriptor pointers.
+ */
+std::vector<NimBLERemoteDescriptor*>::iterator NimBLERemoteCharacteristic::end() {
+    return m_descriptorVector.end();
+}
+
+
+/**
  * @brief Get the descriptor instance with the given UUID that belongs to this characteristic.
  * @param [in] uuid The UUID of the descriptor to find.
  * @return The Remote descriptor (if present) or null if not present.

--- a/src/NimBLERemoteCharacteristic.h
+++ b/src/NimBLERemoteCharacteristic.h
@@ -42,29 +42,31 @@ public:
     ~NimBLERemoteCharacteristic();
 
     // Public member functions
-    bool        canBroadcast();
-    bool        canIndicate();
-    bool        canNotify();
-    bool        canRead();
-    bool        canWrite();
-    bool        canWriteNoResponse();
-    NimBLERemoteDescriptor* getDescriptor(const NimBLEUUID &uuid);
-    std::vector<NimBLERemoteDescriptor*>* getDescriptors();
-    uint16_t    getHandle();
-    uint16_t    getDefHandle();
-    NimBLEUUID  getUUID();
-    std::string readValue();
-    uint8_t     readUInt8();
-    uint16_t    readUInt16();
-    uint32_t    readUInt32();
-    bool        registerForNotify(notify_callback _callback, bool notifications = true, bool response = true);
-    bool        writeValue(const uint8_t* data, size_t length, bool response = false);
-    bool        writeValue(const std::string &newValue, bool response = false);
-    bool        writeValue(uint8_t newValue, bool response = false);
-    std::string toString();
-    uint8_t*    readRawData();
-    size_t      getDataLength();
-    NimBLERemoteService* getRemoteService();
+    bool                                           canBroadcast();
+    bool                                           canIndicate();
+    bool                                           canNotify();
+    bool                                           canRead();
+    bool                                           canWrite();
+    bool                                           canWriteNoResponse();
+    std::vector<NimBLERemoteDescriptor*>::iterator begin();
+    std::vector<NimBLERemoteDescriptor*>::iterator end();
+    NimBLERemoteDescriptor*                        getDescriptor(const NimBLEUUID &uuid);
+    std::vector<NimBLERemoteDescriptor*>*          getDescriptors();
+    uint16_t                                       getHandle();
+    uint16_t                                       getDefHandle();
+    NimBLEUUID                                     getUUID();
+    std::string                                    readValue();
+    uint8_t                                        readUInt8();
+    uint16_t                                       readUInt16();
+    uint32_t                                       readUInt32();
+    bool                                           registerForNotify(notify_callback _callback, bool notifications = true, bool response = true);
+    bool                                           writeValue(const uint8_t* data, size_t length, bool response = false);
+    bool                                           writeValue(const std::string &newValue, bool response = false);
+    bool                                           writeValue(uint8_t newValue, bool response = false);
+    std::string                                    toString();
+    uint8_t*                                       readRawData();
+    size_t                                         getDataLength();
+    NimBLERemoteService*                           getRemoteService();
 
 private:
 

--- a/src/NimBLERemoteService.cpp
+++ b/src/NimBLERemoteService.cpp
@@ -65,6 +65,24 @@ NimBLERemoteService::~NimBLERemoteService() {
 
 
 /**
+ * @brief Get iterator to the beginning of the vector of remote characteristic pointers.
+ * @return An iterator to the beginning of the vector of remote characteristic pointers.
+ */
+std::vector<NimBLERemoteCharacteristic*>::iterator NimBLERemoteService::begin() {
+    return m_characteristicVector.begin();
+}
+
+
+/**
+ * @brief Get iterator to the end of the vector of remote characteristic pointers.
+ * @return An iterator to the end of the vector of remote characteristic pointers.
+ */
+std::vector<NimBLERemoteCharacteristic*>::iterator NimBLERemoteService::end() {
+    return m_characteristicVector.end();
+}
+
+
+/**
  * @brief Get the remote characteristic object for the characteristic UUID.
  * @param [in] uuid Remote characteristic uuid.
  * @return Reference to the remote characteristic object.

--- a/src/NimBLERemoteService.h
+++ b/src/NimBLERemoteService.h
@@ -39,18 +39,20 @@ public:
     virtual ~NimBLERemoteService();
 
     // Public methods
-    NimBLERemoteCharacteristic* getCharacteristic(const char* uuid);      // Get the specified characteristic reference.
-    NimBLERemoteCharacteristic* getCharacteristic(const NimBLEUUID &uuid);       // Get the specified characteristic reference.
+    std::vector<NimBLERemoteCharacteristic*>::iterator begin();
+    std::vector<NimBLERemoteCharacteristic*>::iterator end();
+    NimBLERemoteCharacteristic*               getCharacteristic(const char* uuid);            // Get the specified characteristic reference.
+    NimBLERemoteCharacteristic*               getCharacteristic(const NimBLEUUID &uuid);      // Get the specified characteristic reference.
 //  BLERemoteCharacteristic* getCharacteristic(uint16_t uuid);      // Get the specified characteristic reference.
     std::vector<NimBLERemoteCharacteristic*>* getCharacteristics();
 //  void getCharacteristics(std::map<uint16_t, BLERemoteCharacteristic*>* pCharacteristicMap);
 
-    NimBLEClient*            getClient(void);                                           // Get a reference to the client associated with this service.
-    uint16_t                 getHandle();                                               // Get the handle of this service.
-    NimBLEUUID               getUUID(void);                                             // Get the UUID of this service.
-    std::string              getValue(const NimBLEUUID &characteristicUuid);                      // Get the value of a characteristic.
-    bool                     setValue(const NimBLEUUID &characteristicUuid, const std::string &value);   // Set the value of a characteristic.
-    std::string              toString(void);
+    NimBLEClient*                             getClient(void);                                // Get a reference to the client associated with this service.
+    uint16_t                                  getHandle();                                    // Get the handle of this service.
+    NimBLEUUID                                getUUID(void);                                  // Get the UUID of this service.
+    std::string                               getValue(const NimBLEUUID &characteristicUuid); // Get the value of a characteristic.
+    bool                                      setValue(const NimBLEUUID &characteristicUuid, const std::string &value); // Set the value of a characteristic.
+    std::string                               toString(void);
 
 private:
     // Private constructor ... never meant to be created by a user application.

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -405,6 +405,24 @@ NimBLEAdvertisedDevice NimBLEScanResults::getDevice(uint32_t i) {
 
 
 /**
+ * @brief Get iterator to the beginning of the vector of advertised device pointers.
+ * @return An iterator to the beginning of the vector of advertised device pointers.
+ */
+std::vector<NimBLEAdvertisedDevice*>::iterator NimBLEScanResults::begin() {
+    return m_advertisedDevicesVector.begin();
+}
+
+
+/**
+ * @brief Get iterator to the end of the vector of advertised device pointers.
+ * @return An iterator to the end of the vector of advertised device pointers.
+ */
+std::vector<NimBLEAdvertisedDevice*>::iterator NimBLEScanResults::end() {
+    return m_advertisedDevicesVector.end();
+}
+
+
+/**
  * @brief Return a pointer to the specified device at the given address.
  * If the address is not found a nullptr is returned.
  * @param [in] address The address of the device.

--- a/src/NimBLEScan.h
+++ b/src/NimBLEScan.h
@@ -41,10 +41,12 @@ class NimBLEAddress;
  */
 class NimBLEScanResults {
 public:
-    void                   dump();
-    int                    getCount();
-    NimBLEAdvertisedDevice getDevice(uint32_t i);
-    NimBLEAdvertisedDevice *getDevice(const NimBLEAddress &address);
+    void                                           dump();
+    int                                            getCount();
+    NimBLEAdvertisedDevice                         getDevice(uint32_t i);
+    std::vector<NimBLEAdvertisedDevice*>::iterator begin();
+    std::vector<NimBLEAdvertisedDevice*>::iterator end();
+    NimBLEAdvertisedDevice                         *getDevice(const NimBLEAddress &address);
 
 private:
     friend NimBLEScan;


### PR DESCRIPTION
Add iterators for `NimBLEScan`: `NimBLEadvertisedDevice`, `NimBLEClient`: `NimBLERemoteService`, `NimBLERemoteService`: `NimBLERemoteCharacteristic` and `NimBLERemoteCharacteristic`: `NimBLERemoteDescriptor`

This is handy e.g. for showing every address of the advertised devices from a scan. To do so, first get a new scan and next:

```
for(auto pAdvertisedDevice: pBLEScan->getResults()) {
  Serial.printf("Address is %s\n", std::string(pAdvertisedDevice->getAddress()).c_str());
}
```
Of course any other property of the advertised device can be shown (or looked up, if that is your use case)

Also this is handy e.g. for showing every UUID in a peripheral. To do so, first connect to a peripheral and next:

```
for(auto pService: *pClient) {
  Serial.printf("Service UUID is %s\n", std::string(pService->getUUID()).c_str());
  for(auto pCharacteristic: *pService) {
    Serial.printf("Characteristic UUID is %s\n", std::string(pCharacteristic->getUUID()).c_str());
    for(auto pDescriptor: *pCharacteristic) {
      Serial.printf("Descriptor UUID is %s\n", std::string(pDescriptor->getUUID()).c_str());
    }
  }
}
```
Again of course any other property can be shown, or looked up.
