### PR TITLE
Don't send notifications to un-paired peers when READ_ENC set

### DIFF
--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -107,7 +107,7 @@ private:
     ~NimBLECharacteristic();
 
     NimBLEService*  getService();
-    uint8_t         getProperties();
+    uint16_t        getProperties();
     void            setSubscribe(struct ble_gap_event *event);
     static int      handleGapEvent(uint16_t conn_handle, uint16_t attr_handle,
                                    struct ble_gatt_access_ctxt *ctxt, void *arg);

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -181,8 +181,8 @@ int NimBLEServer::disconnect(uint16_t connId, uint8_t reason) {
                                     NimBLEUtils::returnCodeToString(rc));
     }
 
-    return rc;
     NIMBLE_LOGD(LOG_TAG, "<< disconnect()");
+    return rc;
 } // disconnect
 
 
@@ -230,7 +230,6 @@ size_t NimBLEServer::getConnectedCount() {
             else {
                 server->m_connectedPeersVec.push_back(event->connect.conn_handle);
 
-                ble_gap_conn_desc desc;
                 rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
                 assert(rc == 0);
 
@@ -276,6 +275,18 @@ size_t NimBLEServer::getConnectedCount() {
 
             for(auto &it : server->m_notifyChrVec) {
                 if(it->getHandle() == event->subscribe.attr_handle) {
+                    if((it->getProperties() & BLE_GATT_CHR_F_READ_AUTHEN) ||
+                       (it->getProperties() & BLE_GATT_CHR_F_READ_AUTHOR) ||
+                       (it->getProperties() & BLE_GATT_CHR_F_READ_ENC))
+                    {
+                        rc = ble_gap_conn_find(event->subscribe.conn_handle, &desc);
+                        assert(rc == 0);
+
+                        if(!desc.sec_state.encrypted) {
+                            NimBLEDevice::startSecurity(event->subscribe.conn_handle);
+                        }
+                    }
+
                     it->setSubscribe(event);
                     break;
                 }
@@ -330,7 +341,7 @@ size_t NimBLEServer::getConnectedCount() {
         } // BLE_GAP_EVENT_REPEAT_PAIRING
 
         case BLE_GAP_EVENT_ENC_CHANGE: {
-            rc = ble_gap_conn_find(event->conn_update.conn_handle, &desc);
+            rc = ble_gap_conn_find(event->enc_change.conn_handle, &desc);
             if(rc != 0) {
                 return BLE_ATT_ERR_INVALID_HANDLE;
             }


### PR DESCRIPTION
If read encryption is applied to a characteristic the server should not allow notifications of it's value to be sent to peers that have not paired with the server.

* Also added minor bugfixes
