### PR TITLE
Adding access to the adv type of an advertised device

### DIFF
--- a/src/NimBLEAdvertisedDevice.cpp
+++ b/src/NimBLEAdvertisedDevice.cpp
@@ -63,6 +63,16 @@ NimBLEAddress NimBLEAdvertisedDevice::getAddress() {
 
 
 /**
+ * @brief Get the advertised type.
+ *
+ * @return The advertised type of the advertised device.
+ */
+uint8_t NimBLEAdvertisedDevice::getAdvType() {
+    return m_advType;
+} // getAddress
+
+
+/**
  * @brief Get the appearance.
  *
  * A %BLE device can declare its own appearance.  The appearance is how it would like to be shown to an end user

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -42,6 +42,7 @@ public:
     NimBLEAdvertisedDevice();
 
     NimBLEAddress   getAddress();
+    uint8_t         getAdvType();
     uint16_t        getAppearance();
     std::string     getManufacturerData();
     std::string     getName();


### PR DESCRIPTION
With this function the advertising type of an advertised device can be checked. According to `NimBLEUtils::advTypeToString()`:
- `BLE_HCI_ADV_TYPE_ADV_IND` (0): "Undirected - Connectable / Scannable"
- `BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_HD` (1): "Directed High Duty - Connectable"
- `BLE_HCI_ADV_TYPE_ADV_SCAN_IND` (2): "Non-Connectable - Scan Response Available"
- `BLE_HCI_ADV_TYPE_ADV_NONCONN_IND` (3): "Non-Connectable - No Scan Response"
- `BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_LD` (4): "Directed Low Duty - Connectable"
