### PR TITLE
Implement scan wantDuplicates parameter in callback registration.

### DIFF
--- a/src/NimBLEAdvertisedDevice.cpp
+++ b/src/NimBLEAdvertisedDevice.cpp
@@ -37,6 +37,8 @@ NimBLEAdvertisedDevice::NimBLEAdvertisedDevice() {
     m_serviceData      = "";
     m_txPower          = 0;
     m_pScan            = nullptr;
+    m_payloadLength    = 0;
+    m_payload          = nullptr;
 
     m_haveAppearance       = false;
     m_haveManufacturerData = false;
@@ -45,6 +47,7 @@ NimBLEAdvertisedDevice::NimBLEAdvertisedDevice() {
     m_haveServiceData      = false;
     m_haveServiceUUID      = false;
     m_haveTXPower          = false;
+    m_callbackSent         = false;
 
 } // NimBLEAdvertisedDevice
 

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -115,7 +115,7 @@ private:
     bool m_haveTXPower;
 
 
-    NimBLEAddress  m_address = NimBLEAddress("");
+    NimBLEAddress   m_address = NimBLEAddress("");
     uint8_t         m_advType;
     uint16_t        m_appearance;
     int             m_deviceType;
@@ -128,9 +128,10 @@ private:
     std::string     m_serviceData;
     NimBLEUUID      m_serviceDataUUID;
     uint8_t*        m_payload;
-    size_t          m_payloadLength = 0;
+    size_t          m_payloadLength;
     uint8_t         m_addressType;
     time_t          m_timestamp;
+    bool            m_callbackSent;
 };
 
 /**

--- a/src/NimBLEScan.h
+++ b/src/NimBLEScan.h
@@ -62,10 +62,13 @@ class NimBLEScan {
 public:
     bool                start(uint32_t duration, void (*scanCompleteCB)(NimBLEScanResults), bool is_continue = false);
     NimBLEScanResults   start(uint32_t duration, bool is_continue = false);
-    void                setAdvertisedDeviceCallbacks(NimBLEAdvertisedDeviceCallbacks* pAdvertisedDeviceCallbacks/*, bool wantDuplicates = false*/);
+    void                setAdvertisedDeviceCallbacks(NimBLEAdvertisedDeviceCallbacks* pAdvertisedDeviceCallbacks, bool wantDuplicates = false);
     void                setActiveScan(bool active);
     void                setInterval(uint16_t intervalMSecs);
     void                setWindow(uint16_t windowMSecs);
+    void                setDuplicateFilter(bool active);
+    void                setLimitedOnly(bool active);
+    void                setFilterPolicy(uint8_t filter);
     bool                stop();
     void                clearResults();
     NimBLEScanResults   getResults();


### PR DESCRIPTION
Also adds:
* NimBLEScan::setDuplicateFilter() to tell the controller to filter duplicates
before sending the result to the host.

* NimBLEScan::setLimitedOnly() to tell the controller only report scan results
from devices advertising in limited discovery mode, i.e. directed advertising.

* NimBLEScan::setFilterPolicy() to set the filter policy i.e whitelist only