### PR TITLE
[Breaking] Update callbacks to use NimBLEConnInfo.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,95 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_esp_pio:
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - "examples/NimBLE_Client"
+          - "examples/NimBLE_Server"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+      - name: Install platformio
+        run: |
+          python -m pip install --upgrade pip
+          pip install platformio
+      - name: Build esp PIO
+        run: |
+          mkdir -p example/lib
+          rsync -Rr . example/lib/
+          mkdir example/src
+          cat > example/platformio.ini << EOF
+            [env]
+            platform = espressif32
+            framework = arduino
+
+            [env:esp32dev]
+            board = esp32dev
+
+            [env:esp32c3]
+            board = esp32-c3-devkitm-1
+
+            [env:esp32s3]
+            board = esp32-s3-devkitc-1
+          EOF
+          cp ${{ matrix.example }}/* example/src/
+          platformio run -d example
+
+  build_arduino-esp32:
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - "examples/NimBLE_Client"
+          - "examples/NimBLE_Server"
+        variant:
+          - esp32
+          - esp32c3
+          - esp32s3
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build arduino-esp32
+        uses: arduino/compile-sketches@v1
+        with:
+          cli-version: latest
+          platforms: |
+            - name: "esp32:esp32"
+              source-url: "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json"
+              version: latest
+          fqbn: "esp32:esp32:${{ matrix.variant }}"
+          sketch-paths: ${{ matrix.example }}
+
+  build_n-able-Arduino:
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - "examples/NimBLE_Client"
+          - "examples/NimBLE_Server"
+        variant:
+          - Generic_nRF51822:chip=xxaa
+          - Generic_nRF52832
+          - Generic_nRF52833
+          - Generic_nRF52840
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build n-able Arduino
+        uses: arduino/compile-sketches@v1
+        with:
+          cli-version: latest
+          platforms: |
+            - name: "h2zero:arm-ble"
+              source-url: "https://h2zero.github.io/n-able-Arduino/package_n-able_boards_index.json"
+              version: latest
+          fqbn: "h2zero:arm-ble:${{ matrix.variant }}"
+          sketch-paths: ${{ matrix.example }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,3 +93,46 @@ jobs:
               version: latest
           fqbn: "h2zero:arm-ble:${{ matrix.variant }}"
           sketch-paths: ${{ matrix.example }}
+
+  build_n-able-pio:
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - "examples/NimBLE_Client"
+          - "examples/NimBLE_Server"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+      - name: Install platformio
+        run: |
+          python -m pip install --upgrade pip
+          pip install platformio
+      - name: Build esp PIO
+        run: |
+          mkdir -p example/lib
+          rsync -Rr . example/lib/
+          mkdir example/src
+          cat > example/platformio.ini << EOF
+            [env]
+            platform = https://github.com/h2zero/platform-n-able.git#1.0.0
+            framework = arduino
+
+            [env:generic_nrf51822_xxaa
+            board = generic_nrf51822_xxaa
+
+            [env:generic_nrf52832]
+            board = generic_nrf52832
+
+            [env:generic_nrf52833]
+            board = generic_nrf52833
+
+            [env:generic_nrf52840]
+            board = generic_nrf52840
+          EOF
+          cp ${{ matrix.example }}/* example/src/
+          platformio run -d example

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,3 +136,11 @@ jobs:
           EOF
           cp ${{ matrix.example }}/* example/src/
           platformio run -d example
+  build_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Doxygen Action
+        uses: mattnotmitt/doxygen-action@v1.9.1
+        with:
+          working-directory: 'docs/'

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = docs
+OUTPUT_DIRECTORY       = doxydocs
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -836,7 +836,7 @@ WARN_NO_PARAMDOC       = NO
 # Possible values are: NO, YES and FAIL_ON_WARNINGS.
 # The default value is: NO.
 
-WARN_AS_ERROR          = FAIL_ON_WARNINGS
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/examples/Bluetooth_5/NimBLE_extended_server/NimBLE_extended_server.ino
+++ b/examples/Bluetooth_5/NimBLE_extended_server/NimBLE_extended_server.ino
@@ -43,11 +43,11 @@ static uint8_t secondaryPhy = BLE_HCI_LE_PHY_1M;
 
 /* Handler class for server events */
 class ServerCallbacks: public NimBLEServerCallbacks {
-    void onConnect(NimBLEServer* pServer, ble_gap_conn_desc* desc) {
-        Serial.printf("Client connected:: %s\n", NimBLEAddress(desc->peer_ota_addr).toString().c_str());
+    void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) {
+        Serial.printf("Client connected:: %s\n", connInfo.getAddress().toString().c_str());
     };
 
-    void onDisconnect(NimBLEServer* pServer) {
+    void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason) {
         Serial.printf("Client disconnected - sleeping for %u seconds\n", sleepSeconds);
         esp_deep_sleep_start();
     };

--- a/examples/Bluetooth_5/NimBLE_multi_advertiser/NimBLE_multi_advertiser.ino
+++ b/examples/Bluetooth_5/NimBLE_multi_advertiser/NimBLE_multi_advertiser.ino
@@ -43,11 +43,11 @@ static uint8_t secondaryPhy = BLE_HCI_LE_PHY_1M;
 
 /* Handler class for server events */
 class ServerCallbacks: public NimBLEServerCallbacks {
-    void onConnect(NimBLEServer* pServer, ble_gap_conn_desc* desc) {
-        Serial.printf("Client connected: %s\n", NimBLEAddress(desc->peer_ota_addr).toString().c_str());
+    void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) {
+        Serial.printf("Client connected: %s\n", connInfo.getAddress().toString().c_str());
     };
 
-    void onDisconnect(NimBLEServer* pServer) {
+    void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason) {
         Serial.printf("Client disconnected\n");
         // if still advertising we won't sleep yet.
         if (!pServer->getAdvertising()->isAdvertising()) {

--- a/examples/NimBLE_Client/NimBLE_Client.ino
+++ b/examples/NimBLE_Client/NimBLE_Client.ino
@@ -71,12 +71,12 @@ class ClientCallbacks : public NimBLEClientCallbacks {
         return true;
     };
 
-    /** Pairing process complete, we can check the results in ble_gap_conn_desc */
-    void onAuthenticationComplete(ble_gap_conn_desc* desc){
-        if(!desc->sec_state.encrypted) {
+    /** Pairing process complete, we can check the results in NimBLEConnInfo */
+    void onAuthenticationComplete(NimBLEConnInfo& connInfo){
+        if(!connInfo.isEncrypted()) {
             Serial.println("Encrypt connection failed - disconnecting");
-            /** Find the client with the connection handle provided in desc */
-            NimBLEDevice::getClientByID(desc->conn_handle)->disconnect();
+            /** Find the client with the connection handle provided in connInfo */
+            NimBLEDevice::getClientByID(connInfo.getConnHandle())->disconnect();
             return;
         }
     };

--- a/examples/NimBLE_Server/NimBLE_Server.ino
+++ b/examples/NimBLE_Server/NimBLE_Server.ino
@@ -15,17 +15,9 @@ static NimBLEServer* pServer;
 /**  None of these are required as they will be handled by the library with defaults. **
  **                       Remove as you see fit for your needs                        */
 class ServerCallbacks: public NimBLEServerCallbacks {
-    void onConnect(NimBLEServer* pServer) {
-        Serial.println("Client connected");
-        Serial.println("Multi-connect support: start advertising");
-        NimBLEDevice::startAdvertising();
-    };
-    /** Alternative onConnect() method to extract details of the connection.
-     *  See: src/ble_gap.h for the details of the ble_gap_conn_desc struct.
-     */
-    void onConnect(NimBLEServer* pServer, ble_gap_conn_desc* desc) {
+    void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) {
         Serial.print("Client address: ");
-        Serial.println(NimBLEAddress(desc->peer_ota_addr).toString().c_str());
+        Serial.println(connInfo.getAddress().toString().c_str());
         /** We can use the connection handle here to ask for different connection parameters.
          *  Args: connection handle, min connection interval, max connection interval
          *  latency, supervision timeout.
@@ -33,14 +25,14 @@ class ServerCallbacks: public NimBLEServerCallbacks {
          *  Latency: number of intervals allowed to skip.
          *  Timeout: 10 millisecond increments, try for 5x interval time for best results.
          */
-        pServer->updateConnParams(desc->conn_handle, 24, 48, 0, 60);
+        pServer->updateConnParams(connInfo.getConnHandle(), 24, 48, 0, 60);
     };
-    void onDisconnect(NimBLEServer* pServer) {
+    void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason) {
         Serial.println("Client disconnected - start advertising");
         NimBLEDevice::startAdvertising();
     };
-    void onMTUChange(uint16_t MTU, ble_gap_conn_desc* desc) {
-        Serial.printf("MTU updated: %u for connection ID: %u\n", MTU, desc->conn_handle);
+    void onMTUChange(uint16_t MTU, NimBLEConnInfo& connInfo) {
+        Serial.printf("MTU updated: %u for connection ID: %u\n", MTU, connInfo.getConnHandle());
     };
 
 /********************* Security handled here **********************
@@ -59,10 +51,10 @@ class ServerCallbacks: public NimBLEServerCallbacks {
         return true;
     };
 
-    void onAuthenticationComplete(ble_gap_conn_desc* desc){
+    void onAuthenticationComplete(NimBLEConnInfo& connInfo){
         /** Check that encryption was successful, if not we disconnect the client */
-        if(!desc->sec_state.encrypted) {
-            NimBLEDevice::getServer()->disconnect(desc->conn_handle);
+        if(!connInfo.isEncrypted()) {
+            NimBLEDevice::getServer()->disconnect(connInfo.getConnHandle());
             Serial.println("Encrypt connection failed - disconnecting client");
             return;
         }
@@ -72,13 +64,13 @@ class ServerCallbacks: public NimBLEServerCallbacks {
 
 /** Handler class for characteristic actions */
 class CharacteristicCallbacks: public NimBLECharacteristicCallbacks {
-    void onRead(NimBLECharacteristic* pCharacteristic){
+    void onRead(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo){
         Serial.print(pCharacteristic->getUUID().toString().c_str());
         Serial.print(": onRead(), value: ");
         Serial.println(pCharacteristic->getValue().c_str());
     };
 
-    void onWrite(NimBLECharacteristic* pCharacteristic) {
+    void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo) {
         Serial.print(pCharacteristic->getUUID().toString().c_str());
         Serial.print(": onWrite(), value: ");
         Serial.println(pCharacteristic->getValue().c_str());
@@ -102,11 +94,11 @@ class CharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         Serial.println(str);
     };
 
-    void onSubscribe(NimBLECharacteristic* pCharacteristic, ble_gap_conn_desc* desc, uint16_t subValue) {
+    void onSubscribe(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo, uint16_t subValue) {
         String str = "Client ID: ";
-        str += desc->conn_handle;
+        str += connInfo.getConnHandle();
         str += " Address: ";
-        str += std::string(NimBLEAddress(desc->peer_ota_addr)).c_str();
+        str += connInfo.getAddress().toString().c_str();
         if(subValue == 0) {
             str += " Unsubscribed to ";
         }else if(subValue == 1) {
@@ -124,13 +116,13 @@ class CharacteristicCallbacks: public NimBLECharacteristicCallbacks {
 
 /** Handler class for descriptor actions */
 class DescriptorCallbacks : public NimBLEDescriptorCallbacks {
-    void onWrite(NimBLEDescriptor* pDescriptor) {
+    void onWrite(NimBLEDescriptor* pDescriptor, NimBLEConnInfo& connInfo) {
         std::string dscVal = pDescriptor->getValue();
         Serial.print("Descriptor witten value:");
         Serial.println(dscVal.c_str());
     };
 
-    void onRead(NimBLEDescriptor* pDescriptor) {
+    void onRead(NimBLEDescriptor* pDescriptor, NimBLEConnInfo& connInfo) {
         Serial.print(pDescriptor->getUUID().toString().c_str());
         Serial.println(" Descriptor read");
     };

--- a/examples/NimBLE_Server_Whitelist/NimBLE_Server_Whitelist.ino
+++ b/examples/NimBLE_Server_Whitelist/NimBLE_Server_Whitelist.ino
@@ -20,15 +20,15 @@ uint32_t value = 0;
 
 
 class MyServerCallbacks: public NimBLEServerCallbacks {
-    void onConnect(NimBLEServer* pServer) {
+    void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) {
       deviceConnected = true;
     };
 
-    void onDisconnect(NimBLEServer* pServer, ble_gap_conn_desc* desc) {
+    void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason) {
       // Peer disconnected, add them to the whitelist
       // This allows us to use the whitelist to filter connection attempts
       // which will minimize reconnection time.
-      NimBLEDevice::whiteListAdd(NimBLEAddress(desc->peer_ota_addr));
+      NimBLEDevice::whiteListAdd(connInfo.getAddress());
       deviceConnected = false;
     }
 };

--- a/examples/Refactored_original_examples/BLE_client/BLE_client.ino
+++ b/examples/Refactored_original_examples/BLE_client/BLE_client.ino
@@ -60,7 +60,7 @@ class MyClientCallback : public BLEClientCallbacks {
     return true;
   }
 
-  void onAuthenticationComplete(ble_gap_conn_desc desc){
+  void onAuthenticationComplete(BLEConnInfo& connInfo){
     Serial.println("Starting BLE work!");
   }
 /*******************************************************************/

--- a/examples/Refactored_original_examples/BLE_notify/BLE_notify.ino
+++ b/examples/Refactored_original_examples/BLE_notify/BLE_notify.ino
@@ -45,11 +45,11 @@ uint32_t value = 0;
 /**  None of these are required as they will be handled by the library with defaults. **
  **                       Remove as you see fit for your needs                        */  
 class MyServerCallbacks: public BLEServerCallbacks {
-    void onConnect(BLEServer* pServer) {
+    void onConnect(BLEServer* pServer, BLEConnInfo& connInfo) {
       deviceConnected = true;
     };
 
-    void onDisconnect(BLEServer* pServer) {
+    void onDisconnect(BLEServer* pServer, BLEConnInfo& connInfo, int reason) {
       deviceConnected = false;
     }
 /***************** New - Security handled here ********************
@@ -64,7 +64,7 @@ class MyServerCallbacks: public BLEServerCallbacks {
     return true; 
   }
 
-  void onAuthenticationComplete(ble_gap_conn_desc desc){
+  void onAuthenticationComplete(BLEConnInfo& connInfo){
     Serial.println("Starting BLE work!");
   }
 /*******************************************************************/

--- a/examples/Refactored_original_examples/BLE_server_multiconnect/BLE_server_multiconnect.ino
+++ b/examples/Refactored_original_examples/BLE_server_multiconnect/BLE_server_multiconnect.ino
@@ -46,12 +46,12 @@ uint32_t value = 0;
 /**  None of these are required as they will be handled by the library with defaults. **
  **                       Remove as you see fit for your needs                        */  
 class MyServerCallbacks: public BLEServerCallbacks {
-    void onConnect(BLEServer* pServer) {
+    void onConnect(BLEServer* pServer, BLEConnInfo& connInfo) {
       deviceConnected = true;
       BLEDevice::startAdvertising();
     };
 
-    void onDisconnect(BLEServer* pServer) {
+    void onDisconnect(BLEServer* pServer, BLEConnInfo& connInfo, int reason) {
       deviceConnected = false;
     }
   /***************** New - Security handled here ********************
@@ -66,7 +66,7 @@ class MyServerCallbacks: public BLEServerCallbacks {
       return true; 
     }
 
-    void onAuthenticationComplete(ble_gap_conn_desc desc){
+    void onAuthenticationComplete(BLEConnInfo& connInfo){
       Serial.println("Starting BLE work!");
     }
   /*******************************************************************/

--- a/examples/Refactored_original_examples/BLE_uart/BLE_uart.ino
+++ b/examples/Refactored_original_examples/BLE_uart/BLE_uart.ino
@@ -47,11 +47,11 @@ uint8_t txValue = 0;
 /**  None of these are required as they will be handled by the library with defaults. **
  **                       Remove as you see fit for your needs                        */  
 class MyServerCallbacks: public BLEServerCallbacks {
-    void onConnect(BLEServer* pServer) {
+    void onConnect(BLEServer* pServer, BLEConnInfo& connInfo) {
       deviceConnected = true;
     };
 
-    void onDisconnect(BLEServer* pServer) {
+    void onDisconnect(BLEServer* pServer, BLEConnInfo& connInfo, int reason) {
       deviceConnected = false;
     }
   /***************** New - Security handled here ********************
@@ -66,14 +66,14 @@ class MyServerCallbacks: public BLEServerCallbacks {
       return true; 
     }
 
-    void onAuthenticationComplete(ble_gap_conn_desc desc){
+    void onAuthenticationComplete(BLEConnInfo& connInfo){
       Serial.println("Starting BLE work!");
     }
   /*******************************************************************/
 };
 
 class MyCallbacks: public BLECharacteristicCallbacks {
-    void onWrite(BLECharacteristic *pCharacteristic) {
+    void onWrite(BLECharacteristic *pCharacteristic, BLEConnInfo& connInfo) {
       std::string rxValue = pCharacteristic->getValue();
 
       if (rxValue.length() > 0) {

--- a/examples/Refactored_original_examples/BLE_write/BLE_write.ino
+++ b/examples/Refactored_original_examples/BLE_write/BLE_write.ino
@@ -20,7 +20,7 @@
 
 
 class MyCallbacks: public BLECharacteristicCallbacks {
-    void onWrite(BLECharacteristic *pCharacteristic) {
+    void onWrite(BLECharacteristic *pCharacteristic, BLEConnInfo& connInfo) {
       std::string value = pCharacteristic->getValue();
 
       if (value.length() > 0) {

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -45,6 +45,7 @@ typedef enum {
 #include "NimBLEService.h"
 #include "NimBLEDescriptor.h"
 #include "NimBLEAttValue.h"
+#include "NimBLEConnInfo.h"
 
 #include <string>
 #include <vector>
@@ -200,14 +201,12 @@ private:
  */
 class NimBLECharacteristicCallbacks {
 public:
-    virtual      ~NimBLECharacteristicCallbacks();
-    virtual void onRead(NimBLECharacteristic* pCharacteristic);
-    virtual void onRead(NimBLECharacteristic* pCharacteristic, ble_gap_conn_desc* desc);
-    virtual void onWrite(NimBLECharacteristic* pCharacteristic);
-    virtual void onWrite(NimBLECharacteristic* pCharacteristic, ble_gap_conn_desc* desc);
+    virtual      ~NimBLECharacteristicCallbacks(){}
+    virtual void onRead(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo);
+    virtual void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo);
     virtual void onNotify(NimBLECharacteristic* pCharacteristic);
     virtual void onStatus(NimBLECharacteristic* pCharacteristic, int code);
-    virtual void onSubscribe(NimBLECharacteristic* pCharacteristic, ble_gap_conn_desc* desc, uint16_t subValue);
+    virtual void onSubscribe(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo, uint16_t subValue);
 };
 
 #endif /* CONFIG_BT_ENABLED  && CONFIG_BT_NIMBLE_ROLE_PERIPHERAL */

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -130,6 +130,7 @@ public:
     /**
      * @brief Called when disconnected from the server.
      * @param [in] pClient A pointer to the calling client object.
+     * @param [in] reason Contains the reason code for the disconnection.
      */
     virtual void onDisconnect(NimBLEClient* pClient, int reason);
 
@@ -149,7 +150,7 @@ public:
 
     /**
      * @brief Called when the pairing procedure is complete.
-     * @param [in] desc A pointer to the struct containing the connection information.\n
+     * @param [in] connInfo A reference to a NimBLEConnInfo instance containing the peer info.\n
      * This can be used to check the status of the connection encryption/pairing.
      */
     virtual void onAuthenticationComplete(NimBLEConnInfo& connInfo);

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -152,7 +152,7 @@ public:
      * @param [in] desc A pointer to the struct containing the connection information.\n
      * This can be used to check the status of the connection encryption/pairing.
      */
-    virtual void onAuthenticationComplete(ble_gap_conn_desc* desc);
+    virtual void onAuthenticationComplete(NimBLEConnInfo& connInfo);
 
     /**
      * @brief Called when using numeric comparision for pairing.

--- a/src/NimBLEConnInfo.h
+++ b/src/NimBLEConnInfo.h
@@ -9,6 +9,9 @@
 class NimBLEConnInfo {
 friend class NimBLEServer;
 friend class NimBLEClient;
+friend class NimBLECharacteristic;
+friend class NimBLEDescriptor;
+
     ble_gap_conn_desc m_desc;
     NimBLEConnInfo()                       { m_desc = {}; }
     NimBLEConnInfo(ble_gap_conn_desc desc) { m_desc = desc; }

--- a/src/NimBLEDescriptor.cpp
+++ b/src/NimBLEDescriptor.cpp
@@ -286,6 +286,7 @@ std::string NimBLEDescriptor::toString() {
 /**
  * @brief Callback function to support a read request.
  * @param [in] pDescriptor The descriptor that is the source of the event.
+ * @param [in] connInfo A reference to a NimBLEConnInfo instance containing the peer info.
  */
 void NimBLEDescriptorCallbacks::onRead(NimBLEDescriptor* pDescriptor, NimBLEConnInfo& connInfo) {
     (void)pDescriptor;
@@ -296,6 +297,7 @@ void NimBLEDescriptorCallbacks::onRead(NimBLEDescriptor* pDescriptor, NimBLEConn
 /**
  * @brief Callback function to support a write request.
  * @param [in] pDescriptor The descriptor that is the source of the event.
+ * @param [in] connInfo A reference to a NimBLEConnInfo instance containing the peer info.
  */
 void NimBLEDescriptorCallbacks::onWrite(NimBLEDescriptor* pDescriptor, NimBLEConnInfo& connInfo) {
     (void)pDescriptor;

--- a/src/NimBLEDescriptor.cpp
+++ b/src/NimBLEDescriptor.cpp
@@ -155,7 +155,7 @@ int NimBLEDescriptor::handleGapEvent(uint16_t conn_handle, uint16_t attr_handle,
 
     const ble_uuid_t *uuid;
     int rc;
-    struct ble_gap_conn_desc desc;
+    NimBLEConnInfo peerInfo;
     NimBLEDescriptor* pDescriptor = (NimBLEDescriptor*)arg;
 
     NIMBLE_LOGD(LOG_TAG, "Descriptor %s %s event", pDescriptor->getUUID().toString().c_str(),
@@ -165,14 +165,14 @@ int NimBLEDescriptor::handleGapEvent(uint16_t conn_handle, uint16_t attr_handle,
     if(ble_uuid_cmp(uuid, &pDescriptor->getUUID().getNative()->u) == 0){
         switch(ctxt->op) {
             case BLE_GATT_ACCESS_OP_READ_DSC: {
-                rc = ble_gap_conn_find(conn_handle, &desc);
+                rc = ble_gap_conn_find(conn_handle, &peerInfo.m_desc);
                 assert(rc == 0);
 
                  // If the packet header is only 8 bytes this is a follow up of a long read
                  // so we don't want to call the onRead() callback again.
                 if(ctxt->om->om_pkthdr_len > 8 ||
-                   pDescriptor->m_value.size() <= (ble_att_mtu(desc.conn_handle) - 3)) {
-                    pDescriptor->m_pCallbacks->onRead(pDescriptor);
+                   pDescriptor->m_value.size() <= (ble_att_mtu(peerInfo.getConnHandle()) - 3)) {
+                    pDescriptor->m_pCallbacks->onRead(pDescriptor, peerInfo);
                 }
 
                 ble_npl_hw_enter_critical();
@@ -182,6 +182,9 @@ int NimBLEDescriptor::handleGapEvent(uint16_t conn_handle, uint16_t attr_handle,
             }
 
             case BLE_GATT_ACCESS_OP_WRITE_DSC: {
+                rc = ble_gap_conn_find(conn_handle, &peerInfo.m_desc);
+                assert(rc == 0);
+
                 uint16_t att_max_len = pDescriptor->m_value.max_size();
 
                 if (ctxt->om->om_len > att_max_len) {
@@ -203,7 +206,7 @@ int NimBLEDescriptor::handleGapEvent(uint16_t conn_handle, uint16_t attr_handle,
                 }
 
                 pDescriptor->setValue(buf, len);
-                pDescriptor->m_pCallbacks->onWrite(pDescriptor);
+                pDescriptor->m_pCallbacks->onWrite(pDescriptor, peerInfo);
                 return 0;
             }
             default:
@@ -280,13 +283,11 @@ std::string NimBLEDescriptor::toString() {
 } // toString
 
 
-NimBLEDescriptorCallbacks::~NimBLEDescriptorCallbacks() {}
-
 /**
  * @brief Callback function to support a read request.
  * @param [in] pDescriptor The descriptor that is the source of the event.
  */
-void NimBLEDescriptorCallbacks::onRead(NimBLEDescriptor* pDescriptor) {
+void NimBLEDescriptorCallbacks::onRead(NimBLEDescriptor* pDescriptor, NimBLEConnInfo& connInfo) {
     (void)pDescriptor;
     NIMBLE_LOGD("NimBLEDescriptorCallbacks", "onRead: default");
 } // onRead
@@ -296,7 +297,7 @@ void NimBLEDescriptorCallbacks::onRead(NimBLEDescriptor* pDescriptor) {
  * @brief Callback function to support a write request.
  * @param [in] pDescriptor The descriptor that is the source of the event.
  */
-void NimBLEDescriptorCallbacks::onWrite(NimBLEDescriptor* pDescriptor) {
+void NimBLEDescriptorCallbacks::onWrite(NimBLEDescriptor* pDescriptor, NimBLEConnInfo& connInfo) {
     (void)pDescriptor;
     NIMBLE_LOGD("NimBLEDescriptorCallbacks", "onWrite: default");
 } // onWrite

--- a/src/NimBLEDescriptor.h
+++ b/src/NimBLEDescriptor.h
@@ -21,6 +21,7 @@
 #include "NimBLECharacteristic.h"
 #include "NimBLEUUID.h"
 #include "NimBLEAttValue.h"
+#include "NimBLEConnInfo.h"
 
 #include <string>
 
@@ -108,9 +109,9 @@ private:
  */
 class NimBLEDescriptorCallbacks {
 public:
-    virtual ~NimBLEDescriptorCallbacks();
-    virtual void onRead(NimBLEDescriptor* pDescriptor);
-    virtual void onWrite(NimBLEDescriptor* pDescriptor);
+    virtual ~NimBLEDescriptorCallbacks(){}
+    virtual void onRead(NimBLEDescriptor* pDescriptor, NimBLEConnInfo& connInfo);
+    virtual void onWrite(NimBLEDescriptor* pDescriptor, NimBLEConnInfo& connInfo);
 };
 
 #include "NimBLE2904.h"

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -78,6 +78,7 @@
 #define BLEBeacon                       NimBLEBeacon
 #define BLEEddystoneTLM                 NimBLEEddystoneTLM
 #define BLEEddystoneURL                 NimBLEEddystoneURL
+#define BLEConnInfo                     NimBLEConnInfo
 
 #ifdef CONFIG_BT_NIMBLE_MAX_CONNECTIONS
 #define NIMBLE_MAX_CONNECTIONS          CONFIG_BT_NIMBLE_MAX_CONNECTIONS

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -150,7 +150,8 @@ public:
                                                   int max_events = 0);
     static bool                  stopAdvertising(uint8_t inst_id);
     static bool                  stopAdvertising();
-#  else
+#  endif
+#  if !CONFIG_BT_NIMBLE_EXT_ADV || defined(_DOXYGEN_)
     static NimBLEAdvertising*    getAdvertising();
     static bool                  startAdvertising(uint32_t duration = 0);
     static bool                  stopAdvertising();

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -584,7 +584,6 @@ bool NimBLERemoteCharacteristic::setNotify(uint16_t val, notify_callback notifyC
  * @brief Subscribe for notifications or indications.
  * @param [in] notifications If true, subscribe for notifications, false subscribe for indications.
  * @param [in] notifyCallback A callback to be invoked for a notification.
- * @param [in] response If true, require a write response from the descriptor write operation.
  * If NULL is provided then no callback is performed.
  * @return false if writing to the descriptor failed.
  */

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -57,7 +57,8 @@ public:
                                             int duration = 0,
                                             int max_events = 0);
     bool                   stopAdvertising(uint8_t inst_id);
-#else
+#endif
+#  if !CONFIG_BT_NIMBLE_EXT_ADV || defined(_DOXYGEN_)
     NimBLEAdvertising*     getAdvertising();
     bool                   startAdvertising(uint32_t duration = 0);
 #endif

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -127,41 +127,28 @@ public:
      * @brief Handle a client connection.
      * This is called when a client connects.
      * @param [in] pServer A pointer to the %BLE server that received the client connection.
+     * @param [in] connInfo A reference to a NimBLEConnInfo instance with information
+     * about the peer connection parameters.
      */
-    virtual void onConnect(NimBLEServer* pServer);
+    virtual void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo);
 
     /**
-     * @brief Handle a client connection.
-     * This is called when a client connects.
-     * @param [in] pServer A pointer to the %BLE server that received the client connection.
-     * @param [in] desc A pointer to the connection description structure containig information
-     * about the connection parameters.
-     */
-    virtual void onConnect(NimBLEServer* pServer, ble_gap_conn_desc* desc);
-
-    /**
-     * @brief Handle a client disconnection.
-     * This is called when a client disconnects.
-     * @param [in] pServer A reference to the %BLE server that received the existing client disconnection.
-     */
-    virtual void onDisconnect(NimBLEServer* pServer);
-
-     /**
      * @brief Handle a client disconnection.
      * This is called when a client discconnects.
      * @param [in] pServer A pointer to the %BLE server that received the client disconnection.
-     * @param [in] desc A pointer to the connection description structure containing information
-     * about the connection.
+     * @param [in] connInfo A reference to a NimBLEConnInfo instance with information
+     * about the peer connection parameters.
+     * @param [in] reason The reason code for the disconnection.
      */
-    virtual void onDisconnect(NimBLEServer* pServer, ble_gap_conn_desc* desc);
+    virtual void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason);
 
-     /**
+    /**
      * @brief Called when the connection MTU changes.
      * @param [in] MTU The new MTU value.
-     * @param [in] desc A pointer to the connection description structure containing information
-     * about the connection.
+     * @param [in] connInfo A reference to a NimBLEConnInfo instance with information
+     * about the peer connection parameters.
      */
-    virtual void onMTUChange(uint16_t MTU, ble_gap_conn_desc* desc);
+    virtual void onMTUChange(uint16_t MTU, NimBLEConnInfo& connInfo);
 
     /**
      * @brief Called when a client requests a passkey for pairing.
@@ -169,15 +156,12 @@ public:
      */
     virtual uint32_t onPassKeyRequest();
 
-    //virtual void onPassKeyNotify(uint32_t pass_key);
-    //virtual bool onSecurityRequest();
-
     /**
      * @brief Called when the pairing procedure is complete.
-     * @param [in] desc A pointer to the struct containing the connection information.\n
-     * This can be used to check the status of the connection encryption/pairing.
+     * @param [in] connInfo A reference to a NimBLEConnInfo instance with information
+     * about the peer connection parameters.
      */
-    virtual void onAuthenticationComplete(ble_gap_conn_desc* desc);
+    virtual void onAuthenticationComplete(NimBLEConnInfo& connInfo);
 
     /**
      * @brief Called when using numeric comparision for pairing.

--- a/src/nimble/esp_port/esp-hci/src/esp_nimble_hci.c
+++ b/src/nimble/esp_port/esp-hci/src/esp_nimble_hci.c
@@ -138,7 +138,9 @@ int ble_hci_trans_hs_acl_tx(struct os_mbuf *om)
 {
     uint16_t len = 0;
     uint8_t data[MYNEWT_VAL(BLE_ACL_BUF_SIZE) + 3], rc = 0;
+#ifndef CONFIG_FREERTOS_UNICORE
     bool tx_using_nimble_core = 0;
+#endif
     /* If this packet is zero length, just free it */
     if (OS_MBUF_PKTLEN(om) == 0) {
         os_mbuf_free_chain(om);


### PR DESCRIPTION
Chnage the callback functions that receive a ble_gap_conn_desc pointer to instead receive a NimBLEConnInfo reference.

* Add a reason parameter to the server disconnect callback.

* Remove connect and disconnect callback that do not receive info parameters.

* Remove onRead and onWrite Characteristic callbacks that do not receive info parameters.

* Add info parameter to Descriptor onWrite and onRead callbacks.

* Add details to migration guide.