### PR TITLE
v1.4.2: Allow dynamically change advertising data

### DIFF
--- a/src/NimBLEAdvertising.cpp
+++ b/src/NimBLEAdvertising.cpp
@@ -386,6 +386,22 @@ void NimBLEAdvertising::clearData() {
 } // clearData
 
 /**
+ * @brief Refresh advertsing data dynamically without stop/start cycle.
+ * For instance allows refreshing manufacturer data dynamically.
+ *
+ * @return True if the data was set successfully.
+ * @details If scan response is enabled it will be refreshed as well.
+ */
+bool NimBLEAdvertising::refreshAdvertisingData() {
+    bool success = setAdvertisementData(m_advData);
+    if (m_scanResp) {
+        success = setScanResponseData(m_scanData);
+    }
+
+    return success;
+} // refreshAdvertisingData
+
+/**
  * @brief Add a service uuid to exposed list of services.
  * @param [in] serviceUUID The UUID of the service to expose.
  * @return True if the service was added successfully.

--- a/src/NimBLEAdvertising.h
+++ b/src/NimBLEAdvertising.h
@@ -67,6 +67,7 @@ class NimBLEAdvertising {
     const NimBLEAdvertisementData& getAdvertisementData();
     const NimBLEAdvertisementData& getScanData();
     void                           clearData();
+    bool                           refreshAdvertisingData();
 
     bool addServiceUUID(const NimBLEUUID& serviceUUID);
     bool addServiceUUID(const char* serviceUUID);


### PR DESCRIPTION
This small change allows dynamically changing advertising data without a stop/start cycle. 
I found it useful for changing the manufacturing data (for instance) frequently without affecting device's ability to be connected to or discovered. 
`refreshAdvertisingData()` should be called after methods that alter the data, e.g. `setManufacturerData(..)`