### PR TITLE
Fixes compile time error in PlatformIO conversion from 'uint8_t* to non-scalar

### DIFF
--- a/examples/NimBLE_Server/NimBLE_Server.ino
+++ b/examples/NimBLE_Server/NimBLE_Server.ino
@@ -9,7 +9,6 @@
 */
 
 #include <NimBLEDevice.h>
-#include <Arduino.h>
 
 static NimBLEServer* pServer;
 

--- a/examples/NimBLE_Server/NimBLE_Server.ino
+++ b/examples/NimBLE_Server/NimBLE_Server.ino
@@ -9,6 +9,7 @@
 */
 
 #include <NimBLEDevice.h>
+#include <Arduino.h>
 
 static NimBLEServer* pServer;
 
@@ -127,7 +128,7 @@ class CharacteristicCallbacks: public NimBLECharacteristicCallbacks {
 /** Handler class for descriptor actions */    
 class DescriptorCallbacks : public NimBLEDescriptorCallbacks {
     void onWrite(NimBLEDescriptor* pDescriptor) {
-        std::string dscVal = pDescriptor->getValue();
+        std::string dscVal((char*)pDescriptor->getValue(), pDescriptor->getLength());
         Serial.print("Descriptor witten value:");
         Serial.println(dscVal.c_str());
     };


### PR DESCRIPTION
Fixes compile time error which happens in PlatformIO:

src/main.cpp: In member function 'virtual void DescriptorCallbacks::onWrite(NimBLEDescriptor*)':
src/main.cpp:155:47: error: conversion from 'uint8_t* {aka unsigned char*}' to non-scalar type 'std::__cxx11::string {aka std::__cxx11::basic_string<char>}' requested
     std::string dscVal = pDescriptor->getValue();