### PR TITLE
Make variable static

### DIFF
--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -40,7 +40,7 @@ static const char* LOG_TAG = "NimBLEDevice";
 /**
  * Singletons for the NimBLEDevice.
  */
-bool            initialized = false;
+static bool            initialized = false;
 #if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)
 NimBLEScan*     NimBLEDevice::m_pScan = nullptr;
 #endif


### PR DESCRIPTION
Otherwise this is visible to the outside and it has a dangerous short generic name. At least with PlatformIO this led to collision and a failed build.
The other driver did the same "bad" thing ;)