### PR TITLE
Refactor NimBLE2904

### DIFF
--- a/examples/NimBLE_Server/NimBLE_Server.ino
+++ b/examples/NimBLE_Server/NimBLE_Server.ino
@@ -185,7 +185,7 @@ void setup() {
      *  However we must cast the returned reference to the correct type as the method
      *  only returns a pointer to the base NimBLEDescriptor class.
      */
-    NimBLE2904* pBeef2904 = (NimBLE2904*)pBeefCharacteristic->createDescriptor("2904");
+    NimBLE2904* pBeef2904 = pBeefCharacteristic->create2904();
     pBeef2904->setFormat(NimBLE2904::FORMAT_UTF8);
     pBeef2904->setCallbacks(&dscCallbacks);
 

--- a/src/NimBLE2904.cpp
+++ b/src/NimBLE2904.cpp
@@ -15,68 +15,57 @@
 #include "nimconfig.h"
 #if defined(CONFIG_BT_ENABLED) && defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
 
-#include "NimBLE2904.h"
+# include "NimBLE2904.h"
 
-
-NimBLE2904::NimBLE2904(NimBLECharacteristic* pCharacteristic)
-: NimBLEDescriptor(NimBLEUUID((uint16_t) 0x2904),
-                            BLE_GATT_CHR_F_READ,
-                            sizeof(BLE2904_Data),
-                            pCharacteristic)
-{
-    m_data.m_format      = 0;
-    m_data.m_exponent    = 0;
-    m_data.m_namespace   = 1;  // 1 = Bluetooth SIG Assigned Numbers
-    m_data.m_unit        = 0;
-    m_data.m_description = 0;
-    setValue((uint8_t*) &m_data, sizeof(m_data));
-} // BLE2904
-
+NimBLE2904::NimBLE2904(NimBLECharacteristic* pChr)
+    : NimBLEDescriptor(NimBLEUUID((uint16_t)0x2904), BLE_GATT_CHR_F_READ, sizeof(NimBLE2904Data), pChr) {
+    setValue(m_data);
+} // NimBLE2904
 
 /**
  * @brief Set the description.
+ * @param [in] description The description value to set.
  */
 void NimBLE2904::setDescription(uint16_t description) {
     m_data.m_description = description;
-    setValue((uint8_t*) &m_data, sizeof(m_data));
-}
-
+    setValue(m_data);
+} // setDescription
 
 /**
  * @brief Set the exponent.
+ * @param [in] exponent The exponent value to set.
  */
 void NimBLE2904::setExponent(int8_t exponent) {
     m_data.m_exponent = exponent;
-    setValue((uint8_t*) &m_data, sizeof(m_data));
+    setValue(m_data);
 } // setExponent
-
 
 /**
  * @brief Set the format.
+ * @param [in] format The format value to set.
  */
 void NimBLE2904::setFormat(uint8_t format) {
     m_data.m_format = format;
-    setValue((uint8_t*) &m_data, sizeof(m_data));
+    setValue(m_data);
 } // setFormat
-
 
 /**
  * @brief Set the namespace.
+ * @param [in] namespace_value The namespace value toset.
  */
 void NimBLE2904::setNamespace(uint8_t namespace_value) {
     m_data.m_namespace = namespace_value;
-    setValue((uint8_t*) &m_data, sizeof(m_data));
+    setValue(m_data);
 } // setNamespace
 
-
 /**
- * @brief Set the units for this value.  It should be one of the encoded values defined here:
- * https://www.bluetooth.com/specifications/assigned-numbers/units
+ * @brief Set the units for this value.
  * @param [in] unit The type of units of this characteristic as defined by assigned numbers.
+ * @details See https://www.bluetooth.com/specifications/assigned-numbers/units
  */
 void NimBLE2904::setUnit(uint16_t unit) {
     m_data.m_unit = unit;
-    setValue((uint8_t*) &m_data, sizeof(m_data));
+    setValue(m_data);
 } // setUnit
 
 #endif /* CONFIG_BT_ENABLED && CONFIG_BT_NIMBLE_ROLE_PERIPHERAL */

--- a/src/NimBLE2904.h
+++ b/src/NimBLE2904.h
@@ -12,31 +12,30 @@
  *      Author: kolban
  */
 
-#ifndef MAIN_NIMBLE2904_H_
-#define MAIN_NIMBLE2904_H_
+#ifndef NIMBLE_CPP_2904_H_
+#define NIMBLE_CPP_2904_H_
+
 #include "nimconfig.h"
 #if defined(CONFIG_BT_ENABLED) && defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
 
-#include "NimBLEDescriptor.h"
+# include "NimBLEDescriptor.h"
 
-struct BLE2904_Data {
-    uint8_t  m_format;
-    int8_t   m_exponent;
-    uint16_t m_unit;      // See https://www.bluetooth.com/specifications/assigned-numbers/units
-    uint8_t  m_namespace;
-    uint16_t m_description;
-
+struct NimBLE2904Data {
+    uint8_t  m_format{0};
+    int8_t   m_exponent{0};
+    uint16_t m_unit{0x2700}; // Unitless; See https://www.bluetooth.com/specifications/assigned-numbers/units
+    uint8_t  m_namespace{1}; // 1 = Bluetooth SIG Assigned Numbers
+    uint16_t m_description{0}; // unknown description
 } __attribute__((packed));
-
 
 /**
  * @brief Descriptor for Characteristic Presentation Format.
  *
  * This is a convenience descriptor for the Characteristic Presentation Format which has a UUID of 0x2904.
  */
-class NimBLE2904: public NimBLEDescriptor {
-public:
-    NimBLE2904(NimBLECharacteristic* pCharacterisitic = nullptr);
+class NimBLE2904 : public NimBLEDescriptor {
+  public:
+    NimBLE2904(NimBLECharacteristic* pChr = nullptr);
     static const uint8_t FORMAT_BOOLEAN   = 1;
     static const uint8_t FORMAT_UINT2     = 2;
     static const uint8_t FORMAT_UINT4     = 3;
@@ -64,6 +63,7 @@ public:
     static const uint8_t FORMAT_UTF8      = 25;
     static const uint8_t FORMAT_UTF16     = 26;
     static const uint8_t FORMAT_OPAQUE    = 27;
+    static const uint8_t FORMAT_MEDASN1   = 28;
 
     void setDescription(uint16_t);
     void setExponent(int8_t exponent);
@@ -71,10 +71,10 @@ public:
     void setNamespace(uint8_t namespace_value);
     void setUnit(uint16_t unit);
 
-private:
+  private:
     friend class NimBLECharacteristic;
-    BLE2904_Data m_data;
-}; // BLE2904
+    NimBLE2904Data m_data{};
+}; // NimBLE2904
 
-#endif /* CONFIG_BT_ENABLED && CONFIG_BT_NIMBLE_ROLE_PERIPHERAL */
-#endif /* MAIN_NIMBLE2904_H_ */
+#endif // CONFIG_BT_ENABLED && CONFIG_BT_NIMBLE_ROLE_PERIPHERAL
+#endif // NIMBLE_CPP_2904_H_

--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -72,8 +72,9 @@ NimBLEDescriptor* NimBLECharacteristic::createDescriptor(const char* uuid, uint3
  */
 NimBLEDescriptor* NimBLECharacteristic::createDescriptor(const NimBLEUUID& uuid, uint32_t properties, uint16_t maxLen) {
     NimBLEDescriptor* pDescriptor = nullptr;
-    if (uuid == NimBLEUUID(uint16_t(0x2904))) {
-        pDescriptor = new NimBLE2904(this);
+    if (uuid == NimBLEUUID(static_cast<uint16_t>(0x2904))) {
+        NIMBLE_LOGW(LOG_TAG, "0x2904 descriptor should be created with create2904()");
+        pDescriptor = create2904();
     } else {
         pDescriptor = new NimBLEDescriptor(uuid, properties, maxLen, this);
     }
@@ -81,6 +82,16 @@ NimBLEDescriptor* NimBLECharacteristic::createDescriptor(const NimBLEUUID& uuid,
     addDescriptor(pDescriptor);
     return pDescriptor;
 } // createDescriptor
+
+/**
+ * @brief Create a Characteristic Presentation Format Descriptor for this characteristic.
+ * @return A pointer to a NimBLE2904 descriptor.
+ */
+NimBLE2904* NimBLECharacteristic::create2904() {
+    NimBLE2904* pDescriptor = new NimBLE2904(this);
+    addDescriptor(pDescriptor);
+    return pDescriptor;
+} // create2904
 
 /**
  * @brief Add a descriptor to the characteristic.

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -17,14 +17,12 @@
 #if defined(CONFIG_BT_ENABLED) && defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
 
 class NimBLECharacteristicCallbacks;
+class NimBLEService;
 class NimBLECharacteristic;
+class NimBLEDescriptor;
+class NimBLE2904;
 
 # include "NimBLELocalValueAttribute.h"
-# include "NimBLEServer.h"
-# include "NimBLEService.h"
-# include "NimBLEDescriptor.h"
-# include "NimBLEAttValue.h"
-# include "NimBLEConnInfo.h"
 
 # include <string>
 # include <vector>
@@ -39,11 +37,11 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
   public:
     NimBLECharacteristic(const char*    uuid,
                          uint16_t       properties = NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE,
-                         uint16_t       maxLen    = BLE_ATT_ATTR_MAX_LEN,
+                         uint16_t       maxLen     = BLE_ATT_ATTR_MAX_LEN,
                          NimBLEService* pService   = nullptr);
     NimBLECharacteristic(const NimBLEUUID& uuid,
                          uint16_t          properties = NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE,
-                         uint16_t          maxLen    = BLE_ATT_ATTR_MAX_LEN,
+                         uint16_t          maxLen     = BLE_ATT_ATTR_MAX_LEN,
                          NimBLEService*    pService   = nullptr);
 
     ~NimBLECharacteristic();
@@ -60,10 +58,11 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
 
     NimBLEDescriptor* createDescriptor(const char* uuid,
                                        uint32_t    properties = NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE,
-                                       uint16_t    maxLen    = BLE_ATT_ATTR_MAX_LEN);
+                                       uint16_t    maxLen     = BLE_ATT_ATTR_MAX_LEN);
     NimBLEDescriptor* createDescriptor(const NimBLEUUID& uuid,
                                        uint32_t          properties = NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE,
-                                       uint16_t          maxLen    = BLE_ATT_ATTR_MAX_LEN);
+                                       uint16_t          maxLen     = BLE_ATT_ATTR_MAX_LEN);
+    NimBLE2904*       create2904();
     NimBLEDescriptor* getDescriptorByUUID(const char* uuid) const;
     NimBLEDescriptor* getDescriptorByUUID(const NimBLEUUID& uuid) const;
     NimBLEDescriptor* getDescriptorByHandle(uint16_t handle) const;
@@ -127,7 +126,7 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
     bool sendValue(const uint8_t* value,
                    size_t         length,
                    bool           is_notification = true,
-                   uint16_t       connHandle     = BLE_HS_CONN_HANDLE_NONE) const;
+                   uint16_t       connHandle      = BLE_HS_CONN_HANDLE_NONE) const;
 
     NimBLECharacteristicCallbacks* m_pCallbacks{nullptr};
     NimBLEService*                 m_pService{nullptr};


### PR DESCRIPTION
* General code cleanup.
* Added method `NimBLECharacteristic::create2904` which will specifically create a CPF(0x2904) descriptor.