### PR TITLE
Set service handle in getHandle function if not set already.

### DIFF
--- a/src/NimBLEService.cpp
+++ b/src/NimBLEService.cpp
@@ -247,6 +247,9 @@ bool NimBLEService::start() {
  * @return The handle associated with this service.
  */
 uint16_t NimBLEService::getHandle() {
+    if (m_handle == NULL_HANDLE) {
+        ble_gatts_find_svc(&getUUID().getNative()->u, &m_handle);
+    }
     return m_handle;
 } // getHandle
 


### PR DESCRIPTION
If a service has been created and started but not yet added to the gatt server then the call to getHandle will result in and invalid handle. This adds a call to set the handle value in the getHandle function.

#541 