### PR TITLE
Remove IPC calls in the esp32 HCI.

### DIFF
--- a/src/nimble/esp_port/esp-hci/src/esp_nimble_hci.c
+++ b/src/nimble/esp_port/esp-hci/src/esp_nimble_hci.c
@@ -17,11 +17,6 @@
 #include <esp_bt.h>
 #include <freertos/semphr.h>
 #include "../include/esp_compiler.h"
-/* IPC is used to improve performance when calls come from a processor not running the NimBLE stack */
-/* but does not exist for solo */
-#ifndef CONFIG_FREERTOS_UNICORE
-  #include "esp_ipc.h"
-#endif
 
 #define NIMBLE_VHCI_TIMEOUT_MS  2000
 #define BLE_HCI_EVENT_HDR_LEN               (2)
@@ -72,15 +67,6 @@ void ble_hci_trans_cfg_hs(ble_hci_trans_rx_cmd_fn *cmd_cb,
     ble_hci_rx_acl_hs_arg = acl_arg;
 }
 
-/* Added; Called from the core NimBLE is running on, not used for unicore */
-#ifndef CONFIG_FREERTOS_UNICORE
-void ble_hci_trans_hs_cmd_tx_on_core(void *arg)
-{
-    // Ugly but necessary as the arduino core does not provide enough IPC stack for variables.
-    esp_vhci_host_send_packet((uint8_t*)arg, *((uint8_t*)arg + 3) + 1 + BLE_HCI_CMD_HDR_LEN);
-}
-#endif
-
 /* Modified to use ipc calls in arduino to correct performance issues */
 int ble_hci_trans_hs_cmd_tx(uint8_t *cmd)
 {
@@ -95,17 +81,7 @@ int ble_hci_trans_hs_cmd_tx(uint8_t *cmd)
     }
 
     if (xSemaphoreTake(vhci_send_sem, NIMBLE_VHCI_TIMEOUT_MS / portTICK_PERIOD_MS) == pdTRUE) {
-/* esp_ipc_call_blocking does not exist for solo */
-#ifndef CONFIG_FREERTOS_UNICORE
-        if (xPortGetCoreID() != CONFIG_BT_NIMBLE_PINNED_TO_CORE && !xPortInIsrContext()) {
-            esp_ipc_call_blocking(CONFIG_BT_NIMBLE_PINNED_TO_CORE,
-                                  ble_hci_trans_hs_cmd_tx_on_core, cmd);
-        } else {
-            esp_vhci_host_send_packet(cmd, len);
-        }
-#else /* Unicore */
         esp_vhci_host_send_packet(cmd, len);
-#endif
     } else {
         rc = BLE_HS_ETIMEOUT_HCI;
     }
@@ -124,23 +100,12 @@ int ble_hci_trans_ll_evt_tx(uint8_t *hci_ev)
     return rc;
 }
 
-/* Added; Called from the core NimBLE is running on, not used for unicore */
-#ifndef CONFIG_FREERTOS_UNICORE
-void ble_hci_trans_hs_acl_tx_on_core(void *arg)
-{
-    // Ugly but necessary as the arduino core does not provide enough IPC stack for variables.
-    esp_vhci_host_send_packet((uint8_t*)arg + 2, *(uint16_t*)arg);
-}
-#endif
-
 /* Modified to use ipc calls in arduino to correct performance issues */
 int ble_hci_trans_hs_acl_tx(struct os_mbuf *om)
 {
     uint16_t len = 0;
     uint8_t data[MYNEWT_VAL(BLE_ACL_BUF_SIZE) + 3], rc = 0;
-#ifndef CONFIG_FREERTOS_UNICORE
-    bool tx_using_nimble_core = 0;
-#endif
+
     /* If this packet is zero length, just free it */
     if (OS_MBUF_PKTLEN(om) == 0) {
         os_mbuf_free_chain(om);
@@ -152,35 +117,11 @@ int ble_hci_trans_hs_acl_tx(struct os_mbuf *om)
     }
 
     len = 1 + OS_MBUF_PKTLEN(om);
-/* Don't check core ID if unicore */
-#ifndef CONFIG_FREERTOS_UNICORE
-    tx_using_nimble_core = xPortGetCoreID() != CONFIG_BT_NIMBLE_PINNED_TO_CORE;
-    if (tx_using_nimble_core && !xPortInIsrContext()) {
-        data[0] = len;
-        data[1] = (len >> 8);
-        data[2] = BLE_HCI_UART_H4_ACL;
-        os_mbuf_copydata(om, 0, OS_MBUF_PKTLEN(om), &data[3]);
-    } else {
-        data[0] = BLE_HCI_UART_H4_ACL;
-        os_mbuf_copydata(om, 0, OS_MBUF_PKTLEN(om), &data[1]);
-    }
-#else /* Unicore */
     data[0] = BLE_HCI_UART_H4_ACL;
     os_mbuf_copydata(om, 0, OS_MBUF_PKTLEN(om), &data[1]);
-#endif
 
     if (xSemaphoreTake(vhci_send_sem, NIMBLE_VHCI_TIMEOUT_MS / portTICK_PERIOD_MS) == pdTRUE) {
-/* esp_ipc_call_blocking does not exist for solo */
-#ifndef CONFIG_FREERTOS_UNICORE
-        if (tx_using_nimble_core && !xPortInIsrContext()) {
-            esp_ipc_call_blocking(CONFIG_BT_NIMBLE_PINNED_TO_CORE,
-                                  ble_hci_trans_hs_acl_tx_on_core, data);
-        } else {
-            esp_vhci_host_send_packet(data, len);
-        }
-#else /* Unicore */
         esp_vhci_host_send_packet(data, len);
-#endif
     } else {
         rc = BLE_HS_ETIMEOUT_HCI;
     }


### PR DESCRIPTION
This removes code that was used in the past to work around an odd delay when starting advertising. The delay does not appear to exist anymore with the newer Arduino cores and has now started causing issues therefore it should be removed.

Fixes #676