### PR TITLE
Just return a pointer for getServices(false) and getCharacteristics(false)

### DIFF
--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -412,15 +412,13 @@ NimBLERemoteService* NimBLEClient::getService(const NimBLEUUID &uuid) {
  * @param [in] bool value to indicate if the current vector should be cleared and
  * subsequently all services retrieved from the peripheral.
  * If false the vector will be returned with the currently stored services,
- * if vector is empty it will retrieve all services from the peripheral.
+ * If true it will retrieve all services from the peripheral and return the vector with all services
  * @return a pointer to the vector of available services.
  */
 std::vector<NimBLERemoteService*>* NimBLEClient::getServices(bool refresh) {
     if(refresh) {
         deleteServices();
-    }
 
-    if(m_servicesVector.empty()) {
         if (!retrieveServices()) {
             NIMBLE_LOGE(LOG_TAG, "Error: Failed to get services");
         }

--- a/src/NimBLERemoteService.cpp
+++ b/src/NimBLERemoteService.cpp
@@ -118,17 +118,15 @@ NimBLERemoteCharacteristic* NimBLERemoteService::getCharacteristic(const NimBLEU
  * @param [in] bool value to indicate if the current vector should be cleared and
  * subsequently all characteristics for this service retrieved from the peripheral.
  * If false the vector will be returned with the currently stored characteristics,
- * if the vector is empty it will retrieve all characteristics of this service
- * from the peripheral.
+ * If true it will retrieve all characteristics of this service from the peripheral 
+ * and return the vector with all characteristics for this service.
  * @return a pointer to the vector of descriptors for this characteristic.
  */
 
 std::vector<NimBLERemoteCharacteristic*>* NimBLERemoteService::getCharacteristics(bool refresh) {
     if(refresh) {
         deleteCharacteristics();
-    }
 
-    if(m_characteristicVector.empty()) {
         if (!retrieveCharacteristics()) {
             NIMBLE_LOGE(LOG_TAG, "Error: Failed to get characteristics");
         }


### PR DESCRIPTION
I was surprised that the services count of my device was not 'zero' directly after connecting to that device. I used this sketch:

```
#include <NimBLEDevice.h>

void setup() {
  // put your setup code here, to run once:
  Serial.begin(115200);
  Serial.println("\n\nStarted");

  BLEDevice::init("ESP32");

  Serial.println("Create client");
  NimBLEClient *pClient = BLEDevice::createClient();
  Serial.printf("Service count before connection is %u\n", pClient->getServices()->size());
  Serial.println("Connecting...");
  bool success = pClient->connect(BLEAddress("a4:c1:38:5d:ef:16"));
  if(!success) {
    BLEDevice::deleteClient(pClient);

    Serial.println("Failed to connect");
  } else {
    Serial.println("Connected!");
  }
  Serial.printf("Service count after connection is %u\n", pClient->getServices()->size());
  pClient->disconnect();
  Serial.printf("Service count after disconnection is %u\n", pClient->getServices()->size());
  pClient->deleteServices();
  Serial.printf("Service count after deletion is %u\n", pClient->getServices()->size());
}

void loop() {
  // put your main code here, to run repeatedly:

}
```

This resulted:

```
Started
Create client
Service count before connection is 0
Connecting...
Connected!
Service count after connection is 8
Service count after disconnection is 8
Service count after deletion is 0

```

It turned out that the inspection of the size of the vector of services `pClient->getServices()->size()` automatically retrieved all services, even though the default parameter to `getServices()` is `false`. IMHO that is semantically wrong.

If parameter 'refresh' equals 'false' services or characteristics should **not** be retrieved, just a pointer to the vector should be returned.