### PR TITLE
Fix compiling errors on nRF devices

### DIFF
--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -70,9 +70,11 @@ NimBLEServer::~NimBLEServer() {
         delete m_pServerCallbacks;
     }
 
+# if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL)
     if (m_pClient != nullptr) {
         delete m_pClient;
     }
+# endif
 }
 
 /**
@@ -399,10 +401,12 @@ int NimBLEServer::handleGapEvent(ble_gap_event* event, void* arg) {
                 }
             }
 
+# if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL)
             if (pServer->m_pClient && pServer->m_pClient->m_connHandle == event->disconnect.conn.conn_handle) {
                 // If this was also the client make sure it's flagged as disconnected.
                 pServer->m_pClient->m_connHandle = BLE_HS_CONN_HANDLE_NONE;
             }
+# endif
 
             if (pServer->m_svcChanged) {
                 pServer->resetGATT();

--- a/src/nimble/porting/nimble/src/nimble_port.c
+++ b/src/nimble/porting/nimble/src/nimble_port.c
@@ -326,11 +326,6 @@ IRAM_ATTR nimble_port_get_dflt_eventq(void)
 
 #else // ESP_PLATFORM
 
-static struct ble_npl_eventq g_eventq_dflt;
-
-extern void os_msys_init(void);
-extern void os_mempool_module_init(void);
-
 void
 nimble_port_init(void)
 {


### PR DESCRIPTION
- Fixed "'class NimBLEServer' has no member named 'm_pClient'" when CONFIG_BT_NIMBLE_ROLE_CENTRAL not defined
- Fixed missing nimble_port_stop(void)