### PR TITLE
[BREAKING] Use an array to manage created client instances.

### DIFF
--- a/examples/NimBLE_Client/NimBLE_Client.ino
+++ b/examples/NimBLE_Client/NimBLE_Client.ino
@@ -129,7 +129,7 @@ bool connectToServer() {
     NimBLEClient* pClient = nullptr;
 
     /** Check if we have a client we should reuse first **/
-    if(NimBLEDevice::getClientListSize()) {
+    if(NimBLEDevice::getCreatedClientCount()) {
         /** Special case when we already know this device, we send false as the
          *  second argument in connect() to prevent refreshing the service database.
          *  This saves considerable time and power.
@@ -152,7 +152,7 @@ bool connectToServer() {
 
     /** No client to reuse? Create a new one. */
     if(!pClient) {
-        if(NimBLEDevice::getClientListSize() >= NIMBLE_MAX_CONNECTIONS) {
+        if(NimBLEDevice::getCreatedClientCount() >= NIMBLE_MAX_CONNECTIONS) {
             Serial.println("Max clients reached - no more connections available");
             return false;
         }

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -45,9 +45,7 @@
 #  include "esp_bt.h"
 #endif
 
-#include <map>
 #include <string>
-#include <list>
 
 #define BLEDevice                       NimBLEDevice
 #define BLEClient                       NimBLEClient
@@ -166,8 +164,7 @@ public:
     static NimBLEClient*    getClientByID(uint16_t conn_id);
     static NimBLEClient*    getClientByPeerAddress(const NimBLEAddress &peer_addr);
     static NimBLEClient*    getDisconnectedClient();
-    static size_t           getClientListSize();
-    static std::list<NimBLEClient*>* getClientList();
+    static size_t           getCreatedClientCount();
 #endif
 
 #if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL) || defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
@@ -221,21 +218,22 @@ private:
 #  endif
 #endif
 
-#if defined( CONFIG_BT_NIMBLE_ROLE_CENTRAL)
-    static std::list <NimBLEClient*>  m_cList;
-#endif
-    static std::list <NimBLEAddress>  m_ignoreList;
+    static std::vector<NimBLEAddress> m_ignoreList;
     static uint32_t                   m_passkey;
     static ble_gap_event_listener     m_listener;
     static gap_event_handler          m_customGapHandler;
     static uint8_t                    m_own_addr_type;
+    static std::vector<NimBLEAddress> m_whiteList;
 #ifdef ESP_PLATFORM
 #  ifdef CONFIG_BTDM_BLE_SCAN_DUPL
     static uint16_t                   m_scanDuplicateSize;
     static uint8_t                    m_scanFilterMode;
 #  endif
 #endif
-    static std::vector<NimBLEAddress> m_whiteList;
+
+#if defined( CONFIG_BT_NIMBLE_ROLE_CENTRAL)
+    static std::array<NimBLEClient*, NIMBLE_MAX_CONNECTIONS>  m_pClients;
+#endif
 };
 
 


### PR DESCRIPTION
* Replaces the use of std::list with a fixed array to track and manage created client instances.
* Removes: NimBLEDevice::getClientList
* Replaces: NimBLEDevice::getClientListSize with NimBLEDevice::getCreatedClientCount