### PR TITLE
Revert 42201d4, app should specify response when (un)subscribing.

### DIFF
--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -616,7 +616,6 @@ bool NimBLERemoteCharacteristic::setNotify(uint16_t val, notify_callback notifyC
 
     NIMBLE_LOGD(LOG_TAG, "<< setNotify()");
 
-    response = true; // Always write with response as per Bluetooth core specification.
     return desc->writeValue((uint8_t *)&val, 2, response);
 } // setNotify
 

--- a/src/NimBLERemoteCharacteristic.h
+++ b/src/NimBLERemoteCharacteristic.h
@@ -73,8 +73,8 @@ public:
 
     bool                                           subscribe(bool notifications = true,
                                                              notify_callback notifyCallback = nullptr,
-                                                             bool response = true);
-    bool                                           unsubscribe(bool response = true);
+                                                             bool response = false);
+    bool                                           unsubscribe(bool response = false);
     bool                                           registerForNotify(notify_callback notifyCallback,
                                                                      bool notifications = true,
                                                                      bool response = true)


### PR DESCRIPTION
In some applications it is benefitial to not write to the 0x2902 descriptor with response, particulary in cases where the device sends notifications regardless of subscribing. This reverts the previous change to the behavior of the (un)subscribe call which forced writing with response, the application should decide if it's required.