### PR TITLE
[Breaking] Replace advertised device callbacks with scan callbacks.

### DIFF
--- a/docs/New_user_guide.md
+++ b/docs/New_user_guide.md
@@ -162,7 +162,7 @@ void app_main(void)
     NimBLEDevice::init("");
     
     NimBLEScan *pScan = NimBLEDevice::getScan();
-    NimBLEScanResults results = pScan->start(10 * 1000);
+    NimBLEScanResults results = pScan->getResults(10 * 1000);
 }
 ```
 <br/>

--- a/examples/BLE_Beacon_Scanner/BLE_Beacon_Scanner.ino
+++ b/examples/BLE_Beacon_Scanner/BLE_Beacon_Scanner.ino
@@ -135,7 +135,7 @@ void setup()
 
   BLEDevice::init("");
   pBLEScan = BLEDevice::getScan(); //create new scan
-  pBLEScan->setAdvertisedDeviceCallbacks(new MyAdvertisedDeviceCallbacks());
+  pBLEScan->setScanCallbacks(new MyAdvertisedDeviceCallbacks());
   pBLEScan->setActiveScan(true); //active scan uses more power, but get results faster
   pBLEScan->setInterval(100);
   pBLEScan->setWindow(99); // less or equal setInterval value
@@ -144,7 +144,7 @@ void setup()
 void loop()
 {
   // put your main code here, to run repeatedly:
-  BLEScanResults foundDevices = pBLEScan->start(scanTime, false);
+  BLEScanResults foundDevices = pBLEScan->getResults(scanTime, false);
   Serial.print("Devices found: ");
   Serial.println(foundDevices.getCount());
   Serial.println("Scan done!");

--- a/examples/NimBLE_Scan_Continuous/NimBLE_Scan_Continuous.ino
+++ b/examples/NimBLE_Scan_Continuous/NimBLE_Scan_Continuous.ino
@@ -11,7 +11,7 @@
 
 NimBLEScan* pBLEScan;
 
-class MyAdvertisedDeviceCallbacks: public NimBLEAdvertisedDeviceCallbacks {
+class scanCallbacks: public NimBLEScanCallbacks {
     void onResult(NimBLEAdvertisedDevice* advertisedDevice) {
       Serial.printf("Advertised Device: %s \n", advertisedDevice->toString().c_str());
     }
@@ -53,7 +53,7 @@ void setup() {
 
   pBLEScan = NimBLEDevice::getScan(); //create new scan
   // Set the callback for when devices are discovered, no duplicates.
-  pBLEScan->setAdvertisedDeviceCallbacks(new MyAdvertisedDeviceCallbacks(), false);
+  pBLEScan->setScanCallbacks(new scanCallbacks(), false);
   pBLEScan->setActiveScan(true); // Set active scanning, this will get more data from the advertiser.
   pBLEScan->setInterval(97); // How often the scan occurs / switches channels; in milliseconds,
   pBLEScan->setWindow(37);  // How long to scan during the interval; in milliseconds.
@@ -64,7 +64,7 @@ void loop() {
   // If an error occurs that stops the scan, it will be restarted here.
   if(pBLEScan->isScanning() == false) {
       // Start scan with: duration = 0 seconds(forever), no scan end callback, not a continuation of a previous scan.
-      pBLEScan->start(0, nullptr, false);
+      pBLEScan->start(0, false);
   }
 
   delay(2000);

--- a/examples/NimBLE_Scan_Whitelist/NimBLE_Scan_whitelist.ino
+++ b/examples/NimBLE_Scan_Whitelist/NimBLE_Scan_whitelist.ino
@@ -33,7 +33,7 @@ void setup() {
 
   NimBLEDevice::init("");
   pBLEScan = NimBLEDevice::getScan();
-  pBLEScan->setAdvertisedDeviceCallbacks(new MyAdvertisedDeviceCallbacks());
+  pBLEScan->setScanCallbacks(new MyAdvertisedDeviceCallbacks());
   pBLEScan->setActiveScan(true);
   pBLEScan->setInterval(100);
   pBLEScan->setFilterPolicy(BLE_HCI_SCAN_FILT_NO_WL);
@@ -41,7 +41,7 @@ void setup() {
 }
 
 void loop() {
-  NimBLEScanResults foundDevices = pBLEScan->start(scanTime, false);
+  NimBLEScanResults foundDevices = pBLEScan->getResults(scanTime, false);
   Serial.print("Devices found: ");
   Serial.println(foundDevices.getCount());
   Serial.println("Scan done!");

--- a/examples/NimBLE_Secure_Client/NimBLE_Secure_Client.ino
+++ b/examples/NimBLE_Secure_Client/NimBLE_Secure_Client.ino
@@ -36,7 +36,7 @@ void setup()
   NimBLEDevice::setSecurityAuth(true, true, true);
   NimBLEDevice::setSecurityIOCap(BLE_HS_IO_KEYBOARD_ONLY);
   NimBLEScan *pScan = NimBLEDevice::getScan();
-  NimBLEScanResults results = pScan->start(5 * 1000);
+  NimBLEScanResults results = pScan->getResults(5 * 1000);
 
   NimBLEUUID serviceUuid("ABCD");
 

--- a/examples/Refactored_original_examples/BLE_client/BLE_client.ino
+++ b/examples/Refactored_original_examples/BLE_client/BLE_client.ino
@@ -161,7 +161,7 @@ void setup() {
   // have detected a new device.  Specify that we want active scanning and start the
   // scan to run for 5 seconds.
   BLEScan* pBLEScan = BLEDevice::getScan();
-  pBLEScan->setAdvertisedDeviceCallbacks(new MyAdvertisedDeviceCallbacks());
+  pBLEScan->setScanCallbacks(new MyAdvertisedDeviceCallbacks());
   pBLEScan->setInterval(1349);
   pBLEScan->setWindow(449);
   pBLEScan->setActiveScan(true);

--- a/examples/Refactored_original_examples/BLE_scan/BLE_scan.ino
+++ b/examples/Refactored_original_examples/BLE_scan/BLE_scan.ino
@@ -32,7 +32,7 @@ void setup() {
 
   BLEDevice::init("");
   pBLEScan = BLEDevice::getScan(); //create new scan
-  pBLEScan->setAdvertisedDeviceCallbacks(new MyAdvertisedDeviceCallbacks());
+  pBLEScan->setScanCallbacks(new MyAdvertisedDeviceCallbacks());
   pBLEScan->setActiveScan(true); //active scan uses more power, but get results faster
   pBLEScan->setInterval(100);
   pBLEScan->setWindow(99);  // less or equal setInterval value
@@ -40,7 +40,7 @@ void setup() {
 
 void loop() {
   // put your main code here, to run repeatedly:
-  BLEScanResults foundDevices = pBLEScan->start(scanTime, false);
+  BLEScanResults foundDevices = pBLEScan->getResults(scanTime, false);
   Serial.print("Devices found: ");
   Serial.println(foundDevices.getCount());
   Serial.println("Scan done!");

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -175,24 +175,5 @@ private:
     std::vector<uint8_t>    m_payload;
 };
 
-/**
- * @brief A callback handler for callbacks associated device scanning.
- *
- * When we are performing a scan as a %BLE client, we may wish to know when a new device that is advertising
- * has been found.  This class can be sub-classed and registered such that when a scan is performed and
- * a new advertised device has been found, we will be called back to be notified.
- */
-class NimBLEAdvertisedDeviceCallbacks {
-public:
-    virtual ~NimBLEAdvertisedDeviceCallbacks() {}
-    /**
-     * @brief Called when a new scan result is detected.
-     *
-     * As we are scanning, we will find new devices.  When found, this call back is invoked with a reference to the
-     * device that was found.  During any individual scan, a device will only be detected one time.
-     */
-    virtual void onResult(NimBLEAdvertisedDevice* advertisedDevice) = 0;
-};
-
 #endif /* CONFIG_BT_ENABLED && CONFIG_BT_NIMBLE_ROLE_OBSERVER */
 #endif /* COMPONENTS_NIMBLEADVERTISEDDEVICE_H_ */

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -62,7 +62,7 @@
 #define BLEAddress                      NimBLEAddress
 #define BLEUtils                        NimBLEUtils
 #define BLEClientCallbacks              NimBLEClientCallbacks
-#define BLEAdvertisedDeviceCallbacks    NimBLEAdvertisedDeviceCallbacks
+#define BLEAdvertisedDeviceCallbacks    NimBLEScanCallbacks
 #define BLEScanResults                  NimBLEScanResults
 #define BLEServer                       NimBLEServer
 #define BLEService                      NimBLEService

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -35,7 +35,7 @@ NimBLEScan::NimBLEScan() {
     m_scan_params.window             = 0; // The duration of the LE scan. LE_Scan_Window shall be less than or equal to LE_Scan_Interval (units=0.625 msec)
     m_scan_params.limited            = 0; // If set, only discover devices in limited discoverable mode.
     m_scan_params.filter_duplicates  = 1; // If set, the controller ignores all but the first advertisement from each device.
-    m_pAdvertisedDeviceCallbacks     = nullptr;
+    m_pScanCallbacks                 = nullptr;
     m_ignoreResults                  = false;
     m_pTaskData                      = nullptr;
     m_duration                       = BLE_HS_FOREVER; // make sure this is non-zero in the event of a host reset
@@ -55,7 +55,8 @@ NimBLEScan::~NimBLEScan() {
  * @param [in] event The event type for this event.
  * @param [in] param Parameter data for this event.
  */
-/*STATIC*/int NimBLEScan::handleGapEvent(ble_gap_event* event, void* arg) {
+/*STATIC*/
+int NimBLEScan::handleGapEvent(ble_gap_event* event, void* arg) {
     (void)arg;
     NimBLEScan* pScan = NimBLEDevice::getScan();
 
@@ -133,7 +134,7 @@ NimBLEScan::~NimBLEScan() {
             advertisedDevice->setPayload(disc.data, disc.length_data, (isLegacyAdv &&
                                          event_type == BLE_HCI_ADV_RPT_EVTYPE_SCAN_RSP));
 
-            if (pScan->m_pAdvertisedDeviceCallbacks) {
+            if (pScan->m_pScanCallbacks) {
                 if (pScan->m_scan_params.filter_duplicates && advertisedDevice->m_callbackSent) {
                     return 0;
                 }
@@ -145,12 +146,12 @@ NimBLEScan::~NimBLEScan() {
                    advertisedDevice->getAdvType() != BLE_HCI_ADV_TYPE_ADV_SCAN_IND))
                 {
                     advertisedDevice->m_callbackSent = true;
-                    pScan->m_pAdvertisedDeviceCallbacks->onResult(advertisedDevice);
+                    pScan->m_pScanCallbacks->onResult(advertisedDevice);
 
                 // Otherwise, wait for the scan response so we can report the complete data.
                 } else if (isLegacyAdv && event_type == BLE_HCI_ADV_RPT_EVTYPE_SCAN_RSP) {
                     advertisedDevice->m_callbackSent = true;
-                    pScan->m_pAdvertisedDeviceCallbacks->onResult(advertisedDevice);
+                    pScan->m_pScanCallbacks->onResult(advertisedDevice);
                 }
                 // If not storing results and we have invoked the callback, delete the device.
                 if(pScan->m_maxResults == 0 && advertisedDevice->m_callbackSent) {
@@ -166,10 +167,10 @@ NimBLEScan::~NimBLEScan() {
 
             // If a device advertised with scan response available and it was not received
             // the callback would not have been invoked, so do it here.
-            if(pScan->m_pAdvertisedDeviceCallbacks) {
+            if(pScan->m_pScanCallbacks) {
                 for(auto &it : pScan->m_scanResults.m_advertisedDevicesVector) {
                     if(!it->m_callbackSent) {
-                        pScan->m_pAdvertisedDeviceCallbacks->onResult(it);
+                        pScan->m_pScanCallbacks->onResult(it);
                     }
                 }
             }
@@ -178,8 +179,8 @@ NimBLEScan::~NimBLEScan() {
                 pScan->clearResults();
             }
 
-            if (pScan->m_scanCompleteCB != nullptr) {
-                pScan->m_scanCompleteCB(pScan->m_scanResults);
+            if (pScan->m_pScanCallbacks != nullptr) {
+                pScan->m_pScanCallbacks->onScanEnd(pScan->m_scanResults);
             }
 
             if(pScan->m_pTaskData != nullptr) {
@@ -263,14 +264,13 @@ void NimBLEScan::setMaxResults(uint8_t maxResults) {
 
 /**
  * @brief Set the call backs to be invoked.
- * @param [in] pAdvertisedDeviceCallbacks Call backs to be invoked.
+ * @param [in] pScanCallbacks Call backs to be invoked.
  * @param [in] wantDuplicates  True if we wish to be called back with duplicates.  Default is false.
  */
-void NimBLEScan::setAdvertisedDeviceCallbacks(NimBLEAdvertisedDeviceCallbacks* pAdvertisedDeviceCallbacks,
-                                              bool wantDuplicates) {
+void NimBLEScan::setScanCallbacks(NimBLEScanCallbacks* pScanCallbacks, bool wantDuplicates) {
     setDuplicateFilter(!wantDuplicates);
-    m_pAdvertisedDeviceCallbacks = pAdvertisedDeviceCallbacks;
-} // setAdvertisedDeviceCallbacks
+    m_pScanCallbacks = pScanCallbacks;
+} // setScanCallbacks
 
 
 /**
@@ -303,15 +303,12 @@ bool NimBLEScan::isScanning() {
 /**
  * @brief Start scanning.
  * @param [in] duration The duration in milliseconds for which to scan.
- * @param [in] scanCompleteCB A function to be called when scanning has completed.
  * @param [in] is_continue Set to true to save previous scan results, false to clear them.
  * @return True if scan started or false if there was an error.
  */
-bool NimBLEScan::start(uint32_t duration, void (*scanCompleteCB)(NimBLEScanResults), bool is_continue) {
+bool NimBLEScan::start(uint32_t duration, bool is_continue) {
     NIMBLE_LOGD(LOG_TAG, ">> start: duration=%" PRIu32, duration);
 
-    // Save the callback to be invoked when the scan completes.
-    m_scanCompleteCB = scanCompleteCB;
     // Save the duration in the case that the host is reset so we can reuse it.
     m_duration = duration;
 
@@ -387,34 +384,6 @@ bool NimBLEScan::start(uint32_t duration, void (*scanCompleteCB)(NimBLEScanResul
 
 
 /**
- * @brief Start scanning and block until scanning has been completed.
- * @param [in] duration The duration in seconds for which to scan.
- * @param [in] is_continue Set to true to save previous scan results, false to clear them.
- * @return The NimBLEScanResults.
- */
-NimBLEScanResults NimBLEScan::start(uint32_t duration, bool is_continue) {
-    if(duration == 0) {
-        NIMBLE_LOGW(LOG_TAG, "Blocking scan called with duration = forever");
-    }
-
-    TaskHandle_t cur_task = xTaskGetCurrentTaskHandle();
-    ble_task_data_t taskData = {nullptr, cur_task, 0, nullptr};
-    m_pTaskData = &taskData;
-
-    if(start(duration, nullptr, is_continue)) {
-#ifdef ulTaskNotifyValueClear
-        // Clear the task notification value to ensure we block
-        ulTaskNotifyValueClear(cur_task, ULONG_MAX);
-#endif
-        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-    }
-
-    m_pTaskData = nullptr;
-    return m_scanResults;
-} // start
-
-
-/**
  * @brief Stop an in progress scan.
  * @return True if successful.
  */
@@ -431,8 +400,8 @@ bool NimBLEScan::stop() {
         clearResults();
     }
 
-    if (rc != BLE_HS_EALREADY && m_scanCompleteCB != nullptr) {
-        m_scanCompleteCB(m_scanResults);
+    if (rc != BLE_HS_EALREADY && m_pScanCallbacks != nullptr) {
+        m_pScanCallbacks->onScanEnd(m_scanResults);
     }
 
     if(m_pTaskData != nullptr) {
@@ -487,10 +456,39 @@ void NimBLEScan::onHostReset() {
 void NimBLEScan::onHostSync() {
     m_ignoreResults = false;
 
-    if(m_duration == 0 && m_pAdvertisedDeviceCallbacks != nullptr) {
-        start(m_duration, m_scanCompleteCB);
+    if(m_duration == 0 && m_pScanCallbacks != nullptr) {
+        start(0, false);
     }
 }
+
+
+/**
+ * @brief Start scanning and block until scanning has been completed.
+ * @param [in] duration The duration in seconds for which to scan.
+ * @param [in] is_continue Set to true to save previous scan results, false to clear them.
+ * @return The scan results.
+ */
+NimBLEScanResults NimBLEScan::getResults(uint32_t duration, bool is_continue) {
+    if(duration == 0) {
+        NIMBLE_LOGW(LOG_TAG, "Blocking scan called with duration = forever");
+    }
+
+    TaskHandle_t cur_task = xTaskGetCurrentTaskHandle();
+    ble_task_data_t taskData = {nullptr, cur_task, 0, nullptr};
+    m_pTaskData = &taskData;
+
+    if(start(duration, is_continue)) {
+#ifdef ulTaskNotifyValueClear
+        // Clear the task notification value to ensure we block
+        ulTaskNotifyValueClear(cur_task, ULONG_MAX);
+#endif
+        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+    }
+
+    m_pTaskData = nullptr;
+    return m_scanResults;
+} // getResults
+
 
 /**
  * @brief Get the results of the scan.


### PR DESCRIPTION
This replaces NimBLEAdvertisedDeviceCallbacks with NimBLEScanCallbacks and adds a onScanEnd callback.

The callback parameter for NimBLEScan::start has been removed and the blocking overload for NimBLEScan::start
has been replaced by an overload of NimBLEScan::getResults with the same parameters.
