### PR TITLE
Set manufacturer data directly instead of converting from string

### DIFF
--- a/src/NimBLEAdvertising.cpp
+++ b/src/NimBLEAdvertising.cpp
@@ -160,7 +160,8 @@ void NimBLEAdvertising::setManufacturerData(const std::string &data) {
  * @brief Set the advertised manufacturer data.
  * @param [in] data The data to advertise.
  */
-void NimBLEAdvertising::setManufacturerData(const std::vector<uint8_t> &m_mfgData) {
+void NimBLEAdvertising::setManufacturerData(const std::vector<uint8_t> &data) {
+    m_mfgData = data;
     m_advData.mfg_data = &m_mfgData[0];
     m_advData.mfg_data_len = m_mfgData.size();
     m_advDataSet = false;
@@ -839,6 +840,18 @@ void NimBLEAdvertisementData::setManufacturerData(const std::string &data) {
     cdata[0] = data.length() + 1;
     cdata[1] = BLE_HS_ADV_TYPE_MFG_DATA ;  // 0xff
     addData(std::string(cdata, 2) + data);
+} // setManufacturerData
+
+
+/**
+ * @brief Set manufacturer specific data.
+ * @param [in] data The manufacturer data to advertise.
+ */
+void NimBLEAdvertisementData::setManufacturerData(const std::vector<uint8_t> &data) {
+    char cdata[2];
+    cdata[0] = data.size() + 1;
+    cdata[1] = BLE_HS_ADV_TYPE_MFG_DATA ;  // 0xff
+    addData(std::string(cdata, 2) + std::string((char*)&data[0], data.size()));
 } // setManufacturerData
 
 

--- a/src/NimBLEAdvertising.cpp
+++ b/src/NimBLEAdvertising.cpp
@@ -157,6 +157,17 @@ void NimBLEAdvertising::setManufacturerData(const std::string &data) {
 
 
 /**
+ * @brief Set the advertised manufacturer data.
+ * @param [in] data The data to advertise.
+ */
+void NimBLEAdvertising::setManufacturerData(const std::vector<uint8_t> &m_mfgData) {
+    m_advData.mfg_data = &m_mfgData[0];
+    m_advData.mfg_data_len = m_mfgData.size();
+    m_advDataSet = false;
+} // setManufacturerData
+
+
+/**
  * @brief Set the advertised URI.
  * @param [in] uri The URI to advertise.
  */

--- a/src/NimBLEAdvertising.h
+++ b/src/NimBLEAdvertising.h
@@ -59,6 +59,7 @@ public:
     void setCompleteServices32(const std::vector<NimBLEUUID> &v_uuid);
     void setFlags(uint8_t);
     void setManufacturerData(const std::string &data);
+    void setManufacturerData(const std::vector<uint8_t> &m_mfgData);
     void setURI(const std::string &uri);
     void setName(const std::string &name);
     void setPartialServices(const NimBLEUUID &uuid);
@@ -96,6 +97,7 @@ public:
     void setAppearance(uint16_t appearance);
     void setName(const std::string &name);
     void setManufacturerData(const std::string &data);
+    void setManufacturerData(const std::vector<uint8_t> &m_mfgData);
     void setURI(const std::string &uri);
     void setServiceData(const NimBLEUUID &uuid, const std::string &data);
     void setAdvertisementType(uint8_t adv_type);

--- a/src/NimBLEAdvertising.h
+++ b/src/NimBLEAdvertising.h
@@ -59,7 +59,7 @@ public:
     void setCompleteServices32(const std::vector<NimBLEUUID> &v_uuid);
     void setFlags(uint8_t);
     void setManufacturerData(const std::string &data);
-    void setManufacturerData(const std::vector<uint8_t> &m_mfgData);
+    void setManufacturerData(const std::vector<uint8_t> &data);
     void setURI(const std::string &uri);
     void setName(const std::string &name);
     void setPartialServices(const NimBLEUUID &uuid);
@@ -97,7 +97,7 @@ public:
     void setAppearance(uint16_t appearance);
     void setName(const std::string &name);
     void setManufacturerData(const std::string &data);
-    void setManufacturerData(const std::vector<uint8_t> &m_mfgData);
+    void setManufacturerData(const std::vector<uint8_t> &data);
     void setURI(const std::string &uri);
     void setServiceData(const NimBLEUUID &uuid, const std::string &data);
     void setAdvertisementType(uint8_t adv_type);


### PR DESCRIPTION
For my purposes, I found it useful to be able to directly input integers into manufacturer data, so I created this PR to allow me to do so. It works perfectly on my application (ESP32 DEVKIT V1).