### PR TITLE
Add directed peer address parameter to advertising start.

### DIFF
--- a/src/NimBLEAdvertising.cpp
+++ b/src/NimBLEAdvertising.cpp
@@ -387,9 +387,10 @@ void NimBLEAdvertising::setScanResponseData(NimBLEAdvertisementData& advertiseme
  * @brief Start advertising.
  * @param [in] duration The duration, in seconds, to advertise, 0 == advertise forever.
  * @param [in] advCompleteCB A pointer to a callback to be invoked when advertising ends.
+ * @param [in] dirAddr The address of a peer to directly advertise to.
  * @return True if advertising started successfully.
  */
-bool NimBLEAdvertising::start(uint32_t duration, void (*advCompleteCB)(NimBLEAdvertising *pAdv)) {
+bool NimBLEAdvertising::start(uint32_t duration, void (*advCompleteCB)(NimBLEAdvertising *pAdv), NimBLEAddress* dirAddr) {
     NIMBLE_LOGD(LOG_TAG, ">> Advertising start: customAdvData: %d, customScanResponseData: %d",
                 m_customAdvData, m_customScanResponseData);
 
@@ -623,15 +624,27 @@ bool NimBLEAdvertising::start(uint32_t duration, void (*advCompleteCB)(NimBLEAdv
         m_advDataSet = true;
     }
 
+    ble_addr_t peerAddr;
+    if (dirAddr != nullptr) {
+        memcpy(&peerAddr.val, dirAddr->getNative(), 6);
+        peerAddr.type = dirAddr->getType();
+    }
+
 #if defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
-    rc = ble_gap_adv_start(NimBLEDevice::m_own_addr_type, NULL, duration,
+    rc = ble_gap_adv_start(NimBLEDevice::m_own_addr_type,
+                           (dirAddr != nullptr) ? &peerAddr : NULL,
+                           duration,
                            &m_advParams,
                            (pServer != nullptr) ? NimBLEServer::handleGapEvent :
                                                   NimBLEAdvertising::handleGapEvent,
                            (void*)this);
 #else
-    rc = ble_gap_adv_start(NimBLEDevice::m_own_addr_type, NULL, duration,
-                           &m_advParams, NimBLEAdvertising::handleGapEvent, this);
+    rc = ble_gap_adv_start(NimBLEDevice::m_own_addr_type,
+                           (dirAddr != nullptr) ? &peerAddr : NULL,
+                           duration,
+                           &m_advParams,
+                           NimBLEAdvertising::handleGapEvent,
+                           (void*)this);
 #endif
     switch(rc) {
         case 0:

--- a/src/NimBLEAdvertising.h
+++ b/src/NimBLEAdvertising.h
@@ -31,6 +31,7 @@
 /**************************/
 
 #include "NimBLEUUID.h"
+#include "NimBLEAddress.h"
 
 #include <vector>
 
@@ -90,7 +91,7 @@ public:
     void addServiceUUID(const NimBLEUUID &serviceUUID);
     void addServiceUUID(const char* serviceUUID);
     void removeServiceUUID(const NimBLEUUID &serviceUUID);
-    bool start(uint32_t duration = 0, void (*advCompleteCB)(NimBLEAdvertising *pAdv) = nullptr);
+    bool start(uint32_t duration = 0, void (*advCompleteCB)(NimBLEAdvertising *pAdv) = nullptr, NimBLEAddress* dirAddr = nullptr);
     bool stop();
     void setAppearance(uint16_t appearance);
     void setName(const std::string &name);


### PR DESCRIPTION
Adds a parameter to NimBLEAdvertising::start to take the peer address for use with directed advertising.

Fixes #501 