### PR TITLE
Add onDiscovered scan callback.

### DIFF
--- a/examples/NimBLE_active_passive_scan/NimBLE_active_passive_scan.ino
+++ b/examples/NimBLE_active_passive_scan/NimBLE_active_passive_scan.ino
@@ -1,0 +1,48 @@
+/*
+ * NimBLE Scan active/passive switching demo
+ *
+ * Demonstrates the use of the scan callbacks while alternating between passive and active scanning.
+ */
+
+#include "NimBLEDevice.h"
+int scanTime = 5 * 1000; // In milliseconds, 0 = scan forever
+BLEScan* pBLEScan;
+
+bool active = false;
+
+class scanCallbacks: public NimBLEScanCallbacks {
+
+    void onDiscovered(NimBLEAdvertisedDevice* advertisedDevice) {
+      Serial.printf("Discovered Advertised Device: %s \n", advertisedDevice->toString().c_str());
+    }
+
+    void onResult(NimBLEAdvertisedDevice* advertisedDevice) {
+      Serial.printf("Advertised Device Result: %s \n", advertisedDevice->toString().c_str());
+    }
+
+    void onScanEnd(NimBLEScanResults results){
+        Serial.println("Scan Ended");
+        active = !active;
+        pBLEScan->setActiveScan(active);
+        Serial.printf("scan start, active = %u\n", active);
+        pBLEScan->start(scanTime);
+    }
+};
+
+
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("Scanning...");
+
+  NimBLEDevice::init("");
+  pBLEScan = NimBLEDevice::getScan();
+  pBLEScan->setScanCallbacks(new scanCallbacks());
+  pBLEScan->setActiveScan(active);
+  pBLEScan->setInterval(100);
+  pBLEScan->setWindow(99);
+  pBLEScan->start(scanTime);
+}
+
+void loop() {
+}

--- a/src/NimBLEAdvertisedDevice.cpp
+++ b/src/NimBLEAdvertisedDevice.cpp
@@ -33,7 +33,7 @@ NimBLEAdvertisedDevice::NimBLEAdvertisedDevice() :
 {
     m_advType          = 0;
     m_rssi             = -9999;
-    m_callbackSent     = false;
+    m_callbackSent     = 0;
     m_timestamp        = 0;
     m_advLength        = 0;
 } // NimBLEAdvertisedDevice

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -162,7 +162,7 @@ private:
     uint8_t         m_advType;
     int             m_rssi;
     time_t          m_timestamp;
-    bool            m_callbackSent;
+    uint8_t         m_callbackSent;
     uint8_t         m_advLength;
 #if CONFIG_BT_NIMBLE_EXT_ADV
     bool            m_isLegacyAdv;

--- a/src/NimBLEScan.h
+++ b/src/NimBLEScan.h
@@ -104,13 +104,23 @@ private:
 class NimBLEScanCallbacks {
 public:
     virtual ~NimBLEScanCallbacks() {}
+
     /**
-     * @brief Called when a new scan result is detected.
-     *
-     * As we are scanning, we will find new devices.  When found, this call back is invoked with a reference to the
-     * device that was found.  During any individual scan, a device will only be detected one time.
+     * @brief Called when a new device is discovered, before the scan result is received (if applicable).
+     * @param [in] advertisedDevice The device which was discovered.
+     */
+    virtual void onDiscovered(NimBLEAdvertisedDevice* advertisedDevice) {};
+
+    /**
+     * @brief Called when a new scan result is complete, including scan response data (if applicable).
+     * @param [in] advertisedDevice The device for which the complete result is available.
      */
     virtual void onResult(NimBLEAdvertisedDevice* advertisedDevice) {};
+
+    /**
+     * @brief Called when a scan operation ends.
+     * @param [in] scanResults The results of the scan that ended.
+     */
     virtual void onScanEnd(NimBLEScanResults scanResults) {};
 };
 


### PR DESCRIPTION
This adds a callback that is called when a device is initially discovered.
It is always called wether scanning in passive or active mode. This allows
for active scanning to receive device detection information in the case where
the scan response is not sent/received.

This callback is optional, the application may decide to implement it or not.