### PR TITLE
Clear duplicates cache when not saving scan results an no duplicates filtering

### DIFF
--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -156,6 +156,10 @@ int NimBLEScan::handleGapEvent(ble_gap_event* event, void* arg) {
                 // If not storing results and we have invoked the callback, delete the device.
                 if(pScan->m_maxResults == 0 && advertisedDevice->m_callbackSent) {
                     pScan->erase(advertisedAddress);
+                    // Avoid ever increasing memoryuse, esp when scanning indefinitely
+                    if (!pScan->m_scan_params.filter_duplicates) {
+                        pScan->clearDuplicateCache();
+                    }
                 }
             }
 


### PR DESCRIPTION
When running indefinite scan, results should not be stored (maxResults == 0), or at least be limited (maxResult < 0xFF) as this will keep increasing memory use.
But also the duplicates cache should be cleared after callback is invoked otherwise this cache will keep increasing.