### PR TITLE
[Breaking] Update server callbacks to use NimBLEConnInfo.

### DIFF
--- a/docs/Migration_guide.md
+++ b/docs/Migration_guide.md
@@ -55,7 +55,16 @@ not affected as the endian change is made within them.
 Creating a `BLEServer` instance is the same as original, no changes required.
 For example `BLEDevice::createServer()` will work just as it did before.
 
-`BLEServerCallbacks` (`NimBLEServerCallbacks`) has new methods for handling security operations.
+`BLEServerCallbacks` (`NimBLEServerCallbacks`) has new methods for handling security operations.  
+
+`BLEServerCallbacks::onConnect` (`NimBLEServerCallbacks::onConnect`) only has a single callback declaration which takes an additional parameter `NimBLEConnInfo & connInfo`, which has methods to get information about the connected peer.  
+> `onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo)`  
+
+`BLEServerCallbacks::onDisconnect` (`NimBLEServerCallbacks::onDisconnect`) only has a single callback declaration which takes 2 additional parameters `NimBLEConnInfo & connInfo`, which provides information about the peer and `int reason`, which gives the reason code for disconnection.  
+> `onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason)`
+
+`BLEServerCallbacks::onMtuChanged` (`NimBLEServerCallbacks::onMtuChanged`) takes the parameter `NimBLEConnInfo & connInfo` instead of `esp_ble_gatts_cb_param_t`, which has methods to get information about the connected peer.  
+
 **Note:** All callback methods have default implementations which allows the application to implement only the methods applicable.
 <br/>
 

--- a/examples/Bluetooth_5/NimBLE_extended_server/NimBLE_extended_server.ino
+++ b/examples/Bluetooth_5/NimBLE_extended_server/NimBLE_extended_server.ino
@@ -43,11 +43,11 @@ static uint8_t secondaryPhy = BLE_HCI_LE_PHY_1M;
 
 /* Handler class for server events */
 class ServerCallbacks: public NimBLEServerCallbacks {
-    void onConnect(NimBLEServer* pServer, ble_gap_conn_desc* desc) {
-        Serial.printf("Client connected:: %s\n", NimBLEAddress(desc->peer_ota_addr).toString().c_str());
+    void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) {
+        Serial.printf("Client connected:: %s\n", connInfo.getAddress().toString().c_str());
     };
 
-    void onDisconnect(NimBLEServer* pServer) {
+    void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason) {
         Serial.printf("Client disconnected - sleeping for %u seconds\n", sleepSeconds);
         esp_deep_sleep_start();
     };

--- a/examples/Bluetooth_5/NimBLE_multi_advertiser/NimBLE_multi_advertiser.ino
+++ b/examples/Bluetooth_5/NimBLE_multi_advertiser/NimBLE_multi_advertiser.ino
@@ -43,11 +43,11 @@ static uint8_t secondaryPhy = BLE_HCI_LE_PHY_1M;
 
 /* Handler class for server events */
 class ServerCallbacks: public NimBLEServerCallbacks {
-    void onConnect(NimBLEServer* pServer, ble_gap_conn_desc* desc) {
-        Serial.printf("Client connected: %s\n", NimBLEAddress(desc->peer_ota_addr).toString().c_str());
+    void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) {
+        Serial.printf("Client connected: %s\n", connInfo.getAddress().toString().c_str());
     };
 
-    void onDisconnect(NimBLEServer* pServer) {
+    void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason) {
         Serial.printf("Client disconnected\n");
         // if still advertising we won't sleep yet.
         if (!pServer->getAdvertising()->isAdvertising()) {

--- a/examples/NimBLE_Server_Whitelist/NimBLE_Server_Whitelist.ino
+++ b/examples/NimBLE_Server_Whitelist/NimBLE_Server_Whitelist.ino
@@ -20,15 +20,15 @@ uint32_t value = 0;
 
 
 class MyServerCallbacks: public NimBLEServerCallbacks {
-    void onConnect(NimBLEServer* pServer) {
+    void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) {
       deviceConnected = true;
     };
 
-    void onDisconnect(NimBLEServer* pServer, ble_gap_conn_desc* desc) {
+    void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason) {
       // Peer disconnected, add them to the whitelist
       // This allows us to use the whitelist to filter connection attempts
       // which will minimize reconnection time.
-      NimBLEDevice::whiteListAdd(NimBLEAddress(desc->peer_ota_addr));
+      NimBLEDevice::whiteListAdd(connInfo.getAddress());
       deviceConnected = false;
     }
 };

--- a/examples/Refactored_original_examples/BLE_notify/BLE_notify.ino
+++ b/examples/Refactored_original_examples/BLE_notify/BLE_notify.ino
@@ -45,11 +45,11 @@ uint32_t value = 0;
 /**  None of these are required as they will be handled by the library with defaults. **
  **                       Remove as you see fit for your needs                        */  
 class MyServerCallbacks: public BLEServerCallbacks {
-    void onConnect(BLEServer* pServer) {
+    void onConnect(BLEServer* pServer, BLEConnInfo& connInfo) {
       deviceConnected = true;
     };
 
-    void onDisconnect(BLEServer* pServer) {
+    void onDisconnect(BLEServer* pServer, BLEConnInfo& connInfo, int reason) {
       deviceConnected = false;
     }
 /***************** New - Security handled here ********************
@@ -64,7 +64,7 @@ class MyServerCallbacks: public BLEServerCallbacks {
     return true; 
   }
 
-  void onAuthenticationComplete(ble_gap_conn_desc desc){
+  void onAuthenticationComplete(BLEConnInfo& connInfo){
     Serial.println("Starting BLE work!");
   }
 /*******************************************************************/

--- a/examples/Refactored_original_examples/BLE_server_multiconnect/BLE_server_multiconnect.ino
+++ b/examples/Refactored_original_examples/BLE_server_multiconnect/BLE_server_multiconnect.ino
@@ -46,12 +46,12 @@ uint32_t value = 0;
 /**  None of these are required as they will be handled by the library with defaults. **
  **                       Remove as you see fit for your needs                        */  
 class MyServerCallbacks: public BLEServerCallbacks {
-    void onConnect(BLEServer* pServer) {
+    void onConnect(BLEServer* pServer, BLEConnInfo& connInfo) {
       deviceConnected = true;
       BLEDevice::startAdvertising();
     };
 
-    void onDisconnect(BLEServer* pServer) {
+    void onDisconnect(BLEServer* pServer, BLEConnInfo& connInfo, int reason) {
       deviceConnected = false;
     }
   /***************** New - Security handled here ********************
@@ -66,7 +66,7 @@ class MyServerCallbacks: public BLEServerCallbacks {
       return true; 
     }
 
-    void onAuthenticationComplete(ble_gap_conn_desc desc){
+    void onAuthenticationComplete(BLEConnInfo& connInfo){
       Serial.println("Starting BLE work!");
     }
   /*******************************************************************/

--- a/examples/Refactored_original_examples/BLE_uart/BLE_uart.ino
+++ b/examples/Refactored_original_examples/BLE_uart/BLE_uart.ino
@@ -47,11 +47,11 @@ uint8_t txValue = 0;
 /**  None of these are required as they will be handled by the library with defaults. **
  **                       Remove as you see fit for your needs                        */  
 class MyServerCallbacks: public BLEServerCallbacks {
-    void onConnect(BLEServer* pServer) {
+    void onConnect(BLEServer* pServer, BLEConnInfo& connInfo) {
       deviceConnected = true;
     };
 
-    void onDisconnect(BLEServer* pServer) {
+    void onDisconnect(BLEServer* pServer, BLEConnInfo& connInfo, int reason) {
       deviceConnected = false;
     }
   /***************** New - Security handled here ********************
@@ -66,7 +66,7 @@ class MyServerCallbacks: public BLEServerCallbacks {
       return true; 
     }
 
-    void onAuthenticationComplete(ble_gap_conn_desc desc){
+    void onAuthenticationComplete(BLEConnInfo& connInfo){
       Serial.println("Starting BLE work!");
     }
   /*******************************************************************/

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -78,6 +78,7 @@
 #define BLEBeacon                       NimBLEBeacon
 #define BLEEddystoneTLM                 NimBLEEddystoneTLM
 #define BLEEddystoneURL                 NimBLEEddystoneURL
+#define BLEConnInfo                     NimBLEConnInfo
 
 #ifdef CONFIG_BT_NIMBLE_MAX_CONNECTIONS
 #define NIMBLE_MAX_CONNECTIONS          CONFIG_BT_NIMBLE_MAX_CONNECTIONS

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -127,41 +127,28 @@ public:
      * @brief Handle a client connection.
      * This is called when a client connects.
      * @param [in] pServer A pointer to the %BLE server that received the client connection.
+     * @param [in] connInfo A reference to a NimBLEConnInfo instance with information
+     * about the peer connection parameters.
      */
-    virtual void onConnect(NimBLEServer* pServer);
+    virtual void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo);
 
     /**
-     * @brief Handle a client connection.
-     * This is called when a client connects.
-     * @param [in] pServer A pointer to the %BLE server that received the client connection.
-     * @param [in] desc A pointer to the connection description structure containig information
-     * about the connection parameters.
-     */
-    virtual void onConnect(NimBLEServer* pServer, ble_gap_conn_desc* desc);
-
-    /**
-     * @brief Handle a client disconnection.
-     * This is called when a client disconnects.
-     * @param [in] pServer A reference to the %BLE server that received the existing client disconnection.
-     */
-    virtual void onDisconnect(NimBLEServer* pServer);
-
-     /**
      * @brief Handle a client disconnection.
      * This is called when a client discconnects.
      * @param [in] pServer A pointer to the %BLE server that received the client disconnection.
-     * @param [in] desc A pointer to the connection description structure containing information
-     * about the connection.
+     * @param [in] connInfo A reference to a NimBLEConnInfo instance with information
+     * about the peer connection parameters.
+     * @param [in] reason The reason code for the disconnection.
      */
-    virtual void onDisconnect(NimBLEServer* pServer, ble_gap_conn_desc* desc);
+    virtual void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason);
 
-     /**
+    /**
      * @brief Called when the connection MTU changes.
      * @param [in] MTU The new MTU value.
-     * @param [in] desc A pointer to the connection description structure containing information
-     * about the connection.
+     * @param [in] connInfo A reference to a NimBLEConnInfo instance with information
+     * about the peer connection parameters.
      */
-    virtual void onMTUChange(uint16_t MTU, ble_gap_conn_desc* desc);
+    virtual void onMTUChange(uint16_t MTU, NimBLEConnInfo& connInfo);
 
     /**
      * @brief Called when a client requests a passkey for pairing.
@@ -169,15 +156,12 @@ public:
      */
     virtual uint32_t onPassKeyRequest();
 
-    //virtual void onPassKeyNotify(uint32_t pass_key);
-    //virtual bool onSecurityRequest();
-
     /**
      * @brief Called when the pairing procedure is complete.
-     * @param [in] desc A pointer to the struct containing the connection information.\n
-     * This can be used to check the status of the connection encryption/pairing.
+     * @param [in] connInfo A reference to a NimBLEConnInfo instance with information
+     * about the peer connection parameters.
      */
-    virtual void onAuthenticationComplete(ble_gap_conn_desc* desc);
+    virtual void onAuthenticationComplete(NimBLEConnInfo& connInfo);
 
     /**
      * @brief Called when using numeric comparision for pairing.


### PR DESCRIPTION
Chnage the server callback functions that receive a ble_gap_conn_desc pointer to instead receive a NimBLEConnInfo reference.

* Add a reason parameter to the disconnect callback.

* Remove connect and disconnect callback that do not receive info parameters.