### PR TITLE
Remove recursive calling when fetching remote attributes.

### DIFF
--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -464,8 +464,8 @@ void NimBLEClient::updateConnParams(uint16_t minInterval, uint16_t maxInterval,
  * @param [in] tx_octets The preferred number of payload octets to use (Range 0x001B-0x00FB).
  */
 void NimBLEClient::setDataLen(uint16_t tx_octets) {
-#if defined(CONFIG_NIMBLE_CPP_IDF) && defined(ESP_IDF_VERSION) && \
-           ESP_IDF_VERSION_MAJOR >= 4 && ESP_IDF_VERSION_MINOR >= 3 && ESP_IDF_VERSION_PATCH >= 2
+#if defined(CONFIG_NIMBLE_CPP_IDF) && !defined(ESP_IDF_VERSION) || \
+  (ESP_IDF_VERSION_MAJOR * 100 + ESP_IDF_VERSION_MINOR * 10 + ESP_IDF_VERSION_PATCH) < 432
     return;
 #else
     uint16_t tx_time = (tx_octets + 14) * 8;

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -618,7 +618,11 @@ NimBLERemoteService* NimBLEClient::getService(const NimBLEUUID &uuid) {
         {
             NimBLEUUID uuid128(uuid);
             uuid128.to128();
-            return getService(uuid128);
+            if(retrieveServices(&uuid128)) {
+                if(m_servicesVector.size() > prev_size) {
+                    return m_servicesVector.back();
+                }
+            }
         } else {
             // If the request was successful but the 128 bit uuid not found
             // try again with the 16 bit uuid.
@@ -626,7 +630,11 @@ NimBLERemoteService* NimBLEClient::getService(const NimBLEUUID &uuid) {
             uuid16.to16();
             // if the uuid was 128 bit but not of the BLE base type this check will fail
             if (uuid16.bitSize() == BLE_UUID_TYPE_16) {
-                return getService(uuid16);
+                if(retrieveServices(&uuid16)) {
+                    if(m_servicesVector.size() > prev_size) {
+                        return m_servicesVector.back();
+                    }
+                }
             }
         }
     }

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -323,7 +323,11 @@ NimBLERemoteDescriptor* NimBLERemoteCharacteristic::getDescriptor(const NimBLEUU
         {
             NimBLEUUID uuid128(uuid);
             uuid128.to128();
-            return getDescriptor(uuid128);
+            if(retrieveDescriptors(&uuid128)) {
+                if(m_descriptorVector.size() > prev_size) {
+                    return m_descriptorVector.back();
+                }
+            }
         } else {
             // If the request was successful but the 128 bit uuid not found
             // try again with the 16 bit uuid.
@@ -331,7 +335,11 @@ NimBLERemoteDescriptor* NimBLERemoteCharacteristic::getDescriptor(const NimBLEUU
             uuid16.to16();
             // if the uuid was 128 bit but not of the BLE base type this check will fail
             if (uuid16.bitSize() == BLE_UUID_TYPE_16) {
-                return getDescriptor(uuid16);
+                if(retrieveDescriptors(&uuid16)) {
+                    if(m_descriptorVector.size() > prev_size) {
+                        return m_descriptorVector.back();
+                    }
+                }
             }
         }
     }

--- a/src/NimBLERemoteService.cpp
+++ b/src/NimBLERemoteService.cpp
@@ -116,7 +116,11 @@ NimBLERemoteCharacteristic* NimBLERemoteService::getCharacteristic(const NimBLEU
         {
             NimBLEUUID uuid128(uuid);
             uuid128.to128();
-            return getCharacteristic(uuid128);
+            if (retrieveCharacteristics(&uuid128)) {
+                if(m_characteristicVector.size() > prev_size) {
+                    return m_characteristicVector.back();
+                }
+            }
         } else {
             // If the request was successful but the 128 bit uuid not found
             // try again with the 16 bit uuid.
@@ -124,7 +128,11 @@ NimBLERemoteCharacteristic* NimBLERemoteService::getCharacteristic(const NimBLEU
             uuid16.to16();
             // if the uuid was 128 bit but not of the BLE base type this check will fail
             if (uuid16.bitSize() == BLE_UUID_TYPE_16) {
-                return getCharacteristic(uuid16);
+                if(retrieveCharacteristics(&uuid16)) {
+                    if(m_characteristicVector.size() > prev_size) {
+                        return m_characteristicVector.back();
+                    }
+                }
             }
         }
     }

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -323,7 +323,8 @@ NimBLEConnInfo NimBLEServer::getPeerIDInfo(uint16_t id) {
  * @param [in] param
  *
  */
-/*STATIC*/int NimBLEServer::handleGapEvent(struct ble_gap_event *event, void *arg) {
+/*STATIC*/
+int NimBLEServer::handleGapEvent(struct ble_gap_event *event, void *arg) {
     NimBLEServer* server = (NimBLEServer*)arg;
     NIMBLE_LOGD(LOG_TAG, ">> handleGapEvent: %s",
                          NimBLEUtils::gapEventToString(event->type));
@@ -782,8 +783,8 @@ void NimBLEServer::updateConnParams(uint16_t conn_handle,
  * @param [in] tx_octets The preferred number of payload octets to use (Range 0x001B-0x00FB).
  */
 void NimBLEServer::setDataLen(uint16_t conn_handle, uint16_t tx_octets) {
-#if defined(CONFIG_NIMBLE_CPP_IDF) && defined(ESP_IDF_VERSION) && \
-           ESP_IDF_VERSION_MAJOR >= 4 && ESP_IDF_VERSION_MINOR >= 3 && ESP_IDF_VERSION_PATCH >= 2
+#if defined(CONFIG_NIMBLE_CPP_IDF) && !defined(ESP_IDF_VERSION) || \
+  (ESP_IDF_VERSION_MAJOR * 100 + ESP_IDF_VERSION_MINOR * 10 + ESP_IDF_VERSION_PATCH) < 432
     return;
 #else
     uint16_t tx_time = (tx_octets + 14) * 8;


### PR DESCRIPTION
Removes looping on recursive calls to retrieve(attribute) when the attribute UUID is not found and conversions attempted.