### PR TITLE
Added nimble_port_freertos_get_hs_hwm() visibility for ESP32 platform

### DIFF
--- a/src/nimble/porting/npl/freertos/include/nimble/nimble_port_freertos.h
+++ b/src/nimble/porting/npl/freertos/include/nimble/nimble_port_freertos.h
@@ -50,6 +50,7 @@ esp_err_t esp_nimble_disable(void);
 
 void nimble_port_freertos_init(TaskFunction_t host_task_fn);
 void nimble_port_freertos_deinit(void);
+UBaseType_t nimble_port_freertos_get_hs_hwm(void);
 
 #if CONFIG_NIMBLE_STACK_USE_MEM_POOLS
 void npl_freertos_funcs_init(void);
@@ -60,7 +61,6 @@ struct npl_funcs_t * npl_freertos_funcs_get(void);
 
 #ifndef ESP_PLATFORM
 UBaseType_t nimble_port_freertos_get_ll_hwm(void);
-UBaseType_t nimble_port_freertos_get_hs_hwm(void);
 #endif
 
 #ifdef __cplusplus

--- a/src/nimble/porting/npl/freertos/src/nimble_port_freertos.c
+++ b/src/nimble/porting/npl/freertos/src/nimble_port_freertos.c
@@ -43,6 +43,12 @@ static StaticTask_t hs_xTaskBuffer;
 
 static TaskHandle_t host_task_h = NULL;
 
+UBaseType_t nimble_port_freertos_get_hs_hwm(void) {
+    if (host_task_h == NULL)
+        return 0;
+    return uxTaskGetStackHighWaterMark(host_task_h);
+}
+
 #ifdef ESP_PLATFORM
 /**
  * @brief esp_nimble_enable - Initialize the NimBLE host
@@ -121,14 +127,9 @@ nimble_port_freertos_deinit(void)
 UBaseType_t
 nimble_port_freertos_get_ll_hwm(void)
 {
+    if (ll_task_h == NULL)
+        return 0;
     return uxTaskGetStackHighWaterMark(ll_task_h);
 }
 #endif
-
-UBaseType_t
-nimble_port_freertos_get_hs_hwm(void)
-{
-    return uxTaskGetStackHighWaterMark(host_task_h);
-}
-
 #endif //ESP_PLATFORM


### PR DESCRIPTION
Added ability to track nimble_host task free stack for ESP32 and fixed wrong values in case of uninitialized BLE stack 