### PR TITLE
Fix task blocking

### DIFF
--- a/src/NimBLEUtils.h
+++ b/src/NimBLEUtils.h
@@ -21,14 +21,8 @@ class NimBLEAddress;
  * All items are optional, the m_pHandle will be set in taskWait().
  */
 struct NimBLETaskData {
-    /**
-     * @brief Constructor.
-     * @param [in] pInstance An instance of the class that is waiting.
-     * @param [in] flags General purpose flags for the caller.
-     * @param [in] buf A buffer for data.
-     */
-    NimBLETaskData(void* pInstance = nullptr, int flags = 0, void* buf = nullptr)
-        : m_pInstance(pInstance), m_flags(flags), m_pBuf(buf) {}
+    NimBLETaskData(void* pInstance = nullptr, int flags = 0, void* buf = nullptr);
+    ~NimBLETaskData();
     void*       m_pInstance{nullptr};
     mutable int m_flags{0};
     void*       m_pBuf{nullptr};

--- a/src/nimconfig.h
+++ b/src/nimconfig.h
@@ -148,6 +148,13 @@
  */
 // #define CONFIG_NIMBLE_STACK_USE_MEM_POOLS 1
 
+/**
+ * @brief Un-comment to change the bit used to block tasks during BLE operations
+ * that call NimBLEUtils::taskWait. This should be different than any other
+ * task notification flag used in the system.
+ */
+// #define CONFIG_NIMBLE_CPP_FREERTOS_TASK_BLOCK_BIT 31
+
 /**********************************
  End Arduino user-config
 **********************************/
@@ -348,6 +355,10 @@
 
 #ifndef CONFIG_NIMBLE_CPP_DEBUG_ASSERT_ENABLED
 #define CONFIG_NIMBLE_CPP_DEBUG_ASSERT_ENABLED 0
+#endif
+
+#ifndef CONFIG_NIMBLE_CPP_FREERTOS_TASK_BLOCK_BIT
+#define CONFIG_NIMBLE_CPP_FREERTOS_TASK_BLOCK_BIT 31
 #endif
 
 #if CONFIG_NIMBLE_CPP_DEBUG_ASSERT_ENABLED && !defined NDEBUG


### PR DESCRIPTION
Instead of incrementing the notificatin value via xTaskNotifyGive this will now set a specific bit in the task notification value
which will be tested before blocking a task. This will prevent a task from blocking indefinitely if the event that calls taskRelease
occurs before entering the blocked state.

Adds a config setting for the bit to set in the task notification value.
[Refactor NimBLEClient::connect and NimBLEClient::secureConnection.](https://github.com/h2zero/esp-nimble-cpp/commit/82098d1072e3a1b2de94e63981a6761144db955e)

This change ensures that only the function that sets m_pTaskData clears it, potentially preventing a segmentation fault.

Client will no longer disconnect if task timeout occurs when waiting for MTU exchange response.