### PR TITLE
Fixes a bug where incorrect Tx power level would be advertised.

### DIFF
--- a/src/NimBLEAdvertisementData.cpp
+++ b/src/NimBLEAdvertisementData.cpp
@@ -105,12 +105,12 @@ bool NimBLEAdvertisementData::setFlags(uint8_t flag) {
  * @brief Adds Tx power level to the advertisement data.
  * @return True if successful.
  */
-bool NimBLEAdvertisementData::addTxPower() {
+bool NimBLEAdvertisementData::addTxPower(const esp_ble_power_type_t powerType) {
     uint8_t data[3];
     data[0] = BLE_HS_ADV_TX_PWR_LVL_LEN + 1;
     data[1] = BLE_HS_ADV_TYPE_TX_PWR_LVL;
 # ifndef CONFIG_IDF_TARGET_ESP32P4
-    data[2] = NimBLEDevice::getPower();
+    data[2] = NimBLEDevice::getPower(powerType);
 # else
     data[2] = 0;
 # endif

--- a/src/NimBLEAdvertisementData.h
+++ b/src/NimBLEAdvertisementData.h
@@ -26,6 +26,14 @@
 # include <string>
 # include <vector>
 
+#if defined(CONFIG_BT_ENABLED)
+# ifdef ESP_PLATFORM
+#  ifndef CONFIG_IDF_TARGET_ESP32P4
+#   include <esp_bt.h>
+#  endif
+# endif
+#endif
+
 class NimBLEUUID;
 /**
  * @brief Advertisement data set by the programmer to be published by the BLE server.
@@ -39,7 +47,7 @@ class NimBLEAdvertisementData {
     bool addData(const std::vector<uint8_t>& data);
     bool setAppearance(uint16_t appearance);
     bool setFlags(uint8_t);
-    bool addTxPower();
+    bool addTxPower(const esp_ble_power_type_t powerType = ESP_BLE_PWR_TYPE_DEFAULT);
     bool setPreferredParams(uint16_t minInterval, uint16_t maxInterval);
     bool addServiceUUID(const NimBLEUUID& serviceUUID);
     bool addServiceUUID(const char* serviceUUID);

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -431,7 +431,7 @@ std::vector<NimBLEClient*> NimBLEDevice::getConnectedClients() {
  * @return The power level currently used in esp_power_level_t or a negative value on error.
  */
 esp_power_level_t NimBLEDevice::getPowerLevel(esp_ble_power_type_t powerType) {
-    esp_power_level_t pwr = esp_ble_tx_power_get(powerType);
+    const esp_power_level_t pwr = esp_ble_tx_power_get(powerType);
 
 #   if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)
     // workaround for bug when "enhanced tx power" was added
@@ -493,12 +493,12 @@ bool NimBLEDevice::setPower(int8_t dbm) {
  * @brief Get the transmission power.
  * @return The power level currently used in dbm or 0xFF on error.
  */
-int NimBLEDevice::getPower() {
+int NimBLEDevice::getPower(const esp_ble_power_type_t powerType) {
 # ifdef ESP_PLATFORM
 #  ifdef CONFIG_IDF_TARGET_ESP32P4
     return 0xFF; // CONFIG_IDF_TARGET_ESP32P4 does not support esp_ble_tx_power_get
 #  else
-    int pwr = getPowerLevel();
+    const int pwr = getPowerLevel(powerType);
     if (pwr < 0) {
         NIMBLE_LOGE(LOG_TAG, "esp_ble_tx_power_get failed rc=%d", pwr);
         return 0xFF;

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -138,7 +138,7 @@ class NimBLEDevice {
     static void          onReset(int reason);
     static void          onSync(void);
     static void          host_task(void* param);
-    static int           getPower();
+    static int           getPower(const esp_ble_power_type_t powerType = ESP_BLE_PWR_TYPE_DEFAULT);
     static bool          setPower(int8_t dbm);
 
 # ifdef ESP_PLATFORM


### PR DESCRIPTION
C3 and S3 have a workaround where different power levels could be set for e.g. advertising or scanning. The workaround does not take into account advertisement data, which keeps sending "default" channel with incorrect dbM value to the advertisement packet. 

The fix should be backwards compatible since it only adds an optional parameter when Tx level is added into the advertisement packet.

Tested and verified that I now see -3 dbM when previously setting the Tx Level like this:

`NimBLEDevice::setPowerLevel(ESP_PWR_LVL_N3, ESP_BLE_PWR_TYPE_ADV);`

Without the fix some default value is transmitted.