### PR TITLE
Fix endless loop when calling scan start from scan end callback.

### DIFF
--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -101,6 +101,10 @@ std::vector<NimBLEAddress> NimBLEDevice::m_ignoreList{};
 std::vector<NimBLEAddress> NimBLEDevice::m_whiteList{};
 uint8_t                    NimBLEDevice::m_ownAddrType{BLE_OWN_ADDR_PUBLIC};
 
+# if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL) || defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
+bool NimBLEDevice::m_connectionInProgress{false};
+# endif
+
 # ifdef ESP_PLATFORM
 #  ifdef CONFIG_BTDM_BLE_SCAN_DUPL
 uint16_t NimBLEDevice::m_scanDuplicateSize{CONFIG_BTDM_SCAN_DUPL_CACHE_SIZE};
@@ -1231,6 +1235,23 @@ bool NimBLEDevice::setCustomGapHandler(gap_event_handler handler) {
 
     return rc == 0;
 } // setCustomGapHandler
+
+/**
+ * @brief Set the connection in progress flag.
+ * @param [in] inProgress The connection in progress flag.
+ * @details This is used to prevent a scan from starting while a connection is in progress.
+ */
+void NimBLEDevice::setConnectionInProgress(bool inProgress) {
+    m_connectionInProgress = inProgress;
+} // setConnectionInProgress
+
+/**
+ * @brief Check if a connection is in progress.
+ * @return True if a connection is in progress.
+ */
+bool NimBLEDevice::isConnectionInProgress() {
+    return m_connectionInProgress;
+} // isConnectionInProgress
 
 /**
  * @brief Return a string representation of the address of this device.

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -183,6 +183,8 @@ class NimBLEDevice {
     static bool          isBonded(const NimBLEAddress& address);
     static bool          deleteAllBonds();
     static NimBLEAddress getBondedAddress(int index);
+    static void          setConnectionInProgress(bool inProgress);
+    static bool          isConnectionInProgress();
 # endif
 
   private:
@@ -193,6 +195,10 @@ class NimBLEDevice {
     static ble_gap_event_listener     m_listener;
     static uint8_t                    m_ownAddrType;
     static std::vector<NimBLEAddress> m_whiteList;
+
+# if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL) || defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
+    static bool m_connectionInProgress;
+# endif
 
 # if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)
     static NimBLEScan* m_pScan;

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -292,6 +292,11 @@ bool NimBLEScan::isScanning() {
 bool NimBLEScan::start(uint32_t duration, bool is_continue) {
     NIMBLE_LOGD(LOG_TAG, ">> start: duration=%" PRIu32, duration);
 
+    if (NimBLEDevice::isConnectionInProgress()) {
+        NIMBLE_LOGE(LOG_TAG, "Connection in progress, cannot start scan");
+        return false;
+    }
+
     // Save the duration in the case that the host is reset so we can reuse it.
     m_duration = duration;
 


### PR DESCRIPTION
When attempting to connect and the scanner is running NimBLEScan::stop is called to stop it
which then calls the onScanEnded callback. If the app then starts the scan again in this
callback an endless loop will be created.

This change prevents the endless loop by setting a flag in NimBLEDevice that is checked before
starting a scan while a client is trying to connect.

Adds NimBLEDevice::setConnectionInProgress and NimBLEDevice::isConnectionInProgress functions.