### PR TITLE
Store address type in NimBLEAddress

### DIFF
--- a/src/NimBLEAddress.cpp
+++ b/src/NimBLEAddress.cpp
@@ -33,6 +33,7 @@ static const char* LOG_TAG = "NimBLEAddress";
  */
 NimBLEAddress::NimBLEAddress(ble_addr_t address) {
     memcpy(m_address, address.val, 6);
+    m_addrType = address.type;
 } // NimBLEAddress
 
 
@@ -46,8 +47,11 @@ NimBLEAddress::NimBLEAddress(ble_addr_t address) {
  * which is 17 characters in length.
  *
  * @param [in] stringAddress The hex string representation of the address.
+ * @param [in] type The type of the address.
  */
-NimBLEAddress::NimBLEAddress(const std::string &stringAddress) {
+NimBLEAddress::NimBLEAddress(const std::string &stringAddress, uint8_t type) {
+    m_addrType = type;
+
     if (stringAddress.length() == 0) {
         memset(m_address, 0, 6);
         return;
@@ -78,9 +82,11 @@ NimBLEAddress::NimBLEAddress(const std::string &stringAddress) {
 /**
  * @brief Constructor for compatibility with bluedroid esp library using native ESP representation.
  * @param [in] address A uint8_t[6] or esp_bd_addr_t containing the address.
+ * @param [in] type The type of the address.
  */
-NimBLEAddress::NimBLEAddress(uint8_t address[6]) {
+NimBLEAddress::NimBLEAddress(uint8_t address[6], uint8_t type) {
     std::reverse_copy(address, address + sizeof m_address, m_address);
+    m_addrType = type;
 } // NimBLEAddress
 
 
@@ -88,9 +94,11 @@ NimBLEAddress::NimBLEAddress(uint8_t address[6]) {
  * @brief Constructor for address using a hex value.\n
  * Use the same byte order, so use 0xa4c1385def16 for "a4:c1:38:5d:ef:16"
  * @param [in] address uint64_t containing the address.
+ * @param [in] type The type of the address.
  */
-NimBLEAddress::NimBLEAddress(const uint64_t &address) {
+NimBLEAddress::NimBLEAddress(const uint64_t &address, uint8_t type) {
     memcpy(m_address, &address, sizeof m_address);
+    m_addrType = type;
 } // NimBLEAddress
 
 
@@ -111,6 +119,15 @@ bool NimBLEAddress::equals(const NimBLEAddress &otherAddress) const {
 const uint8_t *NimBLEAddress::getNative() const {
     return m_address;
 } // getNative
+
+
+/**
+ * @brief Get the address type.
+ * @return The address type.
+ */
+uint8_t NimBLEAddress::getType() const {
+    return m_addrType;
+} // getType
 
 
 /**
@@ -152,8 +169,11 @@ bool NimBLEAddress::operator !=(const NimBLEAddress & rhs) const {
  * that accept std::string and/or or it's methods as a parameter.
  */
 NimBLEAddress::operator std::string() const {
-    char buffer[18];
-    sprintf(buffer, "%02x:%02x:%02x:%02x:%02x:%02x", m_address[5], m_address[4], m_address[3], m_address[2], m_address[1], m_address[0]);
+    char buffer[26];
+    snprintf(buffer, sizeof(buffer), "%02x:%02x:%02x:%02x:%02x:%02x type: %d",
+                                     m_address[5], m_address[4], m_address[3],
+                                     m_address[2], m_address[1], m_address[0],
+                                     m_addrType);
     return std::string(buffer);
 } // operator std::string
 

--- a/src/NimBLEAddress.h
+++ b/src/NimBLEAddress.h
@@ -34,12 +34,13 @@
 class NimBLEAddress {
 public:
     NimBLEAddress(ble_addr_t address);
-    NimBLEAddress(uint8_t address[6]);
-    NimBLEAddress(const std::string &stringAddress);
-    NimBLEAddress(const uint64_t &address);
-    bool           equals(const NimBLEAddress &otherAddress) const;
-    const uint8_t*       getNative() const;
-    std::string    toString() const;
+    NimBLEAddress(uint8_t address[6], uint8_t type = BLE_ADDR_PUBLIC);
+    NimBLEAddress(const std::string &stringAddress, uint8_t type = BLE_ADDR_PUBLIC);
+    NimBLEAddress(const uint64_t &address, uint8_t type = BLE_ADDR_PUBLIC);
+    bool            equals(const NimBLEAddress &otherAddress) const;
+    const uint8_t*  getNative() const;
+    std::string     toString() const;
+    uint8_t         getType() const;
 
     bool operator   ==(const NimBLEAddress & rhs) const;
     bool operator   !=(const NimBLEAddress & rhs) const;
@@ -48,6 +49,7 @@ public:
 
 private:
     uint8_t        m_address[6];
+    uint8_t        m_addrType;
 };
 
 #endif /* CONFIG_BT_ENABLED */

--- a/src/NimBLEAdvertisedDevice.cpp
+++ b/src/NimBLEAdvertisedDevice.cpp
@@ -70,7 +70,7 @@ NimBLEAddress NimBLEAdvertisedDevice::getAddress() {
  */
 uint8_t NimBLEAdvertisedDevice::getAdvType() {
     return m_advType;
-} // getAddress
+} // getAdvType
 
 
 /**
@@ -584,7 +584,7 @@ uint8_t* NimBLEAdvertisedDevice::getPayload() {
  * * BLE_ADDR_RANDOM_ID   (0x03)
  */
 uint8_t NimBLEAdvertisedDevice::getAddressType() {
-    return m_addressType;
+    return m_address.getType();
 } // getAddressType
 
 
@@ -595,19 +595,6 @@ uint8_t NimBLEAdvertisedDevice::getAddressType() {
 time_t NimBLEAdvertisedDevice::getTimestamp() {
     return m_timestamp;
 } // getTimestamp
-
-
-/**
- * @brief Set the advertised device address type.
- * @param [in] type The address type of the device:
- * * BLE_ADDR_PUBLIC      (0x00)
- * * BLE_ADDR_RANDOM      (0x01)
- * * BLE_ADDR_PUBLIC_ID   (0x02)
- * * BLE_ADDR_RANDOM_ID   (0x03)
- */
-void NimBLEAdvertisedDevice::setAddressType(uint8_t type) {
-    m_addressType = type;
-} // setAddressType
 
 
 /**

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -111,19 +111,15 @@ public:
     size_t          getPayloadLength();
     uint8_t         getAddressType();
     time_t          getTimestamp();
-    void            setAddressType(uint8_t type);
-
-
-    bool        isAdvertisingService(const NimBLEUUID &uuid) const;
-    bool        haveAppearance();
-    bool        haveManufacturerData();
-    bool        haveName();
-    bool        haveRSSI();
-    bool        haveServiceData();
-    bool        haveServiceUUID();
-    bool        haveTXPower();
-
-    std::string toString();
+    bool            isAdvertisingService(const NimBLEUUID &uuid) const;
+    bool            haveAppearance();
+    bool            haveManufacturerData();
+    bool            haveName();
+    bool            haveRSSI();
+    bool            haveServiceData();
+    bool            haveServiceUUID();
+    bool            haveTXPower();
+    std::string     toString();
 
 private:
     friend class NimBLEScan;
@@ -158,7 +154,6 @@ private:
     int8_t          m_txPower;
     uint8_t*        m_payload;
     size_t          m_payloadLength;
-    uint8_t         m_addressType;
     time_t          m_timestamp;
     bool            m_callbackSent;
 

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -127,21 +127,27 @@ size_t NimBLEClient::deleteService(const NimBLEUUID &uuid) {
 } // deleteServices
 
 
-bool NimBLEClient::connect(bool refreshServices) {
-    return connect(m_peerAddress, 0, refreshServices);
+/**
+ * @brief Connect to the BLE Server.
+ * @param [in] deleteAttibutes If true this will delete any attribute objects this client may already\n
+ * have created and clears the vectors after successful connection.
+ * @return True on success.
+ */
+bool NimBLEClient::connect(bool deleteAttibutes) {
+    return connect(m_peerAddress, 0, deleteAttibutes);
 }
 
 /**
  * @brief Connect to an advertising device.
  * @param [in] device The device to connect to.
- * @param [in] refreshServices If true this will delete any attribute objects this client may already\n
+ * @param [in] deleteAttibutes If true this will delete any attribute objects this client may already\n
  * have created and clears the vectors after successful connection.
  * @return True on success.
  */
-bool NimBLEClient::connect(NimBLEAdvertisedDevice* device, bool refreshServices) {
+bool NimBLEClient::connect(NimBLEAdvertisedDevice* device, bool deleteAttibutes) {
     NimBLEAddress address(device->getAddress());
     uint8_t type = device->getAddressType();
-    return connect(address, type, refreshServices);
+    return connect(address, type, deleteAttibutes);
 }
 
 
@@ -149,11 +155,11 @@ bool NimBLEClient::connect(NimBLEAdvertisedDevice* device, bool refreshServices)
  * @brief Connect to the BLE Server.
  * @param [in] address The address of the server.
  * @param [in] type The address type of the server (Random/public/other)
- * @param [in] refreshServices If true this will delete any attribute objects this client may already\n
+ * @param [in] deleteAttibutes If true this will delete any attribute objects this client may already\n
  * have created and clears the vectors after successful connection.
  * @return True on success.
  */
-bool NimBLEClient::connect(const NimBLEAddress &address, uint8_t type, bool refreshServices) {
+bool NimBLEClient::connect(const NimBLEAddress &address, uint8_t type, bool deleteAttibutes) {
     NIMBLE_LOGD(LOG_TAG, ">> connect(%s)", address.toString().c_str());
 
     if(!NimBLEDevice::m_synced) {
@@ -212,7 +218,7 @@ bool NimBLEClient::connect(const NimBLEAddress &address, uint8_t type, bool refr
         return false;
     }
 
-    if(refreshServices) {
+    if(deleteAttibutes) {
         NIMBLE_LOGD(LOG_TAG, "Refreshing Services for: (%s)", address.toString().c_str());
         deleteServices();
     }

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -127,6 +127,10 @@ size_t NimBLEClient::deleteService(const NimBLEUUID &uuid) {
 } // deleteServices
 
 
+bool NimBLEClient::connect(bool refreshServices) {
+    return connect(m_peerAddress, 0, refreshServices);
+}
+
 /**
  * @brief Connect to an advertising device.
  * @param [in] device The device to connect to.
@@ -348,7 +352,23 @@ uint16_t NimBLEClient::getConnId() {
  */
 NimBLEAddress NimBLEClient::getPeerAddress() {
     return m_peerAddress;
-} // getAddress
+} // getPeerAddress
+
+
+/**
+ * @brief Set the peer address.
+ * @param [in] address The address of the peer that this client is
+ * connected or should connect to.
+ */
+void NimBLEClient::setPeerAddress(const NimBLEAddress &address) {
+    if(isConnected()) {
+        NIMBLE_LOGE(LOG_TAG, "Cannot set peer address while connected");
+        return;
+    }
+
+    m_peerAddress = address;
+    NIMBLE_LOGE(LOG_TAG, "Peer address set: %s", std::string(m_peerAddress).c_str());
+} // setPeerAddress
 
 
 /**

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -146,8 +146,7 @@ bool NimBLEClient::connect(bool deleteAttibutes) {
  */
 bool NimBLEClient::connect(NimBLEAdvertisedDevice* device, bool deleteAttibutes) {
     NimBLEAddress address(device->getAddress());
-    uint8_t type = device->getAddressType();
-    return connect(address, type, deleteAttibutes);
+    return connect(address, 0, deleteAttibutes);
 }
 
 
@@ -181,7 +180,7 @@ bool NimBLEClient::connect(const NimBLEAddress &address, uint8_t type, bool dele
 
     ble_addr_t peerAddrt;
     memcpy(&peerAddrt.val, address.getNative(),6);
-    peerAddrt.type = type;
+    peerAddrt.type = address.getType();
 
     ble_task_data_t taskData = {this, xTaskGetCurrentTaskHandle(), 0, nullptr};
     m_pTaskData = &taskData;
@@ -199,10 +198,9 @@ bool NimBLEClient::connect(const NimBLEAddress &address, uint8_t type, bool dele
     }while(rc == BLE_HS_EBUSY);
 
     if (rc != 0 && rc != BLE_HS_EDONE) {
-        NIMBLE_LOGE(LOG_TAG, "Error: Failed to connect to device; addr_type=%d "
+        NIMBLE_LOGE(LOG_TAG, "Error: Failed to connect to device; "
                     "addr=%s, rc=%d; %s",
-                    type,
-                    m_peerAddress.toString().c_str(),
+                    std::string(m_peerAddress).c_str(),
                     rc, NimBLEUtils::returnCodeToString(rc));
         m_pTaskData = nullptr;
         m_waitingToConnect = false;
@@ -219,7 +217,6 @@ bool NimBLEClient::connect(const NimBLEAddress &address, uint8_t type, bool dele
     }
 
     if(deleteAttibutes) {
-        NIMBLE_LOGD(LOG_TAG, "Refreshing Services for: (%s)", address.toString().c_str());
         deleteServices();
     }
 
@@ -373,7 +370,7 @@ void NimBLEClient::setPeerAddress(const NimBLEAddress &address) {
     }
 
     m_peerAddress = address;
-    NIMBLE_LOGE(LOG_TAG, "Peer address set: %s", std::string(m_peerAddress).c_str());
+    NIMBLE_LOGD(LOG_TAG, "Peer address set: %s", std::string(m_peerAddress).c_str());
 } // setPeerAddress
 
 

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -38,10 +38,10 @@ class NimBLEAdvertisedDevice;
  */
 class NimBLEClient {
 public:
-    bool                                        connect(NimBLEAdvertisedDevice* device, bool refreshServices = true);
+    bool                                        connect(NimBLEAdvertisedDevice* device, bool deleteAttibutes = true);
     bool                                        connect(const NimBLEAddress &address, uint8_t type = BLE_ADDR_PUBLIC,
-                                                        bool refreshServices = true);
-    bool                                        connect(bool refreshServices = true);
+                                                        bool deleteAttibutes = true);
+    bool                                        connect(bool deleteAttibutes = true);
     int                                         disconnect(uint8_t reason = BLE_ERR_REM_USER_CONN_TERM);
     NimBLEAddress                               getPeerAddress();
     void                                        setPeerAddress(const NimBLEAddress &address);

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -41,8 +41,10 @@ public:
     bool                                        connect(NimBLEAdvertisedDevice* device, bool refreshServices = true);
     bool                                        connect(const NimBLEAddress &address, uint8_t type = BLE_ADDR_PUBLIC,
                                                         bool refreshServices = true);
+    bool                                        connect(bool refreshServices = true);
     int                                         disconnect(uint8_t reason = BLE_ERR_REM_USER_CONN_TERM);
     NimBLEAddress                               getPeerAddress();
+    void                                        setPeerAddress(const NimBLEAddress &address);
     int                                         getRssi();
     std::vector<NimBLERemoteService*>*          getServices(bool refresh = false);
     std::vector<NimBLERemoteService*>::iterator begin();

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -38,10 +38,10 @@ class NimBLEAdvertisedDevice;
  */
 class NimBLEClient {
 public:
-    bool                                        connect(NimBLEAdvertisedDevice* device, bool deleteAttibutes = true);
-    bool                                        connect(const NimBLEAddress &address, uint8_t type = BLE_ADDR_PUBLIC,
-                                                        bool deleteAttibutes = true);
     bool                                        connect(bool deleteAttibutes = true);
+    bool                                        connect(NimBLEAdvertisedDevice* device, bool deleteAttibutes = true);
+    bool                                        connect(const NimBLEAddress &address, uint8_t type = 0xFF,
+                                                        bool deleteAttibutes = true);
     int                                         disconnect(uint8_t reason = BLE_ERR_REM_USER_CONN_TERM);
     NimBLEAddress                               getPeerAddress();
     void                                        setPeerAddress(const NimBLEAddress &address);

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -40,8 +40,7 @@ class NimBLEClient {
 public:
     bool                                        connect(bool deleteAttibutes = true);
     bool                                        connect(NimBLEAdvertisedDevice* device, bool deleteAttibutes = true);
-    bool                                        connect(const NimBLEAddress &address, uint8_t type = 0xFF,
-                                                        bool deleteAttibutes = true);
+    bool                                        connect(const NimBLEAddress &address, bool deleteAttibutes = true);
     int                                         disconnect(uint8_t reason = BLE_ERR_REM_USER_CONN_TERM);
     NimBLEAddress                               getPeerAddress();
     void                                        setPeerAddress(const NimBLEAddress &address);

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -138,7 +138,7 @@ void NimBLEDevice::stopAdvertising() {
  * @brief Creates a new client object and maintains a list of all client objects
  * each client can connect to 1 peripheral device.
  * @param [in] peerAddress An optional peer address that is copied to the new client
- * object, allows for calling connect() without providing a device or address.
+ * object, allows for calling NimBLEClient::connect(bool) without a device or address parameter.
  * @return A reference to the new client object.
  */
 #if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL)

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -140,13 +140,16 @@ void NimBLEDevice::stopAdvertising() {
  * @return A reference to the new client object.
  */
 #if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL)
-/* STATIC */ NimBLEClient* NimBLEDevice::createClient() {
+/* STATIC */ NimBLEClient* NimBLEDevice::createClient(NimBLEAddress peerAddress) {
     if(m_cList.size() >= NIMBLE_MAX_CONNECTIONS) {
         NIMBLE_LOGW("Number of clients exceeds Max connections. Max=(%d)",
                                             NIMBLE_MAX_CONNECTIONS);
     }
 
     NimBLEClient* pClient = new NimBLEClient();
+    if(peerAddress != NimBLEAddress("")) {
+        pClient->setPeerAddress(peerAddress);
+    }
     m_cList.push_back(pClient);
 
     return pClient;

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -137,6 +137,8 @@ void NimBLEDevice::stopAdvertising() {
 /**
  * @brief Creates a new client object and maintains a list of all client objects
  * each client can connect to 1 peripheral device.
+ * @param [in] peerAddress An optional peer address that is copied to the new client
+ * object, allows for calling connect() without providing a device or address.
  * @return A reference to the new client object.
  */
 #if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL)

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -130,7 +130,7 @@ public:
 #endif
 
 #if defined( CONFIG_BT_NIMBLE_ROLE_CENTRAL)
-    static NimBLEClient*    createClient();
+    static NimBLEClient*    createClient(NimBLEAddress peerAddress = NimBLEAddress(""));
     static bool             deleteClient(NimBLEClient* pClient);
     static NimBLEClient*    getClientByID(uint16_t conn_id);
     static NimBLEClient*    getClientByPeerAddress(const NimBLEAddress &peer_addr);

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -90,7 +90,6 @@ NimBLEScan::~NimBLEScan() {
             // Otherwise just update the relevant parameters of the already known device.
             if(advertisedDevice == nullptr){
                 advertisedDevice = new NimBLEAdvertisedDevice();
-                advertisedDevice->setAddressType(event->disc.addr.type);
                 advertisedDevice->setAddress(advertisedAddress);
                 advertisedDevice->setAdvType(event->disc.event_type);
                 pScan->m_scanResults.m_advertisedDevicesVector.push_back(advertisedDevice);


### PR DESCRIPTION
Currently only the address value is stored in NimBLEAddress. 

This adds the address type as a member variable and adds a type parameter to the constructor.

* New NimBLEAddress::getType() method added to access the type value.