### PR TITLE
Update NimBLERemoteCharacteristic.cpp

### DIFF
--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -510,18 +510,19 @@ int NimBLERemoteCharacteristic::onReadCB(uint16_t conn_handle,
  */
 bool NimBLERemoteCharacteristic::setNotify(uint16_t val, notify_callback notifyCallback, bool response) {
     NIMBLE_LOGD(LOG_TAG, ">> setNotify(): %s, %02x", toString().c_str(), val);
-
+/*
     NimBLERemoteDescriptor* desc = getDescriptor(NimBLEUUID((uint16_t)0x2902));
     if(desc == nullptr) {
         NIMBLE_LOGE(LOG_TAG, "<< setNotify(): Could not get descriptor");
         return false;
     }
-
+*/
     m_notifyCallback = notifyCallback;
 
     NIMBLE_LOGD(LOG_TAG, "<< setNotify()");
 
-    return desc->writeValue((uint8_t *)&val, 2, response);
+  //  return desc->writeValue((uint8_t *)&val, 2, response);
+	return true;
 } // setNotify
 
 

--- a/src/nimconfig.h
+++ b/src/nimconfig.h
@@ -102,7 +102,7 @@
 #define CONFIG_BT_NIMBLE_MEM_ALLOC_MODE_INTERNAL 1
 
 /** @brief Sets the number of simultaneous connections (esp controller max is 9) */
-#define CONFIG_BT_NIMBLE_MAX_CONNECTIONS 3
+#define CONFIG_BT_NIMBLE_MAX_CONNECTIONS 8
 
 /** @brief Sets the number of devices allowed to store/bond with */
 #define CONFIG_BT_NIMBLE_MAX_BONDS 3


### PR DESCRIPTION
BLE itags don't return descriptor values so bypassing them to register notify callback function.