### PR TITLE
[Server][Client] Add function to set data length.

### DIFF
--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -437,6 +437,20 @@ void NimBLEClient::updateConnParams(uint16_t minInterval, uint16_t maxInterval,
 
 
 /**
+ * @brief Request an update of the data packet length.
+ * * Can only be used after a connection has been established.
+ * @param [in] tx_octets The preferred number of payload octets to use (Range 0x001B-0x00FB).
+ * @param [in] tx_time The preferred number of microseconds to use when transmitting a single packet (Range 0x0148-0x4290).
+ */
+void NimBLEServer::setDataLen(uint16_t tx_octets, uint16_t tx_time) {
+    int rc = ble_gap_set_data_len(m_conn_id, tx_octets, tx_time);
+    if(rc != 0) {
+        NIMBLE_LOGE(LOG_TAG, "Set data length error: %d, %s", rc, NimBLEUtils::returnCodeToString(rc));
+    }
+}// setDataLen
+
+
+/**
  * @brief Get detailed information about the current peer connection.
  */
 NimBLEConnInfo NimBLEClient::getConnInfo() {

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -439,15 +439,19 @@ void NimBLEClient::updateConnParams(uint16_t minInterval, uint16_t maxInterval,
 /**
  * @brief Request an update of the data packet length.
  * * Can only be used after a connection has been established.
+ * @details Sends a data length update request to the server the client is connected to.
+ * The Data Length Extension (DLE) allows to increase the Data Channel Payload from 27 bytes to up to 251 bytes.
+ * The server needs to support the Bluetooth 4.2 specifications, to be capable of DLE.
  * @param [in] tx_octets The preferred number of payload octets to use (Range 0x001B-0x00FB).
- * @param [in] tx_time The preferred number of microseconds to use when transmitting a single packet (Range 0x0148-0x4290).
  */
-void NimBLEServer::setDataLen(uint16_t tx_octets, uint16_t tx_time) {
+void NimBLEClient::setDataLen(uint16_t tx_octets) {
+    uint16_t tx_time = (tx_octets + 14) * 8;
+
     int rc = ble_gap_set_data_len(m_conn_id, tx_octets, tx_time);
     if(rc != 0) {
         NIMBLE_LOGE(LOG_TAG, "Set data length error: %d, %s", rc, NimBLEUtils::returnCodeToString(rc));
     }
-}// setDataLen
+} // setDataLen
 
 
 /**

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -68,6 +68,7 @@ public:
                                                                     uint16_t scanInterval=16, uint16_t scanWindow=16);
     void                                        updateConnParams(uint16_t minInterval, uint16_t maxInterval,
                                                                  uint16_t latency, uint16_t timeout);
+    void                                        setDataLen(uint16_t tx_octets, uint16_t tx_time);
     void                                        discoverAttributes();
     NimBLEConnInfo                              getConnInfo();
 

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -68,7 +68,7 @@ public:
                                                                     uint16_t scanInterval=16, uint16_t scanWindow=16);
     void                                        updateConnParams(uint16_t minInterval, uint16_t maxInterval,
                                                                  uint16_t latency, uint16_t timeout);
-    void                                        setDataLen(uint16_t tx_octets, uint16_t tx_time);
+    void                                        setDataLen(uint16_t tx_octets);
     void                                        discoverAttributes();
     NimBLEConnInfo                              getConnInfo();
 

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -773,22 +773,26 @@ void NimBLEServer::updateConnParams(uint16_t conn_handle,
     if(rc != 0) {
         NIMBLE_LOGE(LOG_TAG, "Update params error: %d, %s", rc, NimBLEUtils::returnCodeToString(rc));
     }
-}// updateConnParams
+} // updateConnParams
 
 
 /**
  * @brief Request an update of the data packet length.
  * * Can only be used after a connection has been established.
+ * @details Sends a data length update request to the peer.
+ * The Data Length Extension (DLE) allows to increase the Data Channel Payload from 27 bytes to up to 251 bytes.
+ * The peer needs to support the Bluetooth 4.2 specifications, to be capable of DLE.
  * @param [in] conn_handle The connection handle of the peer to send the request to.
  * @param [in] tx_octets The preferred number of payload octets to use (Range 0x001B-0x00FB).
- * @param [in] tx_time The preferred number of microseconds to use when transmitting a single packet (Range 0x0148-0x4290).
  */
-void NimBLEServer::setDataLen(uint16_t conn_handle, uint16_t tx_octets, uint16_t tx_time) {
+void NimBLEServer::setDataLen(uint16_t conn_handle, uint16_t tx_octets) {
+    uint16_t tx_time = (tx_octets + 14) * 8;
+
     int rc = ble_gap_set_data_len(conn_handle, tx_octets, tx_time);
     if(rc != 0) {
         NIMBLE_LOGE(LOG_TAG, "Set data length error: %d, %s", rc, NimBLEUtils::returnCodeToString(rc));
     }
-}// setDataLen
+} // setDataLen
 
 
 bool NimBLEServer::setIndicateWait(uint16_t conn_handle) {

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -735,7 +735,7 @@ void NimBLEServer::startAdvertising() {
  */
 void NimBLEServer::stopAdvertising() {
     NimBLEDevice::stopAdvertising();
-} // startAdvertising
+} // stopAdvertising
 
 
 /**
@@ -774,6 +774,21 @@ void NimBLEServer::updateConnParams(uint16_t conn_handle,
         NIMBLE_LOGE(LOG_TAG, "Update params error: %d, %s", rc, NimBLEUtils::returnCodeToString(rc));
     }
 }// updateConnParams
+
+
+/**
+ * @brief Request an update of the data packet length.
+ * * Can only be used after a connection has been established.
+ * @param [in] conn_handle The connection handle of the peer to send the request to.
+ * @param [in] tx_octets The preferred number of payload octets to use (Range 0x001B-0x00FB).
+ * @param [in] tx_time The preferred number of microseconds to use when transmitting a single packet (Range 0x0148-0x4290).
+ */
+void NimBLEServer::setDataLen(uint16_t conn_handle, uint16_t tx_octets, uint16_t tx_time) {
+    int rc = ble_gap_set_data_len(conn_handle, tx_octets, tx_time);
+    if(rc != 0) {
+        NIMBLE_LOGE(LOG_TAG, "Set data length error: %d, %s", rc, NimBLEUtils::returnCodeToString(rc));
+    }
+}// setDataLen
 
 
 bool NimBLEServer::setIndicateWait(uint16_t conn_handle) {

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -59,7 +59,7 @@ public:
     void                   updateConnParams(uint16_t conn_handle,
                                             uint16_t minInterval, uint16_t maxInterval,
                                             uint16_t latency, uint16_t timeout);
-    void                   setDataLen(uint16_t conn_handle, uint16_t tx_octets, uint16_t tx_time);
+    void                   setDataLen(uint16_t conn_handle, uint16_t tx_octets);
     uint16_t               getPeerMTU(uint16_t conn_id);
     std::vector<uint16_t>  getPeerDevices();
     NimBLEConnInfo         getPeerInfo(size_t index);

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -59,6 +59,7 @@ public:
     void                   updateConnParams(uint16_t conn_handle,
                                             uint16_t minInterval, uint16_t maxInterval,
                                             uint16_t latency, uint16_t timeout);
+    void                   setDataLen(uint16_t conn_handle, uint16_t tx_octets, uint16_t tx_time);
     uint16_t               getPeerMTU(uint16_t conn_id);
     std::vector<uint16_t>  getPeerDevices();
     NimBLEConnInfo         getPeerInfo(size_t index);


### PR DESCRIPTION
This allows to set the data packet length.
Either the Server or Client can perform this action.

I am not quite sure about the `tx_time` limits.
When `tx_time` is greater or equal to  0x0849 I am getting an error in the logs which says it is an invalid value:
`E NimBLEServer: "Set data length error: 530, Invalid HCI Command Parameters"`
