### PR TITLE
Fix pairing when already in progress.

### DIFF
--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -336,6 +336,7 @@ bool NimBLEClient::connect(const NimBLEAddress &address, bool deleteAttributes) 
  * @return True on success.
  */
 bool NimBLEClient::secureConnection() {
+    NIMBLE_LOGD(LOG_TAG, ">> secureConnection()");
     TaskHandle_t cur_task = xTaskGetCurrentTaskHandle();
     ble_task_data_t taskData = {this, cur_task, 0, nullptr};
 
@@ -345,7 +346,7 @@ bool NimBLEClient::secureConnection() {
         m_pTaskData = &taskData;
 
         int rc = NimBLEDevice::startSecurity(m_conn_id);
-        if(rc != 0){
+        if(rc != 0 && rc != BLE_HS_EALREADY){
             m_lastErr = rc;
             m_pTaskData = nullptr;
             return false;
@@ -360,9 +361,11 @@ bool NimBLEClient::secureConnection() {
 
     if(taskData.rc != 0){
         m_lastErr = taskData.rc;
+        NIMBLE_LOGE(LOG_TAG, "secureConnection: failed rc=%d", taskData.rc);
         return false;
     }
 
+    NIMBLE_LOGD(LOG_TAG, "<< secureConnection: success");
     return true;
 } // secureConnection
 


### PR DESCRIPTION
If pairing is requested before performing an action on a protected attribute pairing could fail due to already being in progress. This fix will wait for the result of the pairing process before proceeding with the action.