### PR TITLE
[Breaking] Change all time input parameters to milliseconds.

### DIFF
--- a/src/NimBLEAdvertising.cpp
+++ b/src/NimBLEAdvertising.cpp
@@ -385,7 +385,7 @@ void NimBLEAdvertising::setScanResponseData(NimBLEAdvertisementData& advertiseme
 
 /**
  * @brief Start advertising.
- * @param [in] duration The duration, in seconds, to advertise, 0 == advertise forever.
+ * @param [in] duration The duration, in milliseconds, to advertise, 0 == advertise forever.
  * @param [in] advCompleteCB A pointer to a callback to be invoked when advertising ends.
  * @return True if advertising started successfully.
  */
@@ -422,9 +422,6 @@ bool NimBLEAdvertising::start(uint32_t duration, void (*advCompleteCB)(NimBLEAdv
 
     if(duration == 0){
         duration = BLE_HS_FOREVER;
-    }
-    else{
-        duration = duration*1000; // convert duration to milliseconds
     }
 
     m_advCompCB = advCompleteCB;

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -533,10 +533,10 @@ NimBLEConnInfo NimBLEClient::getConnInfo() {
 
 /**
  * @brief Set the timeout to wait for connection attempt to complete.
- * @param [in] time The number of seconds before timeout.
+ * @param [in] time The number of milliseconds before timeout.
  */
-void NimBLEClient::setConnectTimeout(uint8_t time) {
-    m_connectTimeout = (uint32_t)(time * 1000);
+void NimBLEClient::setConnectTimeout(uint32_t time) {
+    m_connectTimeout = time;
 } // setConnectTimeout
 
 

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -63,7 +63,7 @@ public:
     uint16_t                                    getConnId();
     uint16_t                                    getMTU();
     bool                                        secureConnection();
-    void                                        setConnectTimeout(uint8_t timeout);
+    void                                        setConnectTimeout(uint32_t timeout);
     void                                        setConnectionParams(uint16_t minInterval, uint16_t maxInterval,
                                                                     uint16_t latency, uint16_t timeout,
                                                                     uint16_t scanInterval=16, uint16_t scanWindow=16);

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -171,10 +171,11 @@ NimBLEAdvertising* NimBLEDevice::getAdvertising() {
 
 /**
  * @brief Convenience function to begin advertising.
+ * @param [in] duration The duration in milliseconds to advertise for, default = forever.
  * @return True if advertising started successfully.
  */
-bool NimBLEDevice::startAdvertising() {
-    return getAdvertising()->start();
+bool NimBLEDevice::startAdvertising(uint32_t duration) {
+    return getAdvertising()->start(duration);
 } // startAdvertising
 #  endif
 

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -152,7 +152,7 @@ public:
     static bool                  stopAdvertising();
 #  else
     static NimBLEAdvertising*    getAdvertising();
-    static bool                  startAdvertising();
+    static bool                  startAdvertising(uint32_t duration = 0);
     static bool                  stopAdvertising();
 #  endif
 #endif

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -298,7 +298,7 @@ bool NimBLEScan::isScanning() {
 
 /**
  * @brief Start scanning.
- * @param [in] duration The duration in seconds for which to scan.
+ * @param [in] duration The duration in milliseconds for which to scan.
  * @param [in] scanCompleteCB A function to be called when scanning has completed.
  * @param [in] is_continue Set to true to save previous scan results, false to clear them.
  * @return True if scan started or false if there was an error.
@@ -314,10 +314,6 @@ bool NimBLEScan::start(uint32_t duration, void (*scanCompleteCB)(NimBLEScanResul
     // If 0 duration specified then we assume a continuous scan is desired.
     if(duration == 0){
         duration = BLE_HS_FOREVER;
-    }
-    else{
-        // convert duration to milliseconds
-        duration = duration * 1000;
     }
 
     // Set the flag to ignore the results while we are deleting the vector

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -767,15 +767,16 @@ bool NimBLEServer::stopAdvertising(uint8_t inst_id) {
 } // stopAdvertising
 #endif
 
-#if !CONFIG_BT_NIMBLE_EXT_ADV|| defined(_DOXYGEN_)
+#if !CONFIG_BT_NIMBLE_EXT_ADV || defined(_DOXYGEN_)
 /**
  * @brief Start advertising.
+ * @param [in] duration The duration in milliseconds to advertise for, default = forever.
  * @return True if advertising started successfully.
- * @details Start the server advertising its existence.  This is a convenience function and is equivalent to
+ * @details Start the server advertising its existence. This is a convenience function and is equivalent to
  * retrieving the advertising object and invoking start upon it.
  */
-bool NimBLEServer::startAdvertising() {
-    return getAdvertising()->start();
+bool NimBLEServer::startAdvertising(uint32_t duration) {
+    return getAdvertising()->start(duration);
 } // startAdvertising
 #endif
 

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -60,7 +60,7 @@ public:
     bool                   stopAdvertising(uint8_t inst_id);
 #else
     NimBLEAdvertising*     getAdvertising();
-    bool                   startAdvertising();
+    bool                   startAdvertising(uint32_t duration = 0);
 #endif
     bool                   stopAdvertising();
     void                   start();


### PR DESCRIPTION
Changes all functions that accept a time parameter to use milliseconds instead of seconds.

* Adds duration input to NimBLEDevice::startAdvertising and NimBLEServer::startAdvertising.