### PR TITLE
Add asynchronous client connect and MTU exchange.

### DIFF
--- a/examples/NimBLE_Async_Client/NimBLE_Async_Client.ino
+++ b/examples/NimBLE_Async_Client/NimBLE_Async_Client.ino
@@ -1,0 +1,84 @@
+
+/**
+ *  NimBLE_Async_client Demo:
+ *
+ *  Demonstrates asynchronous client operations.
+ *
+ *  Created: on November 4, 2024
+ *      Author: H2zero
+ *
+ */
+
+#include <NimBLEDevice.h>
+
+static constexpr uint32_t scanTimeMs = 5 * 1000;
+
+class ClientCallbacks : public NimBLEClientCallbacks {
+    void onConnect(NimBLEClient* pClient) {
+        Serial.printf("Connected to: %s\n", pClient->getPeerAddress().toString().c_str());
+    }
+
+    void onDisconnect(NimBLEClient* pClient, int reason) {
+        Serial.printf("%s Disconnected, reason = %d - Starting scan\n", pClient->getPeerAddress().toString().c_str(), reason);
+        NimBLEDevice::getScan()->start(scanTimeMs);
+    }
+} clientCB;
+
+class scanCallbacks : public NimBLEScanCallbacks {
+    void onResult(NimBLEAdvertisedDevice* advertisedDevice) {
+        Serial.printf("Advertised Device found: %s\n", advertisedDevice->toString().c_str());
+        if (advertisedDevice->haveName() && advertisedDevice->getName() == "NimBLE-Server") {
+            Serial.println("Found Our Device");
+
+            auto pClient = NimBLEDevice::getDisconnectedClient();
+            if (!pClient) {
+                pClient = NimBLEDevice::createClient(advertisedDevice->getAddress());
+                if (!pClient) {
+                    Serial.println("Failed to create client");
+                    return;
+                }
+            }
+
+            pClient->setClientCallbacks(&clientCB, false);
+            if (!pClient->connect(true, true, false)) { // delete attributes, async connect, no MTU exchange
+                NimBLEDevice::deleteClient(pClient);
+                Serial.println("Failed to connect");
+                return;
+            }
+        }
+    }
+
+    void onScanEnd(NimBLEScanResults results) {
+        Serial.println("Scan Ended");
+        NimBLEDevice::getScan()->start(scanTimeMs);
+    }
+};
+
+void setup() {
+    Serial.begin(115200);
+    Serial.println("Starting NimBLE Client");
+    NimBLEDevice::init("");
+    NimBLEDevice::setPower(3); /** +3db */
+
+    NimBLEScan* pScan = NimBLEDevice::getScan();
+    pScan->setScanCallbacks(new scanCallbacks());
+    pScan->setInterval(45);
+    pScan->setWindow(15);
+    pScan->setActiveScan(true);
+    pScan->start(scanTimeMs);
+}
+
+void loop() {
+    delay(1000);
+    auto pClients = NimBLEDevice::getConnectedClients();
+    if (pClients.size() == 0) {
+        return;
+    }
+
+    for (auto& pClient : pClients) {
+        Serial.println(pClient->toString().c_str());
+        NimBLEDevice::deleteClient(pClient);
+    }
+
+    NimBLEDevice::getScan()->start(scanTimeMs);
+}

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -44,9 +44,12 @@ struct BleTaskData;
  */
 class NimBLEClient {
   public:
-    bool           connect(NimBLEAdvertisedDevice* device, bool deleteAttributes = true);
-    bool           connect(const NimBLEAddress& address, bool deleteAttributes = true);
-    bool           connect(bool deleteAttributes = true);
+    bool connect(NimBLEAdvertisedDevice* device,
+                 bool                    deleteAttributes = true,
+                 bool                    asyncConnect     = false,
+                 bool                    exchangeMTU      = true);
+    bool connect(const NimBLEAddress& address, bool deleteAttributes = true, bool asyncConnect = false, bool exchangeMTU = true);
+    bool           connect(bool deleteAttributes = true, bool asyncConnect = false, bool exchangeMTU = true);
     bool           disconnect(uint8_t reason = BLE_ERR_REM_USER_CONN_TERM);
     NimBLEAddress  getPeerAddress() const;
     bool           setPeerAddress(const NimBLEAddress& address);
@@ -59,6 +62,7 @@ class NimBLEClient {
     bool           setConnection(const NimBLEConnInfo& connInfo);
     bool           setConnection(uint16_t connHandle);
     uint16_t       getMTU() const;
+    bool           exchangeMTU();
     bool           secureConnection() const;
     void           setConnectTimeout(uint32_t timeout);
     bool           setDataLen(uint16_t txOctets);
@@ -98,6 +102,7 @@ class NimBLEClient {
 
     bool       retrieveServices(const NimBLEUUID* uuidFilter = nullptr);
     static int handleGapEvent(struct ble_gap_event* event, void* arg);
+    static int exchangeMTUCb(uint16_t conn_handle, const ble_gatt_error* error, uint16_t mtu, void* arg);
     static int serviceDiscoveredCB(uint16_t                     connHandle,
                                    const struct ble_gatt_error* error,
                                    const struct ble_gatt_svc*   service,
@@ -113,6 +118,8 @@ class NimBLEClient {
     uint8_t                           m_terminateFailCount;
     bool                              m_deleteCallbacks;
     bool                              m_connEstablished;
+    bool                              m_asyncConnect;
+    bool                              m_exchangeMTU;
 # if CONFIG_BT_NIMBLE_EXT_ADV
     uint8_t m_phyMask;
 # endif
@@ -174,6 +181,14 @@ class NimBLEClientCallbacks {
      * @param [in] connInfo A reference to a NimBLEConnInfo instance with information
      */
     virtual void onIdentity(NimBLEConnInfo& connInfo);
+
+    /**
+     * @brief Called when the connection MTU changes.
+     * @param [in] pClient A pointer to the client that the MTU change is associated with.
+     * @param [in] MTU The new MTU value.
+     * about the peer connection parameters.
+     */
+    virtual void onMTUChange(NimBLEClient* pClient, uint16_t MTU);
 };
 
 #endif /* CONFIG_BT_ENABLED && CONFIG_BT_NIMBLE_ROLE_CENTRAL */

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -405,7 +405,7 @@ NimBLEClient* NimBLEDevice::getClientByPeerAddress(const NimBLEAddress& addr) {
 } // getClientPeerAddress
 
 /**
- * @brief Finds the first disconnected client in the list.
+ * @brief Finds the first disconnected client available.
  * @return A pointer to the first client object that is not connected to a peer or nullptr.
  */
 NimBLEClient* NimBLEDevice::getDisconnectedClient() {
@@ -417,6 +417,21 @@ NimBLEClient* NimBLEDevice::getDisconnectedClient() {
 
     return nullptr;
 } // getDisconnectedClient
+
+/**
+ * @brief Get a list of connected clients.
+ * @return A vector of connected client objects.
+ */
+std::vector<NimBLEClient*> NimBLEDevice::getConnectedClients() {
+    std::vector<NimBLEClient*> clients;
+    for (const auto clt : m_pClients) {
+        if (clt != nullptr && clt->isConnected()) {
+            clients.push_back(clt);
+        }
+    }
+
+    return clients;
+} // getConnectedClients
 
 # endif // #if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL)
 

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -168,13 +168,14 @@ class NimBLEDevice {
 # endif
 
 # if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL)
-    static NimBLEClient* createClient();
-    static NimBLEClient* createClient(const NimBLEAddress& peerAddress);
-    static bool          deleteClient(NimBLEClient* pClient);
-    static NimBLEClient* getClientByHandle(uint16_t connHandle);
-    static NimBLEClient* getClientByPeerAddress(const NimBLEAddress& peerAddress);
-    static NimBLEClient* getDisconnectedClient();
-    static size_t        getCreatedClientCount();
+    static NimBLEClient*              createClient();
+    static NimBLEClient*              createClient(const NimBLEAddress& peerAddress);
+    static bool                       deleteClient(NimBLEClient* pClient);
+    static NimBLEClient*              getClientByHandle(uint16_t connHandle);
+    static NimBLEClient*              getClientByPeerAddress(const NimBLEAddress& peerAddress);
+    static NimBLEClient*              getDisconnectedClient();
+    static size_t                     getCreatedClientCount();
+    static std::vector<NimBLEClient*> getConnectedClients();
 # endif
 
 # if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL) || defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)


### PR DESCRIPTION
* Adds parameters `asyncConnect` and `exchangeMTU` to `NimBLEClient::connect`, default values work as the original connect method.
* * `asyncConnect`; if true, will send the connect command and return immediately with a true value for successfully sending the command, else false.
* * `exchangeMTU`; if true will send the exchange MTU command upon connection, otherwise not and the application can choose to do this later via the `exchangeMTU` method.
* Adds `onMTUChange` callback to `NimBLEClientCallbacks`
* Add `NimBLEDevice::getConnectedClients()` which returns a vector of pointers to the currently connected client instances.
* Calling `NimBLEClient::connect` will no longer cancel already in progress connections.