### PR TITLE
add NimBLEHIDDevice::batteryLevel()

### DIFF
--- a/src/NimBLEHIDDevice.cpp
+++ b/src/NimBLEHIDDevice.cpp
@@ -203,12 +203,12 @@ void NimBLEHIDDevice::setBatteryLevel(uint8_t level) {
 /*
  * @brief Returns battery level characteristic
  * @ return battery level characteristic
- *//*
-BLECharacteristic* BLEHIDDevice::batteryLevel() {
+ */
+NimBLECharacteristic* NimBLEHIDDevice::batteryLevel() {
 	return m_batteryLevelCharacteristic;
 }
 
-
+/*
 
 BLECharacteristic*	 BLEHIDDevice::reportMap() {
 	return m_reportMapCharacteristic;

--- a/src/NimBLEHIDDevice.h
+++ b/src/NimBLEHIDDevice.h
@@ -55,7 +55,7 @@ public:
 	void	pnp(uint8_t sig, uint16_t vid, uint16_t pid, uint16_t version);
 	//NimBLECharacteristic*	hidInfo();
 	void	hidInfo(uint8_t country, uint8_t flags);
-	//NimBLECharacteristic* 	batteryLevel();
+	NimBLECharacteristic* 	batteryLevel();
 	void 	setBatteryLevel(uint8_t level);
 
 


### PR DESCRIPTION
This is needed to notify the updated battery level set with `NimBLEHIDDevice::setBatteryLevel(uint8_t level);`.
It seems pointless to set value if no `NimBLEHIDDevice::batteryLevel()->notify()` can follow.