### PR TITLE
Remove automatic discovery in NimBLEClient::connect().

### DIFF
--- a/API_DIFFERENCES.md
+++ b/API_DIFFERENCES.md
@@ -122,6 +122,35 @@ Has been removed from the API as it is no longer maintained in the library.
 
 The last two above changes reduce the heap usage significantly with minimal application code adjustments.   
 
+**NEW** on May 23, 2020
+> ```
+> NimBLEClient::getServices(bool refresh = false)   
+> NimBLERemoteService::getCharacteristics(bool refresh = false)   
+> NimBLERemoteCharacteristic::getDecriptors(bool refresh = false)
+>```
+> These methods now take an optional (bool) parameter.   
+If true it will clear the respective vector and retrieve all the respective attributes from the peripheral.   
+If false it will retrieve the attributes only if the vector is empty, otherwise the vector is returned   
+with the currently stored attributes.   
+
+> Removed the automatic discovery of all peripheral attributes as they consumed time and resources for data   
+the user may not be interested in.   
+   
+> Added `NimBLEClient::discoverAtrributes()` for the user to discover all the peripheral attributes   
+to replace the the former functionality.
+   
+   
+> ```
+>getService(NimBLEUUID)   
+>getCharacteristic(NimBLEUUID)   
+>getDescriptor(NimBLEUUID)
+>```
+>These methods will now check the respective vectors for the attribute object and, if not found, will retrieve (only)   
+the specified attribute from the peripheral.
+
+> These changes allow more control for the user to manage the resources used for the attributes.   
+
+
 #### Client Security:
 The client will automatically initiate security when the peripheral responds that it's required.    
 The default configuration will use "just-works" pairing with no bonding, if you wish to enable bonding see below.

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -413,6 +413,18 @@ std::vector<NimBLERemoteService*>* NimBLEClient::getServices(bool refresh) {
 
 
 /**
+ * @ Retrieves the full database of attributes that the peripheral device has available.
+ */
+void NimBLEClient::discoverAttributes() {
+    for(auto svc: *getServices(true)) {
+        for(auto chr: *svc->getCharacteristics(true)) {
+            chr->getDescriptors(true);
+        }
+    }
+}
+
+
+/**
  * @brief Ask the remote %BLE server for its services.
  * A %BLE Server exposes a set of services for its partners.  Here we ask the server for its set of
  * services and wait until we have received them all.
@@ -472,7 +484,8 @@ int NimBLEClient::serviceDiscoveredCB(
                 const struct ble_gatt_error *error,
                 const struct ble_gatt_svc *service, void *arg)
 {
-    NIMBLE_LOGD(LOG_TAG,"Service Discovered >> status: %d handle: %d", error->status, conn_handle);
+    NIMBLE_LOGD(LOG_TAG,"Service Discovered >> status: %d handle: %d",
+                        error->status, (error->status == 0) ? service->start_handle : -1);
 
     NimBLEClient *peer = (NimBLEClient*)arg;
     int rc=0;

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -53,8 +53,8 @@ NimBLEClient::NimBLEClient()
 {
     m_pClientCallbacks = &defaultCallbacks;
     m_conn_id          = BLE_HS_CONN_HANDLE_NONE;
-    m_haveServices     = false;
     m_isConnected      = false;
+    m_haveAllServices  = false;
     m_connectTimeout   = 30000;
 
     m_pConnParams.scan_itvl = 16;          // Scan interval in 0.625ms units (NimBLE Default)
@@ -94,8 +94,8 @@ void NimBLEClient::clearServices() {
         delete it;
     }
     m_servicesVector.clear();
+    m_haveAllServices = false;
 
-    m_haveServices = false;
     NIMBLE_LOGD(LOG_TAG, "<< clearServices");
 } // clearServices
 
@@ -181,18 +181,6 @@ bool NimBLEClient::connect(const NimBLEAddress &address, uint8_t type, bool refr
     if(refreshServices) {
         NIMBLE_LOGD(LOG_TAG, "Refreshing Services for: (%s)", address.toString().c_str());
         clearServices();
-    }
-
-    if (!m_haveServices) {
-        if (!retrieveServices()) {
-            // error getting services, make sure we disconnect and release any resources before returning
-            disconnect();
-            clearServices();
-            return false;
-        }
-        else{
-            NIMBLE_LOGD(LOG_TAG, "Found %d services", getServices()->size());
-        }
     }
 
     m_pClientCallbacks->onConnect(this);
@@ -384,14 +372,17 @@ NimBLERemoteService* NimBLEClient::getService(const char* uuid) {
 NimBLERemoteService* NimBLEClient::getService(const NimBLEUUID &uuid) {
     NIMBLE_LOGD(LOG_TAG, ">> getService: uuid: %s", uuid.toString().c_str());
 
-    if (!m_haveServices) {
-        return nullptr;
-    }
-
     for(auto &it: m_servicesVector) {
         if(it->getUUID() == uuid) {
             NIMBLE_LOGD(LOG_TAG, "<< getService: found the service with uuid: %s", uuid.toString().c_str());
             return it;
+        }
+    }
+
+    size_t prev_size = m_servicesVector.size();
+    if(retrieveServices(&uuid)) {
+        if(m_servicesVector.size() > prev_size) {
+            return m_servicesVector.back();
         }
     }
 
@@ -403,7 +394,20 @@ NimBLERemoteService* NimBLEClient::getService(const NimBLEUUID &uuid) {
 /**
  * @Get a pointer to the vector of found services.
  */
-std::vector<NimBLERemoteService*>* NimBLEClient::getServices() {
+std::vector<NimBLERemoteService*>* NimBLEClient::getServices(bool refresh) {
+    if(refresh) {
+        clearServices();
+    }
+
+    if(!m_haveAllServices && m_servicesVector.empty()) {
+        if (!retrieveServices()) {
+            NIMBLE_LOGE(LOG_TAG, "Error: Failed to get services");
+        }
+        else{
+            m_haveAllServices = true;
+            NIMBLE_LOGD(LOG_TAG, "Found %d services", m_servicesVector.size());
+        }
+    }
     return &m_servicesVector;
 }
 
@@ -415,7 +419,7 @@ std::vector<NimBLERemoteService*>* NimBLEClient::getServices() {
  * We then ask for the characteristics for each service found and their desciptors.
  * @return true on success otherwise false if an error occurred
  */
-bool NimBLEClient::retrieveServices() {
+bool NimBLEClient::retrieveServices(const NimBLEUUID *uuid_filter) {
 /**
  * Design
  * ------
@@ -424,6 +428,7 @@ bool NimBLEClient::retrieveServices() {
  */
 
     NIMBLE_LOGD(LOG_TAG, ">> retrieveServices");
+    int rc = 0;
 
     if(!m_isConnected){
         NIMBLE_LOGE(LOG_TAG, "Disconnected, could not retrieve services -aborting");
@@ -432,26 +437,21 @@ bool NimBLEClient::retrieveServices() {
 
     m_semaphoreSearchCmplEvt.take("retrieveServices");
 
-    int rc = ble_gattc_disc_all_svcs(m_conn_id, NimBLEClient::serviceDiscoveredCB, this);
+    if(uuid_filter == nullptr) {
+        rc = ble_gattc_disc_all_svcs(m_conn_id, NimBLEClient::serviceDiscoveredCB, this);
+    } else {
+        rc = ble_gattc_disc_svc_by_uuid(m_conn_id, &uuid_filter->getNative()->u,
+                                        NimBLEClient::serviceDiscoveredCB, this);
+    }
 
     if (rc != 0) {
         NIMBLE_LOGE(LOG_TAG, "ble_gattc_disc_all_svcs: rc=%d %s", rc, NimBLEUtils::returnCodeToString(rc));
-        m_haveServices = false;
         m_semaphoreSearchCmplEvt.give();
         return false;
     }
 
     // wait until we have all the services
-    // If sucessful, remember that we now have services.
-    m_haveServices = (m_semaphoreSearchCmplEvt.wait("retrieveServices") == 0);
-    if(m_haveServices){
-        for (auto &it: m_servicesVector) {
-            if(!m_isConnected || !it->retrieveCharacteristics()) {
-                NIMBLE_LOGE(LOG_TAG, "Disconnected, could not retrieve characteristics -aborting");
-                return false;
-            }
-        }
-
+    if(m_semaphoreSearchCmplEvt.wait("retrieveServices") == 0){
         NIMBLE_LOGD(LOG_TAG, "<< retrieveServices");
         return true;
     }
@@ -473,6 +473,7 @@ int NimBLEClient::serviceDiscoveredCB(
                 const struct ble_gatt_svc *service, void *arg)
 {
     NIMBLE_LOGD(LOG_TAG,"Service Discovered >> status: %d handle: %d", error->status, conn_handle);
+
     NimBLEClient *peer = (NimBLEClient*)arg;
     int rc=0;
 
@@ -679,8 +680,6 @@ uint16_t NimBLEClient::getMTU() {
                 return 0;
 
             NIMBLE_LOGD(LOG_TAG, "Notify Recieved for handle: %d",event->notify_rx.attr_handle);
-            if(!client->m_haveServices)
-                return 0;
 
             for(auto &it: client->m_servicesVector) {
                 // Dont waste cycles searching services without this handle in their range
@@ -688,19 +687,26 @@ uint16_t NimBLEClient::getMTU() {
                     continue;
                 }
 
-                auto cVector = it->getCharacteristics();
-                NIMBLE_LOGD(LOG_TAG, "checking service %s for handle: %d", it->getUUID().toString().c_str(),event->notify_rx.attr_handle);
+                auto cVector = &it->m_characteristicVector;
+                NIMBLE_LOGD(LOG_TAG, "checking service %s for handle: %d",
+                                      it->getUUID().toString().c_str(),
+                                      event->notify_rx.attr_handle);
+
                 auto characteristic = cVector->cbegin();
                 for(; characteristic != cVector->cend(); ++characteristic) {
-                    if((*characteristic)->m_handle == event->notify_rx.attr_handle) break;
+                    if((*characteristic)->m_handle == event->notify_rx.attr_handle)
+                        break;
                 }
 
                 if(characteristic != cVector->cend()) {
                     NIMBLE_LOGD(LOG_TAG, "Got Notification for characteristic %s", (*characteristic)->toString().c_str());
 
                     if ((*characteristic)->m_notifyCallback != nullptr) {
-                        NIMBLE_LOGD(LOG_TAG, "Invoking callback for notification on characteristic %s", (*characteristic)->toString().c_str());
-                        (*characteristic)->m_notifyCallback(*characteristic, event->notify_rx.om->om_data, event->notify_rx.om->om_len, !event->notify_rx.indication);
+                        NIMBLE_LOGD(LOG_TAG, "Invoking callback for notification on characteristic %s",
+                                             (*characteristic)->toString().c_str());
+                        (*characteristic)->m_notifyCallback(*characteristic, event->notify_rx.om->om_data,
+                                                            event->notify_rx.om->om_len,
+                                                            !event->notify_rx.indication);
                     }
 
                     break;

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -27,6 +27,11 @@
 #include <vector>
 #include <string>
 
+typedef struct {
+    const NimBLEUUID *uuid;
+    const void *attribute;
+} disc_filter_t;
+
 class NimBLERemoteService;
 class NimBLEClientCallbacks;
 class NimBLEAdvertisedDevice;
@@ -42,7 +47,7 @@ public:
     NimBLEAddress                               getPeerAddress();              // Get the address of the remote BLE Server
     int                                         getRssi();                     // Get the RSSI of the remote BLE Server
 
-    std::vector<NimBLERemoteService*>*          getServices();                 // Get a vector of the services offered by the remote BLE Server
+    std::vector<NimBLERemoteService*>*          getServices(bool refresh = false);                 // Get a vector of the services offered by the remote BLE Server
     std::vector<NimBLERemoteService*>::iterator begin();
     std::vector<NimBLERemoteService*>::iterator end();
     NimBLERemoteService*                        getService(const char* uuid);  // Get a reference to a specified service offered by the remote BLE server.
@@ -62,7 +67,6 @@ public:
     void                                        updateConnParams(uint16_t minInterval, uint16_t maxInterval,
                                                             uint16_t latency, uint16_t timeout);
 
-
 private:
     NimBLEClient();
     ~NimBLEClient();
@@ -72,12 +76,12 @@ private:
     static int          handleGapEvent(struct ble_gap_event *event, void *arg);
     static int          serviceDiscoveredCB(uint16_t conn_handle, const struct ble_gatt_error *error, const struct ble_gatt_svc *service, void *arg);
     void                clearServices();   // Clear any existing services.
-    bool                retrieveServices();  //Retrieve services from the server
+    bool                retrieveServices(const NimBLEUUID *uuid_filter = nullptr);
 //    void                onHostReset();
 
     NimBLEAddress    m_peerAddress = NimBLEAddress("");   // The BD address of the remote server.
     uint16_t         m_conn_id;
-    bool             m_haveServices = false;    // Have we previously obtain the set of services from the remote server.
+    bool             m_haveAllServices = false;    // Have we previously obtain the set of services from the remote server.
     bool             m_isConnected = false;     // Are we currently connected.
     bool             m_waitingToConnect =false;
     bool             m_deleteCallbacks = true;

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -66,6 +66,7 @@ public:
                                                             uint16_t scanInterval=16, uint16_t scanWindow=16); // NimBLE default scan settings
     void                                        updateConnParams(uint16_t minInterval, uint16_t maxInterval,
                                                             uint16_t latency, uint16_t timeout);
+    void                                       discoverAttributes();
 
 private:
     NimBLEClient();

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -42,55 +42,56 @@ class NimBLEAdvertisedDevice;
 class NimBLEClient {
 public:
     bool                                        connect(NimBLEAdvertisedDevice* device, bool refreshServices = true);
-    bool                                        connect(const NimBLEAddress &address, uint8_t type = BLE_ADDR_PUBLIC, bool refreshServices = true);   // Connect to the remote BLE Server
-    int                                         disconnect(uint8_t reason = BLE_ERR_REM_USER_CONN_TERM);                  // Disconnect from the remote BLE Server
-    NimBLEAddress                               getPeerAddress();              // Get the address of the remote BLE Server
-    int                                         getRssi();                     // Get the RSSI of the remote BLE Server
-
-    std::vector<NimBLERemoteService*>*          getServices(bool refresh = false);                 // Get a vector of the services offered by the remote BLE Server
+    bool                                        connect(const NimBLEAddress &address, uint8_t type = BLE_ADDR_PUBLIC,
+                                                        bool refreshServices = true);
+    int                                         disconnect(uint8_t reason = BLE_ERR_REM_USER_CONN_TERM);
+    NimBLEAddress                               getPeerAddress();
+    int                                         getRssi();
+    std::vector<NimBLERemoteService*>*          getServices(bool refresh = false);
     std::vector<NimBLERemoteService*>::iterator begin();
     std::vector<NimBLERemoteService*>::iterator end();
-    NimBLERemoteService*                        getService(const char* uuid);  // Get a reference to a specified service offered by the remote BLE server.
-    NimBLERemoteService*                        getService(const NimBLEUUID &uuid);   // Get a reference to a specified service offered by the remote BLE server.
-    std::string                                 getValue(const NimBLEUUID &serviceUUID, const NimBLEUUID &characteristicUUID);   // Get the value of a given characteristic at a given service.
-    bool                                        setValue(const NimBLEUUID &serviceUUID, const NimBLEUUID &characteristicUUID, const std::string &value);   // Set the value of a given characteristic at a given service.
-    bool                                        isConnected();                 // Return true if we are connected.
-    void                                        setClientCallbacks(NimBLEClientCallbacks *pClientCallbacks, bool deleteCallbacks = true);
-    std::string                                 toString();                    // Return a string representation of this client.
+    NimBLERemoteService*                        getService(const char* uuid);
+    NimBLERemoteService*                        getService(const NimBLEUUID &uuid);
+    std::string                                 getValue(const NimBLEUUID &serviceUUID, const NimBLEUUID &characteristicUUID);
+    bool                                        setValue(const NimBLEUUID &serviceUUID, const NimBLEUUID &characteristicUUID,
+                                                         const std::string &value);
+    bool                                        isConnected();
+    void                                        setClientCallbacks(NimBLEClientCallbacks *pClientCallbacks,
+                                                                   bool deleteCallbacks = true);
+    std::string                                 toString();
     uint16_t                                    getConnId();
     uint16_t                                    getMTU();
     bool                                        secureConnection();
     void                                        setConnectTimeout(uint8_t timeout);
     void                                        setConnectionParams(uint16_t minInterval, uint16_t maxInterval,
-                                                            uint16_t latency, uint16_t timeout,
-                                                            uint16_t scanInterval=16, uint16_t scanWindow=16); // NimBLE default scan settings
+                                                                    uint16_t latency, uint16_t timeout,
+                                                                    uint16_t scanInterval=16, uint16_t scanWindow=16);
     void                                        updateConnParams(uint16_t minInterval, uint16_t maxInterval,
-                                                            uint16_t latency, uint16_t timeout);
-    void                                       discoverAttributes();
+                                                                 uint16_t latency, uint16_t timeout);
+    void                                        discoverAttributes();
 
 private:
     NimBLEClient();
     ~NimBLEClient();
-    friend class NimBLEDevice;
-    friend class NimBLERemoteService;
 
-    static int          handleGapEvent(struct ble_gap_event *event, void *arg);
-    static int          serviceDiscoveredCB(uint16_t conn_handle, const struct ble_gatt_error *error, const struct ble_gatt_svc *service, void *arg);
-    void                clearServices();   // Clear any existing services.
-    bool                retrieveServices(const NimBLEUUID *uuid_filter = nullptr);
-//    void                onHostReset();
+    friend class            NimBLEDevice;
+    friend class            NimBLERemoteService;
 
-    NimBLEAddress    m_peerAddress = NimBLEAddress("");   // The BD address of the remote server.
-    uint16_t         m_conn_id;
-    bool             m_haveAllServices = false;    // Have we previously obtain the set of services from the remote server.
-    bool             m_isConnected = false;     // Are we currently connected.
-    bool             m_waitingToConnect =false;
-    bool             m_deleteCallbacks = true;
-    int32_t          m_connectTimeout;
-    //uint16_t         m_mtu = 23;
+    static int              handleGapEvent(struct ble_gap_event *event, void *arg);
+    static int              serviceDiscoveredCB(uint16_t conn_handle,
+                                                const struct ble_gatt_error *error,
+                                                const struct ble_gatt_svc *service,
+                                                void *arg);
+    void                    clearServices();
+    bool                    retrieveServices(const NimBLEUUID *uuid_filter = nullptr);
 
+    NimBLEAddress           m_peerAddress = NimBLEAddress("");
+    uint16_t                m_conn_id;
+    bool                    m_isConnected = false;
+    bool                    m_waitingToConnect =false;
+    bool                    m_deleteCallbacks = true;
+    int32_t                 m_connectTimeout;
     NimBLEClientCallbacks*  m_pClientCallbacks = nullptr;
-
     FreeRTOS::Semaphore     m_semaphoreOpenEvt       = FreeRTOS::Semaphore("OpenEvt");
     FreeRTOS::Semaphore     m_semaphoreSearchCmplEvt = FreeRTOS::Semaphore("SearchCmplEvt");
     FreeRTOS::Semaphore     m_semeaphoreSecEvt       = FreeRTOS::Semaphore("Security");

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -35,7 +35,9 @@ static const char* LOG_TAG = "NimBLERemoteCharacteristic";
  *      ble_uuid_any_t uuid;
  *  };
  */
- NimBLERemoteCharacteristic::NimBLERemoteCharacteristic(NimBLERemoteService *pRemoteService, const struct ble_gatt_chr *chr) {
+ NimBLERemoteCharacteristic::NimBLERemoteCharacteristic(NimBLERemoteService *pRemoteService,
+                                                        const struct ble_gatt_chr *chr)
+{
 
      switch (chr->uuid.u.type) {
         case BLE_UUID_TYPE_16:
@@ -58,7 +60,6 @@ static const char* LOG_TAG = "NimBLERemoteCharacteristic";
     m_notifyCallback     = nullptr;
     m_rawData            = nullptr;
     m_dataLen            = 0;
-    m_haveAllDescriptors = false;
  } // NimBLERemoteCharacteristic
 
 
@@ -199,6 +200,7 @@ int NimBLERemoteCharacteristic::descriptorDiscCB(uint16_t conn_handle,
     return rc;
 }
 
+
 /**
  * @brief Populate the descriptors (if any) for this characteristic.
  * @param [in] the end handle of the characteristic, or the service, whichever comes first.
@@ -234,62 +236,6 @@ bool NimBLERemoteCharacteristic::retrieveDescriptors(const NimBLEUUID *uuid_filt
 
 
 /**
- * @brief Retrieve the vector of descriptors.
- */
-std::vector<NimBLERemoteDescriptor*>* NimBLERemoteCharacteristic::getDescriptors(bool refresh) {
-    if(refresh) {
-        removeDescriptors();
-    }
-
-    if(!m_haveAllDescriptors && m_descriptorVector.empty()) {
-        if (!retrieveDescriptors()) {
-            NIMBLE_LOGE(LOG_TAG, "Error: Failed to get descriptors");
-        }
-        else{
-            m_haveAllDescriptors = true;
-            NIMBLE_LOGD(LOG_TAG, "Found %d descriptor(s)", m_descriptorVector.size());
-        }
-    }
-    return &m_descriptorVector;
-} // getDescriptors
-
-
-/**
- * @brief Get the handle for this characteristic.
- * @return The handle for this characteristic.
- */
-uint16_t NimBLERemoteCharacteristic::getHandle() {
-    return m_handle;
-} // getHandle
-
-/**
- * @brief Get the handle for this characteristics definition.
- * @return The handle for this characteristic definition.
- */
-uint16_t NimBLERemoteCharacteristic::getDefHandle() {
-    return m_defHandle;
-} // getDefHandle
-
-
-/**
- * @brief Get iterator to the beginning of the vector of remote descriptor pointers.
- * @return An iterator to the beginning of the vector of remote descriptor pointers.
- */
-std::vector<NimBLERemoteDescriptor*>::iterator NimBLERemoteCharacteristic::begin() {
-    return m_descriptorVector.begin();
-}
-
-
-/**
- * @brief Get iterator to the end of the vector of remote descriptor pointers.
- * @return An iterator to the end of the vector of remote descriptor pointers.
- */
-std::vector<NimBLERemoteDescriptor*>::iterator NimBLERemoteCharacteristic::end() {
-    return m_descriptorVector.end();
-}
-
-
-/**
  * @brief Get the descriptor instance with the given UUID that belongs to this characteristic.
  * @param [in] uuid The UUID of the descriptor to find.
  * @return The Remote descriptor (if present) or null if not present.
@@ -313,6 +259,67 @@ NimBLERemoteDescriptor* NimBLERemoteCharacteristic::getDescriptor(const NimBLEUU
     NIMBLE_LOGD(LOG_TAG, "<< getDescriptor: Not found");
     return nullptr;
 } // getDescriptor
+
+
+/**
+ * @Get a pointer to the vector of found descriptors.
+ * @param [in] bool value to indicate if the current vector should be cleared and
+ * subsequently all descriptors for this characteristic retrieved from the peripheral.
+ * If false the vector will be returned with the currently stored descriptors,
+ * if the vector is empty it will retrieve all descriptors for this characteristic
+ * from the peripheral.
+ * @return a pointer to the vector of descriptors for this characteristic.
+ */
+std::vector<NimBLERemoteDescriptor*>* NimBLERemoteCharacteristic::getDescriptors(bool refresh) {
+    if(refresh) {
+        removeDescriptors();
+    }
+
+    if(m_descriptorVector.empty()) {
+        if (!retrieveDescriptors()) {
+            NIMBLE_LOGE(LOG_TAG, "Error: Failed to get descriptors");
+        }
+        else{
+            NIMBLE_LOGI(LOG_TAG, "Found %d descriptor(s)", m_descriptorVector.size());
+        }
+    }
+    return &m_descriptorVector;
+} // getDescriptors
+
+
+/**
+ * @brief Get iterator to the beginning of the vector of remote descriptor pointers.
+ * @return An iterator to the beginning of the vector of remote descriptor pointers.
+ */
+std::vector<NimBLERemoteDescriptor*>::iterator NimBLERemoteCharacteristic::begin() {
+    return m_descriptorVector.begin();
+}
+
+
+/**
+ * @brief Get iterator to the end of the vector of remote descriptor pointers.
+ * @return An iterator to the end of the vector of remote descriptor pointers.
+ */
+std::vector<NimBLERemoteDescriptor*>::iterator NimBLERemoteCharacteristic::end() {
+    return m_descriptorVector.end();
+}
+
+
+/**
+ * @brief Get the handle for this characteristic.
+ * @return The handle for this characteristic.
+ */
+uint16_t NimBLERemoteCharacteristic::getHandle() {
+    return m_handle;
+} // getHandle
+
+/**
+ * @brief Get the handle for this characteristics definition.
+ * @return The handle for this characteristic definition.
+ */
+uint16_t NimBLERemoteCharacteristic::getDefHandle() {
+    return m_defHandle;
+} // getDefHandle
 
 
 /**
@@ -377,7 +384,8 @@ uint8_t NimBLERemoteCharacteristic::readUInt8() {
  * @return The value of the remote characteristic.
  */
 std::string NimBLERemoteCharacteristic::readValue() {
-    NIMBLE_LOGD(LOG_TAG, ">> readValue(): uuid: %s, handle: %d 0x%.2x", getUUID().toString().c_str(), getHandle(), getHandle());
+    NIMBLE_LOGD(LOG_TAG, ">> readValue(): uuid: %s, handle: %d 0x%.2x",
+                         getUUID().toString().c_str(), getHandle(), getHandle());
 
     int rc = 0;
     int retryCount = 1;
@@ -511,7 +519,6 @@ void NimBLERemoteCharacteristic::removeDescriptors() {
         delete it;
     }
     m_descriptorVector.clear();
-    m_haveAllDescriptors = false;
 } // removeCharacteristics
 
 

--- a/src/NimBLERemoteCharacteristic.h
+++ b/src/NimBLERemoteCharacteristic.h
@@ -51,7 +51,7 @@ public:
     std::vector<NimBLERemoteDescriptor*>::iterator begin();
     std::vector<NimBLERemoteDescriptor*>::iterator end();
     NimBLERemoteDescriptor*                        getDescriptor(const NimBLEUUID &uuid);
-    std::vector<NimBLERemoteDescriptor*>*          getDescriptors();
+    std::vector<NimBLERemoteDescriptor*>*          getDescriptors(bool refresh = false);
     uint16_t                                       getHandle();
     uint16_t                                       getDefHandle();
     NimBLEUUID                                     getUUID();
@@ -78,7 +78,7 @@ private:
 
     // Private member functions
     void              removeDescriptors();
-    bool              retrieveDescriptors(uint16_t endHdl);
+    bool              retrieveDescriptors(const NimBLEUUID *uuid_filter = nullptr);
     static int        onReadCB(uint16_t conn_handle, const struct ble_gatt_error *error, struct ble_gatt_attr *attr, void *arg);
     static int        onWriteCB(uint16_t conn_handle, const struct ble_gatt_error *error, struct ble_gatt_attr *attr, void *arg);
     void              releaseSemaphores();
@@ -99,6 +99,7 @@ private:
     uint8_t*                m_rawData;
     size_t                  m_dataLen;
     notify_callback         m_notifyCallback;
+    bool                    m_haveAllDescriptors;
 
     // We maintain a vector of descriptors owned by this characteristic.
     std::vector<NimBLERemoteDescriptor*> m_descriptorVector;

--- a/src/NimBLERemoteCharacteristic.h
+++ b/src/NimBLERemoteCharacteristic.h
@@ -20,19 +20,17 @@
 #include "nimconfig.h"
 #if defined( CONFIG_BT_NIMBLE_ROLE_CENTRAL)
 
-//#include "NimBLEUUID.h"
-//#include "FreeRTOS.h"
 #include "NimBLERemoteService.h"
 #include "NimBLERemoteDescriptor.h"
 
-//#include <string>
 #include <vector>
 
 class NimBLERemoteService;
 class NimBLERemoteDescriptor;
 
 
-typedef void (*notify_callback)(NimBLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify);
+typedef void (*notify_callback)(NimBLERemoteCharacteristic* pBLERemoteCharacteristic,
+                                uint8_t* pData, size_t length, bool isNotify);
 
 /**
  * @brief A model of a remote %BLE characteristic.
@@ -59,10 +57,16 @@ public:
     uint8_t                                        readUInt8();
     uint16_t                                       readUInt16();
     uint32_t                                       readUInt32();
-    bool                                           registerForNotify(notify_callback _callback, bool notifications = true, bool response = true);
-    bool                                           writeValue(const uint8_t* data, size_t length, bool response = false);
-    bool                                           writeValue(const std::string &newValue, bool response = false);
-    bool                                           writeValue(uint8_t newValue, bool response = false);
+    bool                                           registerForNotify(notify_callback _callback,
+                                                                     bool notifications = true,
+                                                                     bool response = true);
+    bool                                           writeValue(const uint8_t* data,
+                                                              size_t length,
+                                                              bool response = false);
+    bool                                           writeValue(const std::string &newValue,
+                                                              bool response = false);
+    bool                                           writeValue(uint8_t newValue,
+                                                              bool response = false);
     std::string                                    toString();
     uint8_t*                                       readRawData();
     size_t                                         getDataLength();
@@ -72,19 +76,21 @@ private:
 
     NimBLERemoteCharacteristic(NimBLERemoteService *pRemoteservice, const struct ble_gatt_chr *chr);
 
-    friend class NimBLEClient;
-    friend class NimBLERemoteService;
-    friend class NimBLERemoteDescriptor;
+    friend class      NimBLEClient;
+    friend class      NimBLERemoteService;
+    friend class      NimBLERemoteDescriptor;
 
     // Private member functions
     void              removeDescriptors();
     bool              retrieveDescriptors(const NimBLEUUID *uuid_filter = nullptr);
-    static int        onReadCB(uint16_t conn_handle, const struct ble_gatt_error *error, struct ble_gatt_attr *attr, void *arg);
-    static int        onWriteCB(uint16_t conn_handle, const struct ble_gatt_error *error, struct ble_gatt_attr *attr, void *arg);
+    static int        onReadCB(uint16_t conn_handle, const struct ble_gatt_error *error,
+                               struct ble_gatt_attr *attr, void *arg);
+    static int        onWriteCB(uint16_t conn_handle, const struct ble_gatt_error *error,
+                                struct ble_gatt_attr *attr, void *arg);
     void              releaseSemaphores();
     static int        descriptorDiscCB(uint16_t conn_handle, const struct ble_gatt_error *error,
-                                uint16_t chr_val_handle, const struct ble_gatt_dsc *dsc,
-                                void *arg);
+                                       uint16_t chr_val_handle, const struct ble_gatt_dsc *dsc,
+                                       void *arg);
 
     // Private properties
     NimBLEUUID              m_uuid;
@@ -99,11 +105,10 @@ private:
     uint8_t*                m_rawData;
     size_t                  m_dataLen;
     notify_callback         m_notifyCallback;
-    bool                    m_haveAllDescriptors;
 
     // We maintain a vector of descriptors owned by this characteristic.
     std::vector<NimBLERemoteDescriptor*> m_descriptorVector;
-}; // BLERemoteCharacteristic
+}; // NimBLERemoteCharacteristic
 
 #endif // #if defined( CONFIG_BT_NIMBLE_ROLE_CENTRAL)
 #endif /* CONFIG_BT_ENABLED */

--- a/src/NimBLERemoteDescriptor.cpp
+++ b/src/NimBLERemoteDescriptor.cpp
@@ -29,7 +29,7 @@ static const char* LOG_TAG = "NimBLERemoteDescriptor";
  * @param [in] Reference to the struct that contains the descriptor information.
  */
 NimBLERemoteDescriptor::NimBLERemoteDescriptor(NimBLERemoteCharacteristic* pRemoteCharacteristic,
-                                                const struct ble_gatt_dsc *dsc)
+                                               const struct ble_gatt_dsc *dsc)
 {
     switch (dsc->uuid.u.type) {
         case BLE_UUID_TYPE_16:

--- a/src/NimBLERemoteDescriptor.h
+++ b/src/NimBLERemoteDescriptor.h
@@ -28,30 +28,34 @@ class NimBLERemoteCharacteristic;
  */
 class NimBLERemoteDescriptor {
 public:
-    uint16_t    getHandle();
+    uint16_t                    getHandle();
     NimBLERemoteCharacteristic* getRemoteCharacteristic();
-    NimBLEUUID     getUUID();
-    std::string readValue(void);
-    uint8_t     readUInt8(void);
-    uint16_t    readUInt16(void);
-    uint32_t    readUInt32(void);
-    std::string toString(void);
-    bool        writeValue(const uint8_t* data, size_t length, bool response = false);
-    bool        writeValue(const std::string &newValue, bool response = false);
-    bool        writeValue(uint8_t newValue, bool response = false);
+    NimBLEUUID                  getUUID();
+    std::string                 readValue(void);
+    uint8_t                     readUInt8(void);
+    uint16_t                    readUInt16(void);
+    uint32_t                    readUInt32(void);
+    std::string                 toString(void);
+    bool                        writeValue(const uint8_t* data, size_t length, bool response = false);
+    bool                        writeValue(const std::string &newValue, bool response = false);
+    bool                        writeValue(uint8_t newValue, bool response = false);
 
 
 private:
-    friend class NimBLERemoteCharacteristic;
-    NimBLERemoteDescriptor(NimBLERemoteCharacteristic* pRemoteCharacteristic, const struct ble_gatt_dsc *dsc);
-    static int  onWriteCB(uint16_t conn_handle, const struct ble_gatt_error *error, struct ble_gatt_attr *attr, void *arg);
-    static int  onReadCB(uint16_t conn_handle, const struct ble_gatt_error *error, struct ble_gatt_attr *attr, void *arg);
-    void        releaseSemaphores();
+    friend class                NimBLERemoteCharacteristic;
 
-    uint16_t                    m_handle;                  // Server handle of this descriptor.
-    NimBLEUUID                  m_uuid;                    // UUID of this descriptor.
-    std::string                 m_value;                   // Last received value of the descriptor.
-    NimBLERemoteCharacteristic* m_pRemoteCharacteristic;   // Reference to the Remote characteristic of which this descriptor is associated.
+    NimBLERemoteDescriptor      (NimBLERemoteCharacteristic* pRemoteCharacteristic,
+                                const struct ble_gatt_dsc *dsc);
+    static int                  onWriteCB(uint16_t conn_handle, const struct ble_gatt_error *error,
+                                          struct ble_gatt_attr *attr, void *arg);
+    static int                  onReadCB(uint16_t conn_handle, const struct ble_gatt_error *error,
+                                         struct ble_gatt_attr *attr, void *arg);
+    void                        releaseSemaphores();
+
+    uint16_t                    m_handle;
+    NimBLEUUID                  m_uuid;
+    std::string                 m_value;
+    NimBLERemoteCharacteristic* m_pRemoteCharacteristic;
     FreeRTOS::Semaphore         m_semaphoreReadDescrEvt  = FreeRTOS::Semaphore("ReadDescrEvt");
     FreeRTOS::Semaphore         m_semaphoreDescWrite     = FreeRTOS::Semaphore("WriteDescEvt");
 

--- a/src/NimBLERemoteService.cpp
+++ b/src/NimBLERemoteService.cpp
@@ -31,7 +31,7 @@ static const char* LOG_TAG = "NimBLERemoteService";
  */
 NimBLERemoteService::NimBLERemoteService(NimBLEClient* pClient, const struct ble_gatt_svc* service) {
 
-    NIMBLE_LOGD(LOG_TAG, ">> BLERemoteService()");
+    NIMBLE_LOGD(LOG_TAG, ">> NimBLERemoteService()");
     m_pClient = pClient;
     switch (service->uuid.u.type) {
         case BLE_UUID_TYPE_16:
@@ -51,7 +51,7 @@ NimBLERemoteService::NimBLERemoteService(NimBLEClient* pClient, const struct ble
     m_endHandle = service->end_handle;
     m_haveAllCharacteristics = false;
 
-    NIMBLE_LOGD(LOG_TAG, "<< BLERemoteService()");
+    NIMBLE_LOGD(LOG_TAG, "<< NimBLERemoteService()");
 }
 
 
@@ -122,7 +122,8 @@ int NimBLERemoteService::characteristicDiscCB(uint16_t conn_handle,
                                 const struct ble_gatt_error *error,
                                 const struct ble_gatt_chr *chr, void *arg)
 {
-    NIMBLE_LOGD(LOG_TAG,"Characteristic Discovered >> status: %d handle: %d", error->status, conn_handle);
+    NIMBLE_LOGD(LOG_TAG,"Characteristic Discovered >> status: %d handle: %d",
+                        error->status, (error->status == 0) ? chr->val_handle : -1);
 
     NimBLERemoteService *service = (NimBLERemoteService*)arg;
     int rc=0;
@@ -220,11 +221,11 @@ std::vector<NimBLERemoteCharacteristic*>* NimBLERemoteService::getCharacteristic
 
     if(!m_haveAllCharacteristics && m_characteristicVector.empty()) {
         if (!retrieveCharacteristics()) {
-            NIMBLE_LOGE(LOG_TAG, "Error: Failed to get services");
+            NIMBLE_LOGE(LOG_TAG, "Error: Failed to get characteristics");
         }
         else{
             m_haveAllCharacteristics = true;
-            NIMBLE_LOGD(LOG_TAG, "Found %d services", m_characteristicVector.size());
+            NIMBLE_LOGD(LOG_TAG, "Found %d characteristics", m_characteristicVector.size());
         }
     }
     return &m_characteristicVector;

--- a/src/NimBLERemoteService.h
+++ b/src/NimBLERemoteService.h
@@ -44,7 +44,7 @@ public:
     NimBLERemoteCharacteristic*               getCharacteristic(const char* uuid);            // Get the specified characteristic reference.
     NimBLERemoteCharacteristic*               getCharacteristic(const NimBLEUUID &uuid);      // Get the specified characteristic reference.
 //  BLERemoteCharacteristic* getCharacteristic(uint16_t uuid);      // Get the specified characteristic reference.
-    std::vector<NimBLERemoteCharacteristic*>* getCharacteristics();
+    std::vector<NimBLERemoteCharacteristic*>* getCharacteristics(bool refresh = false);
 //  void getCharacteristics(std::map<uint16_t, BLERemoteCharacteristic*>* pCharacteristicMap);
 
     NimBLEClient*                             getClient(void);                                // Get a reference to the client associated with this service.
@@ -63,7 +63,7 @@ private:
     friend class NimBLERemoteCharacteristic;
 
     // Private methods
-    bool                retrieveCharacteristics(void);   // Retrieve the characteristics from the BLE Server.
+    bool                retrieveCharacteristics(const NimBLEUUID *uuid_filter = nullptr);   // Retrieve the characteristics from the BLE Server.
     static int          characteristicDiscCB(uint16_t conn_handle,
                                 const struct ble_gatt_error *error,
                                 const struct ble_gatt_chr *chr, void *arg);
@@ -78,7 +78,7 @@ private:
     // We maintain a vector of characteristics owned by this service.
     std::vector<NimBLERemoteCharacteristic*> m_characteristicVector;
 
-    bool                m_haveCharacteristics; // Have we previously obtained the characteristics.
+    bool                m_haveAllCharacteristics; // Have we previously obtained the characteristics.
     NimBLEClient*       m_pClient;
     FreeRTOS::Semaphore m_semaphoreGetCharEvt = FreeRTOS::Semaphore("GetCharEvt");
     NimBLEUUID          m_uuid;             // The UUID of this service.

--- a/src/NimBLERemoteService.h
+++ b/src/NimBLERemoteService.h
@@ -41,18 +41,16 @@ public:
     // Public methods
     std::vector<NimBLERemoteCharacteristic*>::iterator begin();
     std::vector<NimBLERemoteCharacteristic*>::iterator end();
-    NimBLERemoteCharacteristic*               getCharacteristic(const char* uuid);            // Get the specified characteristic reference.
-    NimBLERemoteCharacteristic*               getCharacteristic(const NimBLEUUID &uuid);      // Get the specified characteristic reference.
-//  BLERemoteCharacteristic* getCharacteristic(uint16_t uuid);      // Get the specified characteristic reference.
-    std::vector<NimBLERemoteCharacteristic*>* getCharacteristics(bool refresh = false);
-//  void getCharacteristics(std::map<uint16_t, BLERemoteCharacteristic*>* pCharacteristicMap);
-
-    NimBLEClient*                             getClient(void);                                // Get a reference to the client associated with this service.
-    uint16_t                                  getHandle();                                    // Get the handle of this service.
-    NimBLEUUID                                getUUID(void);                                  // Get the UUID of this service.
-    std::string                               getValue(const NimBLEUUID &characteristicUuid); // Get the value of a characteristic.
-    bool                                      setValue(const NimBLEUUID &characteristicUuid, const std::string &value); // Set the value of a characteristic.
+    NimBLERemoteCharacteristic*               getCharacteristic(const char* uuid);
+    NimBLERemoteCharacteristic*               getCharacteristic(const NimBLEUUID &uuid);
+    NimBLEClient*                             getClient(void);
+    uint16_t                                  getHandle();
+    NimBLEUUID                                getUUID(void);
+    std::string                               getValue(const NimBLEUUID &characteristicUuid);
+    bool                                      setValue(const NimBLEUUID &characteristicUuid,
+                                                       const std::string &value);
     std::string                               toString(void);
+    std::vector<NimBLERemoteCharacteristic*>* getCharacteristics(bool refresh = false);
 
 private:
     // Private constructor ... never meant to be created by a user application.
@@ -63,13 +61,14 @@ private:
     friend class NimBLERemoteCharacteristic;
 
     // Private methods
-    bool                retrieveCharacteristics(const NimBLEUUID *uuid_filter = nullptr);   // Retrieve the characteristics from the BLE Server.
+    bool                retrieveCharacteristics(const NimBLEUUID *uuid_filter = nullptr);
     static int          characteristicDiscCB(uint16_t conn_handle,
-                                const struct ble_gatt_error *error,
-                                const struct ble_gatt_chr *chr, void *arg);
+                                             const struct ble_gatt_error *error,
+                                             const struct ble_gatt_chr *chr,
+                                             void *arg);
 
-    uint16_t            getStartHandle();                // Get the start handle for this service.
-    uint16_t            getEndHandle();                  // Get the end handle for this service.
+    uint16_t            getStartHandle();
+    uint16_t            getEndHandle();
     void                releaseSemaphores();
     void                removeCharacteristics();
 
@@ -78,13 +77,12 @@ private:
     // We maintain a vector of characteristics owned by this service.
     std::vector<NimBLERemoteCharacteristic*> m_characteristicVector;
 
-    bool                m_haveAllCharacteristics; // Have we previously obtained the characteristics.
     NimBLEClient*       m_pClient;
     FreeRTOS::Semaphore m_semaphoreGetCharEvt = FreeRTOS::Semaphore("GetCharEvt");
-    NimBLEUUID          m_uuid;             // The UUID of this service.
-    uint16_t            m_startHandle;      // The starting handle of this service.
-    uint16_t            m_endHandle;        // The ending handle of this service.
-}; // BLERemoteService
+    NimBLEUUID          m_uuid;
+    uint16_t            m_startHandle;
+    uint16_t            m_endHandle;
+}; // NimBLERemoteService
 
 #endif // #if defined( CONFIG_BT_NIMBLE_ROLE_CENTRAL)
 #endif /* CONFIG_BT_ENABLED */


### PR DESCRIPTION
Instead of discovering the peripheral database on connection and consuming the associated resources this will give the user more control over the discovery operation.

* Adds `void NimBLEClient::discoverAtrributes()` for the user to discover all the peripheral attributes as a replacement for the former functionality.

* `getServices()`, `getCharacteristics()`, `getDescriptors()` now take an optional `bool` parameter (`default false`). If `true` it will clear the respective vector and retrieve all the respective attributes from the peripheral. If false it will retrieve the attributes only if the vector is empty, otherwise the vector is returned with the currently stored attributes.

* `getService(NimBLEUUID)`, `getCharacteristic(NimBLEUUID)`, `getDescriptor(NimBLEUUID)` will now  check the respective vectors for the attribute object and, if not found, will retrieve (only) the specified attribute from the peripheral.

User API functionality remains unchanged except for the added (optional) parameters stated above.