### PR TITLE
Add uint64_t cast of an address

### DIFF
--- a/src/NimBLEAddress.cpp
+++ b/src/NimBLEAddress.cpp
@@ -142,4 +142,10 @@ NimBLEAddress::operator std::string() const {
     return std::string(buffer);
 }
 
+NimBLEAddress::operator uint64_t() const {
+    uint64_t address = 0;
+    memcpy(&address, m_address, sizeof m_address);
+    return address;
+}
+
 #endif

--- a/src/NimBLEAddress.h
+++ b/src/NimBLEAddress.h
@@ -44,6 +44,7 @@ public:
     bool operator   ==(const NimBLEAddress & rhs) const;
     bool operator   !=(const NimBLEAddress & rhs) const;
     operator        std::string() const;
+    operator        uint64_t() const;
 
 private:
     uint8_t        m_address[6];


### PR DESCRIPTION
Now you can do

```
NimBLEAddress address("12:34:56:78:90:ab");
Serial.printf("Address is %12llx\n", uint64_t(address));

```
resulting in:

`Address is 1234567890ab`