### PR TITLE
Add optional clearing of scan results when stopping scan.

### DIFF
--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -225,7 +225,7 @@ bool NimBLEClient::connect(const NimBLEAddress &address, bool deleteAttibutes) {
 
             case BLE_HS_EBUSY:
                 // Scan was still running, stop it and try again
-                if (!NimBLEDevice::getScan()->stop()) {
+                if (!NimBLEDevice::getScan()->stop(false)) {
                     rc = BLE_HS_EUNKNOWN;
                 }
                 break;

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -370,9 +370,11 @@ NimBLEScanResults NimBLEScan::start(uint32_t duration, bool is_continue) {
 
 /**
  * @brief Stop an in progress scan.
+ * @param [in] clear_results Only used when scanning continuously, clears leftover results if true.\n
+   NimBLEClient::connect will call with false to avoid concurrent access in edge cases. Default = true.
  * @return True if successful.
  */
-bool NimBLEScan::stop() {
+bool NimBLEScan::stop(bool clear_results) {
     NIMBLE_LOGD(LOG_TAG, ">> stop()");
 
     int rc = ble_gap_disc_cancel();
@@ -381,7 +383,7 @@ bool NimBLEScan::stop() {
         return false;
     }
 
-    if(m_maxResults == 0) {
+    if(m_maxResults == 0 && clear_results) {
         clearResults();
     }
 

--- a/src/NimBLEScan.h
+++ b/src/NimBLEScan.h
@@ -73,7 +73,7 @@ public:
     void                setLimitedOnly(bool enabled);
     void                setFilterPolicy(uint8_t filter);
     void                clearDuplicateCache();
-    bool                stop();
+    bool                stop(bool clear_results = true);
     void                clearResults();
     NimBLEScanResults   getResults();
     void                setMaxResults(uint8_t maxResults);


### PR DESCRIPTION
This resolves a possible collision when scanning is active and a call to connect to a device is made.

When the scanner is still active in a continuous scan the results may be pushed at the same time as clearing them in the call to stop scanning when attempting to connect to a device. This propses to add a parameter to the scan stop call to not clear the scan results in this scenario and may be useful for other use cases.