### PR TITLE
Define scanCompleteCB with using std::function

### DIFF
--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -282,7 +282,7 @@ bool NimBLEScan::isScanning() {
  * @param [in] is_continue Set to true to save previous scan results, false to clear them.
  * @return True if scan started or false if there was an error.
  */
-bool NimBLEScan::start(uint32_t duration, void (*scanCompleteCB)(NimBLEScanResults), bool is_continue) {
+bool NimBLEScan::start(uint32_t duration, scan_complete_callback scanCompleteCB, bool is_continue) {
     NIMBLE_LOGD(LOG_TAG, ">> start: duration=%" PRIu32, duration);
 
     // Save the callback to be invoked when the scan completes.

--- a/src/NimBLEScan.h
+++ b/src/NimBLEScan.h
@@ -27,6 +27,7 @@
 #endif
 
 #include <vector>
+#include <functional>
 
 class NimBLEDevice;
 class NimBLEScan;
@@ -55,6 +56,8 @@ private:
     std::vector<NimBLEAdvertisedDevice*> m_advertisedDevicesVector;
 };
 
+typedef std::function<void (NimBLEScanResults scanResults)> scan_complete_callback;
+
 /**
  * @brief Perform and manage %BLE scans.
  *
@@ -62,7 +65,7 @@ private:
  */
 class NimBLEScan {
 public:
-    bool                start(uint32_t duration, void (*scanCompleteCB)(NimBLEScanResults), bool is_continue = false);
+    bool                start(uint32_t duration, scan_complete_callback scanCompleteCB, bool is_continue = false);
     NimBLEScanResults   start(uint32_t duration, bool is_continue = false);
     bool                isScanning();
     void                setAdvertisedDeviceCallbacks(NimBLEAdvertisedDeviceCallbacks* pAdvertisedDeviceCallbacks, bool wantDuplicates = false);
@@ -90,7 +93,7 @@ private:
     void                onHostSync();
 
     NimBLEAdvertisedDeviceCallbacks*    m_pAdvertisedDeviceCallbacks = nullptr;
-    void                                (*m_scanCompleteCB)(NimBLEScanResults scanResults);
+    scan_complete_callback              m_scanCompleteCB;
     ble_gap_disc_params                 m_scan_params;
     bool                                m_ignoreResults;
     NimBLEScanResults                   m_scanResults;


### PR DESCRIPTION
I want to use bind for scanCompleteCB like this.
```cpp
class Controller {
  void startScan() {
    scanning = true;
    auto pScan = NimBLEDevice::getScan();
    pScan->setAdvertisedDeviceCallbacks(advDeviceCBs);
    pScan->setInterval(45);
    pScan->setWindow(15);
    Serial.println("Start scan");
    // pScan->start(scanTime, scanEndedCB);
    pScan->start(scanTime,
                 std::bind(&Core::scanEndedCB, this, std::placeholders::_1)); // <<<<<<<<<< ======== Here
  }

  void scanEndedCB(NimBLEScanResults results) {
    Serial.println("Scan Ended");
    scanning = false;
  }
};
```

Related issue: https://github.com/h2zero/NimBLE-Arduino/issues/342