### PR TITLE
[NimBLEHIDDevice] Modern Apple devices require `READ_ENC` and `WRITE_ENC`

### DIFF
--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -61,13 +61,13 @@ class NimBLECharacteristic {
 public:
     NimBLEDescriptor* createDescriptor(const char* uuid,
                                        uint32_t properties =
-                                       NIMBLE_PROPERTY::READ |
-                                       NIMBLE_PROPERTY::WRITE,
+                                       NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC |
+                                       NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_ENC,
                                        uint16_t max_len = 100);
     NimBLEDescriptor* createDescriptor(const NimBLEUUID &uuid,
                                        uint32_t properties =
-                                       NIMBLE_PROPERTY::READ |
-                                       NIMBLE_PROPERTY::WRITE,
+                                       NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC |
+                                       NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_ENC,
                                        uint16_t max_len = 100);
 
     NimBLEDescriptor* getDescriptorByUUID(const char* uuid);

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -61,13 +61,13 @@ class NimBLECharacteristic {
 public:
     NimBLEDescriptor* createDescriptor(const char* uuid,
                                        uint32_t properties =
-                                       NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC |
-                                       NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_ENC,
+                                       NIMBLE_PROPERTY::READ |
+                                       NIMBLE_PROPERTY::WRITE,
                                        uint16_t max_len = 100);
     NimBLEDescriptor* createDescriptor(const NimBLEUUID &uuid,
                                        uint32_t properties =
-                                       NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC |
-                                       NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_ENC,
+                                       NIMBLE_PROPERTY::READ |
+                                       NIMBLE_PROPERTY::WRITE,
                                        uint16_t max_len = 100);
 
     NimBLEDescriptor* getDescriptorByUUID(const char* uuid);

--- a/src/NimBLEHIDDevice.cpp
+++ b/src/NimBLEHIDDevice.cpp
@@ -128,7 +128,7 @@ void NimBLEHIDDevice::hidInfo(uint8_t country, uint8_t flags) {
  * @return pointer to new input report characteristic
  */
 NimBLECharacteristic* NimBLEHIDDevice::inputReport(uint8_t reportID) {
-	NimBLECharacteristic* inputReportCharacteristic = m_hidService->createCharacteristic((uint16_t) 0x2a4d, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY | NIMBLE_PROPERTY::READ_ENC);
+	NimBLECharacteristic* inputReportCharacteristic = m_hidService->createCharacteristic((uint16_t) 0x2a4d, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY);
 	NimBLEDescriptor* inputReportDescriptor = inputReportCharacteristic->createDescriptor((uint16_t) 0x2908);
 
 	uint8_t desc1_val[] = { reportID, 0x01 };

--- a/src/NimBLEHIDDevice.cpp
+++ b/src/NimBLEHIDDevice.cpp
@@ -128,8 +128,8 @@ void NimBLEHIDDevice::hidInfo(uint8_t country, uint8_t flags) {
  * @return pointer to new input report characteristic
  */
 NimBLECharacteristic* NimBLEHIDDevice::inputReport(uint8_t reportID) {
-	NimBLECharacteristic* inputReportCharacteristic = m_hidService->createCharacteristic((uint16_t) 0x2a4d, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY);
-	NimBLEDescriptor* inputReportDescriptor = inputReportCharacteristic->createDescriptor((uint16_t) 0x2908);
+	NimBLECharacteristic* inputReportCharacteristic = m_hidService->createCharacteristic((uint16_t) 0x2a4d, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY | NIMBLE_PROPERTY::READ_ENC);
+	NimBLEDescriptor* inputReportDescriptor = inputReportCharacteristic->createDescriptor((uint16_t) 0x2908, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC);
 
 	uint8_t desc1_val[] = { reportID, 0x01 };
 	inputReportDescriptor->setValue((uint8_t*) desc1_val, 2);
@@ -144,7 +144,7 @@ NimBLECharacteristic* NimBLEHIDDevice::inputReport(uint8_t reportID) {
  */
 NimBLECharacteristic* NimBLEHIDDevice::outputReport(uint8_t reportID) {
 	NimBLECharacteristic* outputReportCharacteristic = m_hidService->createCharacteristic((uint16_t) 0x2a4d, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_NR | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::WRITE_ENC);
-	NimBLEDescriptor* outputReportDescriptor = outputReportCharacteristic->createDescriptor((uint16_t) 0x2908);
+	NimBLEDescriptor* outputReportDescriptor = outputReportCharacteristic->createDescriptor((uint16_t) 0x2908, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::WRITE_ENC);
 
 	uint8_t desc1_val[] = { reportID, 0x02 };
 	outputReportDescriptor->setValue((uint8_t*) desc1_val, 2);
@@ -159,7 +159,7 @@ NimBLECharacteristic* NimBLEHIDDevice::outputReport(uint8_t reportID) {
  */
 NimBLECharacteristic* NimBLEHIDDevice::featureReport(uint8_t reportID) {
 	NimBLECharacteristic* featureReportCharacteristic = m_hidService->createCharacteristic((uint16_t) 0x2a4d, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::WRITE_ENC);
-	NimBLEDescriptor* featureReportDescriptor = featureReportCharacteristic->createDescriptor((uint16_t) 0x2908);
+	NimBLEDescriptor* featureReportDescriptor = featureReportCharacteristic->createDescriptor((uint16_t) 0x2908, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::WRITE_ENC);
 
 	uint8_t desc1_val[] = { reportID, 0x03 };
 	featureReportDescriptor->setValue((uint8_t*) desc1_val, 2);

--- a/src/NimBLEHIDDevice.cpp
+++ b/src/NimBLEHIDDevice.cpp
@@ -128,7 +128,7 @@ void NimBLEHIDDevice::hidInfo(uint8_t country, uint8_t flags) {
  * @return pointer to new input report characteristic
  */
 NimBLECharacteristic* NimBLEHIDDevice::inputReport(uint8_t reportID) {
-	NimBLECharacteristic* inputReportCharacteristic = m_hidService->createCharacteristic((uint16_t) 0x2a4d, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY);
+	NimBLECharacteristic* inputReportCharacteristic = m_hidService->createCharacteristic((uint16_t) 0x2a4d, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY | NIMBLE_PROPERTY::READ_ENC);
 	NimBLEDescriptor* inputReportDescriptor = inputReportCharacteristic->createDescriptor((uint16_t) 0x2908);
 
 	uint8_t desc1_val[] = { reportID, 0x01 };


### PR DESCRIPTION
I noticed while evaluating the [ESP32-NimBLE-Keyboard](https://github.com/wakwak-koba/ESP32-NimBLE-Keyboard) that I ported.
I'm having trouble pairing from iOS, or I can't receive data even if pairing is successful.

As a result of various attempts, the end result is that modern Apple devices may refuse to communicate in clear text.

Specifically, in HID-Keyboard (ServiceUUID: 0x1812), it was found that READ_ENC must be specified in Report Input (CharacteristicUUID: 0x2a4d).
Furthermore, Apple devices did not receive data unless `*_ENC` was specified during `createDescriptor()`.

If adding `*_ENC` to the default value of `createDescriptor()` does not cause another problem, I think it would be more convenient to add it on the NimBLE-Arduino side, so instead of `NimHIDDevice.cpp`, Fixed the `NimBLECharacteristic.h` side.

Please let me know your opinions !