### PR TITLE
[BREAKING] - Refactor NimBLEScan

### DIFF
--- a/examples/Bluetooth_5/NimBLE_extended_client/NimBLE_extended_client.ino
+++ b/examples/Bluetooth_5/NimBLE_extended_client/NimBLE_extended_client.ino
@@ -16,7 +16,7 @@
 #define SERVICE_UUID        "ABCD"
 #define CHARACTERISTIC_UUID "1234"
 
-static NimBLEAdvertisedDevice* advDevice;
+static const NimBLEAdvertisedDevice* advDevice;
 static bool doConnect = false;
 static uint32_t scanTime = 10 * 1000; // In milliseconds, 0 = scan forever
 
@@ -40,7 +40,7 @@ class ClientCallbacks : public NimBLEClientCallbacks {
 /* Define a class to handle the callbacks when advertisements are received */
 class scanCallbacks: public NimBLEScanCallbacks {
 
-    void onResult(NimBLEAdvertisedDevice* advertisedDevice) {
+    void onResult(const NimBLEAdvertisedDevice* advertisedDevice) {
         Serial.printf("Advertised Device found: %s\n", advertisedDevice->toString().c_str());
         if(advertisedDevice->isAdvertisingService(NimBLEUUID("ABCD")))
         {
@@ -55,8 +55,8 @@ class scanCallbacks: public NimBLEScanCallbacks {
     }
 
     /** Callback to process the results of the completed scan or restart it */
-    void onScanEnd(NimBLEScanResults results) {
-        Serial.println("Scan Ended");
+    void onScanEnd(const NimBLEScanResults& results, int reason) {
+        Serial.print("Scan Ended; reason = "); Serial.println(reason);
     }
 };
 

--- a/examples/NimBLE_Async_Client/NimBLE_Async_Client.ino
+++ b/examples/NimBLE_Async_Client/NimBLE_Async_Client.ino
@@ -25,7 +25,7 @@ class ClientCallbacks : public NimBLEClientCallbacks {
 } clientCB;
 
 class scanCallbacks : public NimBLEScanCallbacks {
-    void onResult(NimBLEAdvertisedDevice* advertisedDevice) {
+    void onResult(const NimBLEAdvertisedDevice* advertisedDevice) {
         Serial.printf("Advertised Device found: %s\n", advertisedDevice->toString().c_str());
         if (advertisedDevice->haveName() && advertisedDevice->getName() == "NimBLE-Server") {
             Serial.println("Found Our Device");
@@ -48,8 +48,8 @@ class scanCallbacks : public NimBLEScanCallbacks {
         }
     }
 
-    void onScanEnd(NimBLEScanResults results) {
-        Serial.println("Scan Ended");
+    void onScanEnd(const NimBLEScanResults& results, int reason) {
+        Serial.print("Scan Ended; reason = "); Serial.println(reason);
         NimBLEDevice::getScan()->start(scanTimeMs);
     }
 };

--- a/examples/NimBLE_Client/NimBLE_Client.ino
+++ b/examples/NimBLE_Client/NimBLE_Client.ino
@@ -10,7 +10,7 @@
 
 #include <NimBLEDevice.h>
 
-static NimBLEAdvertisedDevice* advDevice;
+static const NimBLEAdvertisedDevice* advDevice;
 
 static bool doConnect = false;
 static uint32_t scanTime = 0 * 1000; // In milliseconds, 0 = scan forever
@@ -85,7 +85,7 @@ class ClientCallbacks : public NimBLEClientCallbacks {
 /** Define a class to handle the callbacks when advertisments are received */
 class scanCallbacks: public NimBLEScanCallbacks {
 
-    void onResult(NimBLEAdvertisedDevice* advertisedDevice) {
+    void onResult(const NimBLEAdvertisedDevice* advertisedDevice) {
         Serial.print("Advertised Device found: ");
         Serial.println(advertisedDevice->toString().c_str());
         if(advertisedDevice->isAdvertisingService(NimBLEUUID("DEAD")))
@@ -101,8 +101,8 @@ class scanCallbacks: public NimBLEScanCallbacks {
     }
 
     /** Callback to process the results of the completed scan or restart it */
-    void onScanEnd(NimBLEScanResults results) {
-        Serial.println("Scan Ended");
+    void onScanEnd(const NimBLEScanResults& results, int reason) {
+        Serial.print("Scan Ended; reason = "); Serial.println(reason);
     }
 };
 

--- a/examples/NimBLE_active_passive_scan/NimBLE_active_passive_scan.ino
+++ b/examples/NimBLE_active_passive_scan/NimBLE_active_passive_scan.ino
@@ -12,16 +12,16 @@ bool active = false;
 
 class scanCallbacks: public NimBLEScanCallbacks {
 
-    void onDiscovered(NimBLEAdvertisedDevice* advertisedDevice) {
+    void onDiscovered(const NimBLEAdvertisedDevice* advertisedDevice) {
       Serial.printf("Discovered Advertised Device: %s \n", advertisedDevice->toString().c_str());
     }
 
-    void onResult(NimBLEAdvertisedDevice* advertisedDevice) {
+    void onResult(const NimBLEAdvertisedDevice* advertisedDevice) {
       Serial.printf("Advertised Device Result: %s \n", advertisedDevice->toString().c_str());
     }
 
-    void onScanEnd(NimBLEScanResults results){
-        Serial.println("Scan Ended");
+    void onScanEnd(const NimBLEScanResults& results, int reason) {
+        Serial.print("Scan Ended; reason = "); Serial.println(reason);
         active = !active;
         pBLEScan->setActiveScan(active);
         Serial.printf("scan start, active = %u\n", active);

--- a/examples/Refactored_original_examples/BLE_client/BLE_client.ino
+++ b/examples/Refactored_original_examples/BLE_client/BLE_client.ino
@@ -22,7 +22,9 @@ static boolean doConnect = false;
 static boolean connected = false;
 static boolean doScan = false;
 static BLERemoteCharacteristic* pRemoteCharacteristic;
-static BLEAdvertisedDevice* myDevice;
+/* const required now */
+/* static BLEAdvertisedDevice* myDevice;*/
+static const BLEAdvertisedDevice* myDevice;
 
 static void notifyCallback(
   BLERemoteCharacteristic* pBLERemoteCharacteristic,
@@ -128,9 +130,9 @@ class MyAdvertisedDeviceCallbacks: public BLEAdvertisedDeviceCallbacks {
    * Called for each advertising BLE server.
    */
 
-/*** Only a reference to the advertised device is passed now
+/*** Only a const pointer to the advertised device is passed now
   void onResult(BLEAdvertisedDevice advertisedDevice) { **/
-  void onResult(BLEAdvertisedDevice* advertisedDevice) {
+  void onResult(const BLEAdvertisedDevice* advertisedDevice) {
     Serial.print("BLE Advertised Device found: ");
     Serial.println(advertisedDevice->toString().c_str());
 

--- a/examples/Refactored_original_examples/BLE_scan/BLE_scan.ino
+++ b/examples/Refactored_original_examples/BLE_scan/BLE_scan.ino
@@ -18,9 +18,9 @@ int scanTime = 5 * 1000; // In milliseconds, 0 = scan forever
 BLEScan* pBLEScan;
 
 class MyAdvertisedDeviceCallbacks: public BLEAdvertisedDeviceCallbacks {
-  /*** Only a reference to the advertised device is passed now
+  /*** Only a const pointer to the advertised device is passed now
     void onResult(BLEAdvertisedDevice advertisedDevice) { **/
-    void onResult(BLEAdvertisedDevice* advertisedDevice) {
+    void onResult(const BLEAdvertisedDevice* advertisedDevice) {
   /** Serial.printf("Advertised Device: %s \n", advertisedDevice.toString().c_str()); **/
       Serial.printf("Advertised Device: %s \n", advertisedDevice->toString().c_str());
     }

--- a/src/NimBLEAdvertisedDevice.cpp
+++ b/src/NimBLEAdvertisedDevice.cpp
@@ -758,6 +758,14 @@ bool NimBLEAdvertisedDevice::isConnectable() const {
 } // isConnectable
 
 /**
+ * @brief Check if this device is advertising as scannable.
+ * @return True if the device is scannable.
+ */
+bool NimBLEAdvertisedDevice::isScannable() const {
+    return isLegacyAdvertisement() && (m_advType == BLE_HCI_ADV_TYPE_ADV_IND || m_advType == BLE_HCI_ADV_TYPE_ADV_SCAN_IND);
+} // isScannable
+
+/**
  * @brief Check if this advertisement is a legacy or extended type
  * @return True if legacy (Bluetooth 4.x), false if extended (bluetooth 5.x).
  */

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -82,6 +82,7 @@ class NimBLEAdvertisedDevice {
     bool                 haveType(uint16_t type) const;
     std::string          toString() const;
     bool                 isConnectable() const;
+    bool                 isScannable() const;
     bool                 isLegacyAdvertisement() const;
 # if CONFIG_BT_NIMBLE_EXT_ADV
     uint8_t  getSetId() const;

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -723,15 +723,7 @@ void NimBLEDevice::onReset(int reason) {
 
     m_synced = false;
 
-    NIMBLE_LOGE(LOG_TAG, "Resetting state; reason=%d, %s", reason, NimBLEUtils::returnCodeToString(reason));
-
-# if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)
-    if (m_initialized) {
-        if (m_pScan != nullptr) {
-            m_pScan->onHostReset();
-        }
-    }
-# endif
+    NIMBLE_LOGE(LOG_TAG, "Host reset; reason=%d, %s", reason, NimBLEUtils::returnCodeToString(reason));
 } // onReset
 
 /**

--- a/src/NimBLEScan.h
+++ b/src/NimBLEScan.h
@@ -17,16 +17,16 @@
 #include "nimconfig.h"
 #if defined(CONFIG_BT_ENABLED) && defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)
 
-#include "NimBLEAdvertisedDevice.h"
-#include "NimBLEUtils.h"
+# include "NimBLEAdvertisedDevice.h"
+# include "NimBLEUtils.h"
 
-#if defined(CONFIG_NIMBLE_CPP_IDF)
-#include "host/ble_gap.h"
-#else
-#include "nimble/nimble/host/include/host/ble_gap.h"
-#endif
+# if defined(CONFIG_NIMBLE_CPP_IDF)
+#  include "host/ble_gap.h"
+# else
+#  include "nimble/nimble/host/include/host/ble_gap.h"
+# endif
 
-#include <vector>
+# include <vector>
 
 class NimBLEDevice;
 class NimBLEScan;
@@ -42,17 +42,17 @@ class NimBLEAddress;
  * index (starting at 0) of the desired device.
  */
 class NimBLEScanResults {
-public:
-    void                                           dump();
-    int                                            getCount();
-    NimBLEAdvertisedDevice                         getDevice(uint32_t i);
-    std::vector<NimBLEAdvertisedDevice*>::iterator begin();
-    std::vector<NimBLEAdvertisedDevice*>::iterator end();
-    NimBLEAdvertisedDevice                         *getDevice(const NimBLEAddress &address);
+  public:
+    void                                                 dump() const;
+    int                                                  getCount() const;
+    const NimBLEAdvertisedDevice*                        getDevice(uint32_t idx) const;
+    const NimBLEAdvertisedDevice*                        getDevice(const NimBLEAddress& address) const;
+    std::vector<NimBLEAdvertisedDevice*>::const_iterator begin() const;
+    std::vector<NimBLEAdvertisedDevice*>::const_iterator end() const;
 
-private:
+  private:
     friend NimBLEScan;
-    std::vector<NimBLEAdvertisedDevice*> m_advertisedDevicesVector;
+    std::vector<NimBLEAdvertisedDevice*> m_deviceVec;
 };
 
 /**
@@ -61,67 +61,65 @@ private:
  * Scanning is associated with a %BLE client that is attempting to locate BLE servers.
  */
 class NimBLEScan {
-public:
-    bool                start(uint32_t duration, bool is_continue = false);
-    bool                isScanning();
-    void                setScanCallbacks(NimBLEScanCallbacks* pScanCallbacks, bool wantDuplicates = false);
-    void                setActiveScan(bool active);
-    void                setInterval(uint16_t intervalMSecs);
-    void                setWindow(uint16_t windowMSecs);
-    void                setDuplicateFilter(bool enabled);
-    void                setLimitedOnly(bool enabled);
-    void                setFilterPolicy(uint8_t filter);
-    void                clearDuplicateCache();
-    bool                stop();
-    void                clearResults();
-    NimBLEScanResults   getResults();
-    NimBLEScanResults   getResults(uint32_t duration, bool is_continue = false);
-    void                setMaxResults(uint8_t maxResults);
-    void                erase(const NimBLEAddress &address);
+  public:
+    bool              start(uint32_t duration, bool isContinue = false, bool restart = true);
+    bool              isScanning();
+    void              setScanCallbacks(NimBLEScanCallbacks* pScanCallbacks, bool wantDuplicates = false);
+    void              setActiveScan(bool active);
+    void              setInterval(uint16_t intervalMSecs);
+    void              setWindow(uint16_t windowMSecs);
+    void              setDuplicateFilter(bool enabled);
+    void              setLimitedOnly(bool enabled);
+    void              setFilterPolicy(uint8_t filter);
+    bool              stop();
+    void              clearResults();
+    NimBLEScanResults getResults();
+    NimBLEScanResults getResults(uint32_t duration, bool is_continue = false);
+    void              setMaxResults(uint8_t maxResults);
+    void              erase(const NimBLEAddress& address);
+    void              erase(const NimBLEAdvertisedDevice* device);
 
-
-private:
+  private:
     friend class NimBLEDevice;
 
     NimBLEScan();
     ~NimBLEScan();
-    static int  handleGapEvent(ble_gap_event*  event, void* arg);
-    void        onHostReset();
-    void        onHostSync();
+    static int handleGapEvent(ble_gap_event* event, void* arg);
+    void       onHostSync();
 
-    NimBLEScanCallbacks*  m_pScanCallbacks;
-    ble_gap_disc_params   m_scan_params;
-    bool                  m_ignoreResults;
-    NimBLEScanResults     m_scanResults;
-    uint32_t              m_duration;
-    NimBLETaskData        *m_pTaskData;
-    uint8_t               m_maxResults;
+    NimBLEScanCallbacks* m_pScanCallbacks;
+    ble_gap_disc_params  m_scanParams;
+    NimBLEScanResults    m_scanResults;
+    uint32_t             m_duration;
+    NimBLETaskData*      m_pTaskData;
+    uint8_t              m_maxResults;
 };
 
 /**
  * @brief A callback handler for callbacks associated device scanning.
  */
 class NimBLEScanCallbacks {
-public:
+  public:
     virtual ~NimBLEScanCallbacks() {}
 
     /**
      * @brief Called when a new device is discovered, before the scan result is received (if applicable).
      * @param [in] advertisedDevice The device which was discovered.
      */
-    virtual void onDiscovered(NimBLEAdvertisedDevice* advertisedDevice) {};
+    virtual void onDiscovered(const NimBLEAdvertisedDevice* advertisedDevice);
 
     /**
      * @brief Called when a new scan result is complete, including scan response data (if applicable).
      * @param [in] advertisedDevice The device for which the complete result is available.
      */
-    virtual void onResult(NimBLEAdvertisedDevice* advertisedDevice) {};
+    virtual void onResult(const NimBLEAdvertisedDevice* advertisedDevice);
 
     /**
      * @brief Called when a scan operation ends.
      * @param [in] scanResults The results of the scan that ended.
+     * @param [in] reason The reason code for why the scan ended.
      */
-    virtual void onScanEnd(NimBLEScanResults scanResults) {};
+    virtual void onScanEnd(const NimBLEScanResults& scanResults, int reason);
 };
 
 #endif /* CONFIG_BT_ENABLED CONFIG_BT_NIMBLE_ROLE_OBSERVER */


### PR DESCRIPTION
* General code cleanup
* `NimBLEScan::start` will no longer clear cache or results if scanning is already in progress.
* `NimBLEScan::clearResults` will now reset the vector capacity to 0.
* `NimBLEScan::stop` will no longer call the `onScanEnd` callback as the caller should know its been stopped when this is called.
* `NimBLEScan::clearDuplicateCache` has been removed as it was problematic and only for the esp32. Stop and start the scanner for the same effect.
* `NimBLEScan::start` takes a new bool parameter `restart`, default `true`, that will restart an already in progress scan and clear the duplicate filter so all devices will be discovered again.
* Scan response data that is received without advertisement first will now create the device and send a callback.
* Added new method: `NimBLEAdvertisedDevice::isScannable()` that returns true if the device is scannable.
* Added default callbacks for `NimBLEScanCallbacks`
* `NimBLEScanCallbacks` function signatures updated:
* - `onDiscovered` now takes a `const NimBLEAdvertisedDevice*`
* - `onResult` now takes a `const NimBLEAdvertisedDevice*`
* - `onScanEnd` now takes a `const NimBLEScanResults&` and `int reason`
* Added new erase overload: `NimBLEScan::erase(const NimBLEAdvertisedDevice* device)`
* `NimBLEScanResults::getDevice` methods now return `const NimBLEAdvertisedDevice*`
* `NimBLEScanResults` iterators are now `const_iterator`