### PR TITLE
Add missing NimBLEUtils and NimBLEConnInfo includes to NimBLEDevice.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 - Compile error when central is disabled, class `NimBLEServer` has no member named `m_pClient`.
 - Compile error with nRF devices, unresolved symbol `nimble_port_stop`.
 
+## Changed
+- Added missing includes for `NimBLEConnInfo` and `NimBLEUtils` to `NimBLEDevice.h`.
+
 ## [2.1.0] 2024-12-14
 
 ## **Breaking changes**

--- a/src/NimBLEDescriptor.h
+++ b/src/NimBLEDescriptor.h
@@ -21,16 +21,11 @@
 #include "nimconfig.h"
 #if defined(CONFIG_BT_ENABLED) && defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
 
-class NimBLEDescriptor;
-class NimBLEDescriptorCallbacks;
-
 # include "NimBLELocalValueAttribute.h"
-# include "NimBLECharacteristic.h"
-# include "NimBLEUUID.h"
-# include "NimBLEAttValue.h"
-# include "NimBLEConnInfo.h"
-
 # include <string>
+
+class NimBLECharacteristic;
+class NimBLEDescriptorCallbacks;
 
 /**
  * @brief A model of a BLE descriptor.

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -282,5 +282,11 @@ class NimBLEDevice {
 #  endif
 # endif
 
+# if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL) || defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
+#  include "NimBLEConnInfo.h"
+# endif
+
+# include "NimBLEUtils.h"
+
 #endif // CONFIG_BT_ENABLED
 #endif // NIMBLE_CPP_DEVICE_H_


### PR DESCRIPTION
In some cases compilation of examples would fail due to missing these headers so they should be included in NimBLEDevice.h