### PR TITLE
[BREAKING] Refactor NimBLELog

### DIFF
--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -1230,7 +1230,8 @@ std::string NimBLEDevice::toString() {
  * @param [in] line The line number where the assert occurred.
  */
 void nimble_cpp_assert(const char* file, unsigned line) {
-    NIMBLE_LOGC("", "Assertion failed at %s:%u\n", file, line);
+    console_printf("Assertion failed at %s:%u\n", file, line);
+    ble_npl_time_delay(10);
     abort();
 }
 # endif // CONFIG_NIMBLE_CPP_DEBUG_ASSERT_ENABLED

--- a/src/NimBLELog.h
+++ b/src/NimBLELog.h
@@ -5,75 +5,65 @@
  *      Author H2zero
  *
  */
-#ifndef MAIN_NIMBLELOG_H_
-#define MAIN_NIMBLELOG_H_
+
+#ifndef NIMBLE_CPP_LOG_H_
+#define NIMBLE_CPP_LOG_H_
 
 #include "nimconfig.h"
-
 #if defined(CONFIG_BT_ENABLED)
 
-#if defined(CONFIG_NIMBLE_CPP_IDF) // using esp-idf
+# if defined(CONFIG_NIMBLE_CPP_IDF)
 #  include "esp_log.h"
 #  include "console/console.h"
 #  ifndef CONFIG_NIMBLE_CPP_LOG_LEVEL
-#    define CONFIG_NIMBLE_CPP_LOG_LEVEL 0
+#   define CONFIG_NIMBLE_CPP_LOG_LEVEL 0
 #  endif
 
-#  define NIMBLE_CPP_LOG_PRINT(level, tag, format, ...) do { \
-    if (CONFIG_NIMBLE_CPP_LOG_LEVEL >= level) \
-      ESP_LOG_LEVEL_LOCAL(level, tag, format, ##__VA_ARGS__); \
-    } while(0)
+#  define NIMBLE_CPP_LOG_PRINT(level, tag, format, ...)                                                     \
+      do {                                                                                                  \
+          if (CONFIG_NIMBLE_CPP_LOG_LEVEL >= level) ESP_LOG_LEVEL_LOCAL(level, tag, format, ##__VA_ARGS__); \
+      } while (0)
 
-#  define NIMBLE_LOGD(tag, format, ...) \
-     NIMBLE_CPP_LOG_PRINT(ESP_LOG_DEBUG, tag, format, ##__VA_ARGS__)
+#  define NIMBLE_LOGD(tag, format, ...) NIMBLE_CPP_LOG_PRINT(ESP_LOG_DEBUG, tag, format, ##__VA_ARGS__)
+#  define NIMBLE_LOGI(tag, format, ...) NIMBLE_CPP_LOG_PRINT(ESP_LOG_INFO, tag, format, ##__VA_ARGS__)
+#  define NIMBLE_LOGW(tag, format, ...) NIMBLE_CPP_LOG_PRINT(ESP_LOG_WARN, tag, format, ##__VA_ARGS__)
+#  define NIMBLE_LOGE(tag, format, ...) NIMBLE_CPP_LOG_PRINT(ESP_LOG_ERROR, tag, format, ##__VA_ARGS__)
 
-#  define NIMBLE_LOGI(tag, format, ...) \
-     NIMBLE_CPP_LOG_PRINT(ESP_LOG_INFO, tag, format, ##__VA_ARGS__)
-
-#  define NIMBLE_LOGW(tag, format, ...) \
-     NIMBLE_CPP_LOG_PRINT(ESP_LOG_WARN, tag, format, ##__VA_ARGS__)
-
-#  define NIMBLE_LOGE(tag, format, ...) \
-     NIMBLE_CPP_LOG_PRINT(ESP_LOG_ERROR, tag, format, ##__VA_ARGS__)
-
-#else // using Arduino
+# else
 #  include "nimble/porting/nimble/include/syscfg/syscfg.h"
 #  include "nimble/console/console.h"
 #  ifndef CONFIG_NIMBLE_CPP_LOG_LEVEL
-#    if defined(ARDUINO_ARCH_ESP32) && defined(CORE_DEBUG_LEVEL)
-#      define CONFIG_NIMBLE_CPP_LOG_LEVEL CORE_DEBUG_LEVEL
-#    else
-#      define CONFIG_NIMBLE_CPP_LOG_LEVEL 0
-#    endif
+#   if defined(ARDUINO_ARCH_ESP32) && defined(CORE_DEBUG_LEVEL)
+#    define CONFIG_NIMBLE_CPP_LOG_LEVEL CORE_DEBUG_LEVEL
+#   else
+#    define CONFIG_NIMBLE_CPP_LOG_LEVEL 0
+#   endif
 #  endif
 
 #  if CONFIG_NIMBLE_CPP_LOG_LEVEL >= 4
-#    define NIMBLE_LOGD( tag, format, ... ) console_printf("D %s: " format "\n", tag, ##__VA_ARGS__)
+#   define NIMBLE_LOGD(tag, format, ...) console_printf("D %s: " format "\n", tag, ##__VA_ARGS__)
 #  else
-#    define NIMBLE_LOGD( tag, format, ... ) (void)tag
+#   define NIMBLE_LOGD(tag, format, ...) (void)tag
 #  endif
 
 #  if CONFIG_NIMBLE_CPP_LOG_LEVEL >= 3
-#    define NIMBLE_LOGI( tag, format, ... ) console_printf("I %s: " format "\n", tag, ##__VA_ARGS__)
+#   define NIMBLE_LOGI(tag, format, ...) console_printf("I %s: " format "\n", tag, ##__VA_ARGS__)
 #  else
-#    define NIMBLE_LOGI( tag, format, ... ) (void)tag
+#   define NIMBLE_LOGI(tag, format, ...) (void)tag
 #  endif
 
 #  if CONFIG_NIMBLE_CPP_LOG_LEVEL >= 2
-#    define NIMBLE_LOGW( tag, format, ... ) console_printf("W %s: " format "\n", tag, ##__VA_ARGS__)
+#   define NIMBLE_LOGW(tag, format, ...) console_printf("W %s: " format "\n", tag, ##__VA_ARGS__)
 #  else
-#    define NIMBLE_LOGW( tag, format, ... ) (void)tag
+#   define NIMBLE_LOGW(tag, format, ...) (void)tag
 #  endif
 
 #  if CONFIG_NIMBLE_CPP_LOG_LEVEL >= 1
-#    define NIMBLE_LOGE( tag, format, ... ) console_printf("E %s: " format "\n", tag, ##__VA_ARGS__)
+#   define NIMBLE_LOGE(tag, format, ...) console_printf("E %s: " format "\n", tag, ##__VA_ARGS__)
 #  else
-#    define NIMBLE_LOGE( tag, format, ... ) (void)tag
+#   define NIMBLE_LOGE(tag, format, ...) (void)tag
 #  endif
 
-#endif /* CONFIG_NIMBLE_CPP_IDF */
-
-#define NIMBLE_LOGC( tag, format, ... ) console_printf("CRIT %s: " format "\n", tag, ##__VA_ARGS__)
-
-#endif /* CONFIG_BT_ENABLED */
-#endif /* MAIN_NIMBLELOG_H_ */
+# endif /* CONFIG_NIMBLE_CPP_IDF */
+#endif  /* CONFIG_BT_ENABLED */
+#endif  /* NIMBLE_CPP_LOG_H_ */


### PR DESCRIPTION
* Cleanup style.
* Remove NIMBLE_LOGC as it's use was limited to assertions.
* Add delay after assert printf to allow time to display the message.