### PR TITLE
Add register for notify without callback

### DIFF
--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -525,13 +525,13 @@ bool NimBLERemoteCharacteristic::setNotify(uint16_t val, bool response, notify_c
  * is performed for notifications.
  * @return true if successful.
  */
-bool NimBLERemoteCharacteristic::subscribeForNotify(bool notifications, bool response, notify_callback notifyCallback) {
+bool NimBLERemoteCharacteristic::subscribe(bool notifications, bool response, notify_callback notifyCallback) {
     if(notifications) {
         return setNotify(0x01, response, notifyCallback);
     } else {
         return setNotify(0x02, response, notifyCallback);
     }
-} // subscribeForNotify
+} // subscribe
 
 
 /**
@@ -539,9 +539,28 @@ bool NimBLERemoteCharacteristic::subscribeForNotify(bool notifications, bool res
  * @param [in] bool if true, require a write response from the descriptor write operation.
  * @return true if successful.
  */
-bool NimBLERemoteCharacteristic::unsubscribeForNotify(bool response) {
+bool NimBLERemoteCharacteristic::unsubscribe(bool response) {
     return setNotify(0x00, response);
-} // unsubscribeForNotify
+} // unsubscribe
+
+
+ /**
+ * @brief backward-compatibility method for subscribe/unsubscribe notifications/indications
+ * @param [in] notifyCallback A callback to be invoked for a notification.  If NULL is provided then we are
+ * unregistering for notifications.
+ * @param [in] bool if true, register for notifications, false register for indications.
+ * @param [in] bool if true, require a write response from the descriptor write operation.
+ * @return true if successful.
+ */
+bool NimBLERemoteCharacteristic::registerForNotify(notify_callback notifyCallback, bool notifications, bool response) {
+    bool success;
+    if(notifyCallback != nullptr) {
+        success = subscribe(notifications, response, notifyCallback);
+    } else {
+        success = unsubscribe(response);
+    }
+    return success;
+} // registerForNotify
 
 
 /**

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -495,6 +495,32 @@ int NimBLERemoteCharacteristic::onReadCB(uint16_t conn_handle,
 
 /**
  * @brief Register for notifications.
+ * @param [in] bool if true, register for notifications, false register for indications.
+ * @param [in] bool if true, require a write response from the descriptor write operation.
+ * @return true if successful.
+ */
+bool NimBLERemoteCharacteristic::registerForNotify(bool notifications, bool response) {
+    NIMBLE_LOGD(LOG_TAG, ">> registerForNotify(): %s", toString().c_str());
+
+    m_notifyCallback = nullptr;   // register without notification callback.
+
+    uint8_t val[] = {0x01, 0x00};
+
+    NimBLERemoteDescriptor* desc = getDescriptor(NimBLEUUID((uint16_t)0x2902));
+    if(desc == nullptr)
+        return false;
+
+    if(!notifications){
+        val[0] = 0x02;
+    }
+    NIMBLE_LOGD(LOG_TAG, "<< registerForNotify()");
+
+    return desc->writeValue(val, 2, response);
+} // registerForNotify
+
+
+/**
+ * @brief Register for notifications.
  * @param [in] notifyCallback A callback to be invoked for a notification.  If NULL is provided then we are
  * unregistering for notifications.
  * @param [in] bool if true, register for notifications, false register for indications.
@@ -518,7 +544,7 @@ bool NimBLERemoteCharacteristic::registerForNotify(notify_callback notifyCallbac
         }
     }
 
-    else if (notifyCallback == nullptr){
+    else {
         val[0] = 0x00;
     }
 

--- a/src/NimBLERemoteCharacteristic.h
+++ b/src/NimBLERemoteCharacteristic.h
@@ -78,11 +78,10 @@ public:
         return *((T *)pData);
     }
 
-    bool                                           registerForNotify(bool notifications = true,
-                                                                     bool response = true);
-    bool                                           registerForNotify(notify_callback _callback,
-                                                                     bool notifications = true,
-                                                                     bool response = true);
+    bool                                           subscribeForNotify(bool notifications = true, 
+                                                                      bool response = true, 
+                                                                      notify_callback notifyCallback = nullptr);
+    bool                                           unsubscribeForNotify(bool response = true);
     bool                                           writeValue(const uint8_t* data,
                                                               size_t length,
                                                               bool response = false);
@@ -102,6 +101,7 @@ private:
     friend class      NimBLERemoteDescriptor;
 
     // Private member functions
+    bool              setNotify(uint16_t val, bool response = true, notify_callback notifyCallback = nullptr);
     bool              retrieveDescriptors(const NimBLEUUID *uuid_filter = nullptr);
     static int        onReadCB(uint16_t conn_handle, const struct ble_gatt_error *error,
                                struct ble_gatt_attr *attr, void *arg);

--- a/src/NimBLERemoteCharacteristic.h
+++ b/src/NimBLERemoteCharacteristic.h
@@ -78,10 +78,13 @@ public:
         return *((T *)pData);
     }
 
-    bool                                           subscribeForNotify(bool notifications = true, 
-                                                                      bool response = true, 
-                                                                      notify_callback notifyCallback = nullptr);
-    bool                                           unsubscribeForNotify(bool response = true);
+    bool                                           subscribe(bool notifications = true,
+                                                             bool response = true,
+                                                             notify_callback notifyCallback = nullptr);
+    bool                                           unsubscribe(bool response = true);
+    bool                                           registerForNotify(notify_callback notifyCallback,
+                                                                     bool notifications = true,
+                                                                     bool response = true) __attribute__ ((deprecated));
     bool                                           writeValue(const uint8_t* data,
                                                               size_t length,
                                                               bool response = false);

--- a/src/NimBLERemoteCharacteristic.h
+++ b/src/NimBLERemoteCharacteristic.h
@@ -78,6 +78,8 @@ public:
         return *((T *)pData);
     }
 
+    bool                                           registerForNotify(bool notifications = true,
+                                                                     bool response = true);
     bool                                           registerForNotify(notify_callback _callback,
                                                                      bool notifications = true,
                                                                      bool response = true);


### PR DESCRIPTION
Since PR #49 it is possible to access the value set in a remote characteristic by a notification at any time _without using a callback function_ using `getValue()`. For this the possibility is added to register for a notification without a callback function, `registerForNotification(bool, bool)`.
Also in `registerForNotification()` an unneeded test is removed.

I choose for this option to not change the api. In the original design passing a nullptr to  `registerForNotification(bool, bool)` means unregister for notification. I think it would be better to change the order of the parameters and semanitics into `registerForNotification(bool notifications = true, bool response = true, notify_callback = nullptr)` with the semanitic of a nullptr being: _register_ for notification without a callback function instead of _unregister_ for notification, and add a `unregisterForNotification()` function. This will however change the API