### PR TITLE
Fix crashing caused by calling time() in a critical section

### DIFF
--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -473,9 +473,10 @@ void NimBLECharacteristic::setValue(const uint8_t* data, size_t length) {
         return;
     }
 
+    time_t t = time(nullptr);
     portENTER_CRITICAL(&m_valMux);
     m_value = std::string((char*)data, length);
-    m_timestamp = time(nullptr);
+    m_timestamp = t;
     portEXIT_CRITICAL(&m_valMux);
 
     NIMBLE_LOGD(LOG_TAG, "<< setValue");

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -789,9 +789,10 @@ uint16_t NimBLEClient::getMTU() {
                 if(characteristic != cVector->cend()) {
                     NIMBLE_LOGD(LOG_TAG, "Got Notification for characteristic %s", (*characteristic)->toString().c_str());
 
+                    time_t t = time(nullptr);
                     portENTER_CRITICAL(&(*characteristic)->m_valMux);
                     (*characteristic)->m_value = std::string((char *)event->notify_rx.om->om_data, event->notify_rx.om->om_len);
-                    (*characteristic)->m_timestamp = time(nullptr);
+                    (*characteristic)->m_timestamp = t;
                     portEXIT_CRITICAL(&(*characteristic)->m_valMux);
 
                     if ((*characteristic)->m_notifyCallback != nullptr) {

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -447,9 +447,10 @@ std::string NimBLERemoteCharacteristic::readValue(time_t *timestamp) {
         }
     } while(rc != 0 && retryCount--);
 
+    time_t t = time(nullptr);
     portENTER_CRITICAL(&m_valMux);
     m_value = value;
-    m_timestamp = time(nullptr);
+    m_timestamp = t;
     if(timestamp != nullptr) {
         *timestamp = m_timestamp;
     }


### PR DESCRIPTION
Fix for random notify crash in ISR context when  m_timestamp = time(nullptr); was called. 

@h2zero was the brains behind this, I just tested it for him and provided crash reports. 