### PR TITLE
Change typedef of callback to enable the usage of member function as callback functions 

### DIFF
--- a/src/NimBLERemoteCharacteristic.h
+++ b/src/NimBLERemoteCharacteristic.h
@@ -24,13 +24,14 @@
 #include "NimBLERemoteDescriptor.h"
 
 #include <vector>
+#include <functional>
 
 class NimBLERemoteService;
 class NimBLERemoteDescriptor;
 
 
-typedef void (*notify_callback)(NimBLERemoteCharacteristic* pBLERemoteCharacteristic,
-                                uint8_t* pData, size_t length, bool isNotify);
+typedef std::function<void (NimBLERemoteCharacteristic* pBLERemoteCharacteristic,
+                                uint8_t* pData, size_t length, bool isNotify)> notify_callback;
 
 typedef struct {
     const NimBLEUUID *uuid;


### PR DESCRIPTION
With this change the callback function could be also a member function and not only a static function. This is needed if you connect to several devices and want to preserve the state in your objects. The detailed description of the issue could be found here: https://github.com/h2zero/NimBLE-Arduino/issues/122