### PR TITLE
Store address type in NimBLEAddress.

### DIFF
--- a/src/NimBLEAddress.cpp
+++ b/src/NimBLEAddress.cpp
@@ -33,6 +33,7 @@ static const char* LOG_TAG = "NimBLEAddress";
  */
 NimBLEAddress::NimBLEAddress(ble_addr_t address) {
     memcpy(m_address, address.val, 6);
+    m_addrType = address.type;
 } // NimBLEAddress
 
 
@@ -46,8 +47,11 @@ NimBLEAddress::NimBLEAddress(ble_addr_t address) {
  * which is 17 characters in length.
  *
  * @param [in] stringAddress The hex string representation of the address.
+ * @param [in] type The type of the address.
  */
-NimBLEAddress::NimBLEAddress(const std::string &stringAddress) {
+NimBLEAddress::NimBLEAddress(const std::string &stringAddress, uint8_t type) {
+    m_addrType = type;
+
     if (stringAddress.length() == 0) {
         memset(m_address, 0, 6);
         return;
@@ -78,9 +82,11 @@ NimBLEAddress::NimBLEAddress(const std::string &stringAddress) {
 /**
  * @brief Constructor for compatibility with bluedroid esp library using native ESP representation.
  * @param [in] address A uint8_t[6] or esp_bd_addr_t containing the address.
+ * @param [in] type The type of the address.
  */
-NimBLEAddress::NimBLEAddress(uint8_t address[6]) {
+NimBLEAddress::NimBLEAddress(uint8_t address[6], uint8_t type) {
     std::reverse_copy(address, address + sizeof m_address, m_address);
+    m_addrType = type;
 } // NimBLEAddress
 
 
@@ -88,9 +94,11 @@ NimBLEAddress::NimBLEAddress(uint8_t address[6]) {
  * @brief Constructor for address using a hex value.\n
  * Use the same byte order, so use 0xa4c1385def16 for "a4:c1:38:5d:ef:16"
  * @param [in] address uint64_t containing the address.
+ * @param [in] type The type of the address.
  */
-NimBLEAddress::NimBLEAddress(const uint64_t &address) {
+NimBLEAddress::NimBLEAddress(const uint64_t &address, uint8_t type) {
     memcpy(m_address, &address, sizeof m_address);
+    m_addrType = type;
 } // NimBLEAddress
 
 
@@ -111,6 +119,15 @@ bool NimBLEAddress::equals(const NimBLEAddress &otherAddress) const {
 const uint8_t *NimBLEAddress::getNative() const {
     return m_address;
 } // getNative
+
+
+/**
+ * @brief Get the address type.
+ * @return The address type.
+ */
+uint8_t NimBLEAddress::getType() const {
+    return m_addrType;
+} // getType
 
 
 /**
@@ -152,8 +169,11 @@ bool NimBLEAddress::operator !=(const NimBLEAddress & rhs) const {
  * that accept std::string and/or or it's methods as a parameter.
  */
 NimBLEAddress::operator std::string() const {
-    char buffer[18];
-    sprintf(buffer, "%02x:%02x:%02x:%02x:%02x:%02x", m_address[5], m_address[4], m_address[3], m_address[2], m_address[1], m_address[0]);
+    char buffer[26];
+    snprintf(buffer, sizeof(buffer), "%02x:%02x:%02x:%02x:%02x:%02x type: %d",
+                                     m_address[5], m_address[4], m_address[3],
+                                     m_address[2], m_address[1], m_address[0],
+                                     m_addrType);
     return std::string(buffer);
 } // operator std::string
 

--- a/src/NimBLEAddress.h
+++ b/src/NimBLEAddress.h
@@ -34,12 +34,13 @@
 class NimBLEAddress {
 public:
     NimBLEAddress(ble_addr_t address);
-    NimBLEAddress(uint8_t address[6]);
-    NimBLEAddress(const std::string &stringAddress);
-    NimBLEAddress(const uint64_t &address);
-    bool           equals(const NimBLEAddress &otherAddress) const;
-    const uint8_t*       getNative() const;
-    std::string    toString() const;
+    NimBLEAddress(uint8_t address[6], uint8_t type = BLE_ADDR_PUBLIC);
+    NimBLEAddress(const std::string &stringAddress, uint8_t type = BLE_ADDR_PUBLIC);
+    NimBLEAddress(const uint64_t &address, uint8_t type = BLE_ADDR_PUBLIC);
+    bool            equals(const NimBLEAddress &otherAddress) const;
+    const uint8_t*  getNative() const;
+    std::string     toString() const;
+    uint8_t         getType() const;
 
     bool operator   ==(const NimBLEAddress & rhs) const;
     bool operator   !=(const NimBLEAddress & rhs) const;
@@ -48,6 +49,7 @@ public:
 
 private:
     uint8_t        m_address[6];
+    uint8_t        m_addrType;
 };
 
 #endif /* CONFIG_BT_ENABLED */

--- a/src/NimBLEAdvertisedDevice.cpp
+++ b/src/NimBLEAdvertisedDevice.cpp
@@ -70,7 +70,7 @@ NimBLEAddress NimBLEAdvertisedDevice::getAddress() {
  */
 uint8_t NimBLEAdvertisedDevice::getAdvType() {
     return m_advType;
-} // getAddress
+} // getAdvType
 
 
 /**
@@ -584,7 +584,7 @@ uint8_t* NimBLEAdvertisedDevice::getPayload() {
  * * BLE_ADDR_RANDOM_ID   (0x03)
  */
 uint8_t NimBLEAdvertisedDevice::getAddressType() {
-    return m_addressType;
+    return m_address.getType();
 } // getAddressType
 
 
@@ -595,19 +595,6 @@ uint8_t NimBLEAdvertisedDevice::getAddressType() {
 time_t NimBLEAdvertisedDevice::getTimestamp() {
     return m_timestamp;
 } // getTimestamp
-
-
-/**
- * @brief Set the advertised device address type.
- * @param [in] type The address type of the device:
- * * BLE_ADDR_PUBLIC      (0x00)
- * * BLE_ADDR_RANDOM      (0x01)
- * * BLE_ADDR_PUBLIC_ID   (0x02)
- * * BLE_ADDR_RANDOM_ID   (0x03)
- */
-void NimBLEAdvertisedDevice::setAddressType(uint8_t type) {
-    m_addressType = type;
-} // setAddressType
 
 
 /**

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -111,19 +111,15 @@ public:
     size_t          getPayloadLength();
     uint8_t         getAddressType();
     time_t          getTimestamp();
-    void            setAddressType(uint8_t type);
-
-
-    bool        isAdvertisingService(const NimBLEUUID &uuid) const;
-    bool        haveAppearance();
-    bool        haveManufacturerData();
-    bool        haveName();
-    bool        haveRSSI();
-    bool        haveServiceData();
-    bool        haveServiceUUID();
-    bool        haveTXPower();
-
-    std::string toString();
+    bool            isAdvertisingService(const NimBLEUUID &uuid) const;
+    bool            haveAppearance();
+    bool            haveManufacturerData();
+    bool            haveName();
+    bool            haveRSSI();
+    bool            haveServiceData();
+    bool            haveServiceUUID();
+    bool            haveTXPower();
+    std::string     toString();
 
 private:
     friend class NimBLEScan;
@@ -158,7 +154,6 @@ private:
     int8_t          m_txPower;
     uint8_t*        m_payload;
     size_t          m_payloadLength;
-    uint8_t         m_addressType;
     time_t          m_timestamp;
     bool            m_callbackSent;
 

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -90,7 +90,6 @@ NimBLEScan::~NimBLEScan() {
             // Otherwise just update the relevant parameters of the already known device.
             if(advertisedDevice == nullptr){
                 advertisedDevice = new NimBLEAdvertisedDevice();
-                advertisedDevice->setAddressType(event->disc.addr.type);
                 advertisedDevice->setAddress(advertisedAddress);
                 advertisedDevice->setAdvType(event->disc.event_type);
                 pScan->m_scanResults.m_advertisedDevicesVector.push_back(advertisedDevice);


### PR DESCRIPTION
Currently only the address value is stored in NimBLEAddress.

This adds the address type as a member variable and adds a type parameter to the constructor.

New NimBLEAddress::getType() method added to access the type value.