### PR TITLE
Alternative characteristic read/write callbacks

### DIFF
--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -176,7 +176,9 @@ public:
 
     virtual ~NimBLECharacteristicCallbacks();
     virtual void onRead(NimBLECharacteristic* pCharacteristic);
+    virtual void onRead(NimBLECharacteristic* pCharacteristic, ble_gap_conn_desc* desc);
     virtual void onWrite(NimBLECharacteristic* pCharacteristic);
+    virtual void onWrite(NimBLECharacteristic* pCharacteristic, ble_gap_conn_desc* desc);
     virtual void onNotify(NimBLECharacteristic* pCharacteristic);
     virtual void onStatus(NimBLECharacteristic* pCharacteristic, Status s, int code);
 };


### PR DESCRIPTION
As mentioned in #83, I added extended read/write callbacks which pass the connection description information. Now I am able to retrieve the peer address at the write event.