### PR TITLE
Fix Error in converting EddystoneTLM negative temperatures to float

### DIFF
--- a/src/NimBLEEddystoneTLM.cpp
+++ b/src/NimBLEEddystoneTLM.cpp
@@ -81,7 +81,7 @@ uint16_t NimBLEEddystoneTLM::getVolt() {
  * @return The temperature value.
  */
 float NimBLEEddystoneTLM::getTemp() {
-    return ENDIAN_CHANGE_U16(m_eddystoneData.temp) / 256.0f;
+    return (int16_t)ENDIAN_CHANGE_U16(m_eddystoneData.temp) / 256.0f;
 } // getTemp
 
 /**
@@ -203,7 +203,7 @@ void NimBLEEddystoneTLM::setVolt(uint16_t volt) {
  * @param [in] temp The temperature value.
  */
 void NimBLEEddystoneTLM::setTemp(float temp) {
-    m_eddystoneData.temp = (uint16_t)temp;
+    m_eddystoneData.temp = ENDIAN_CHANGE_U16((int16_t)(temp * 256.0f));
 } // setTemp
 
 


### PR DESCRIPTION
In `NimBLEEddystoneTLM.cpp`, there is an issue when receiving negative numbers for temperature readings and when setting the temperature.

For example, a temperature of -0.1°C is incorrectly converted to approximately 256°C.

To address this issue, we made the following changes:

```cpp
/**
 * @brief Set the temperature to advertise.
 * @param [in] temp The temperature value.
 */
void NimBLEEddystoneTLM::setTemp(float temp) {
-  m_eddystoneData.temp = (uint16_t)temp;
+  m_eddystoneData.temp = ENDIAN_CHANGE_U16((int16_t)(temp * 256.0f));
} // setTemp

/**
 * @brief Get the temperature being advertised.
 * @return The temperature value.
 */
float NimBLEEddystoneTLM::getTemp() {
-  return ENDIAN_CHANGE_U16(m_eddystoneData.temp) / 256.0f;
+  return (int16_t)ENDIAN_CHANGE_U16(m_eddystoneData.temp) / 256.0f;
} // getTemp
```

I am a colleague of Giovanni, who opened the issue #675 

Thank you for considering this fix.