### PR TITLE
avoid unused-variable warning

### DIFF
--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -478,12 +478,11 @@ void NimBLEScan::clearResults() {
  * @brief Dump the scan results to the log.
  */
 void NimBLEScanResults::dump() const {
+#if CONFIG_NIMBLE_CPP_LOG_LEVEL >=3
     for (const auto& dev : m_deviceVec) {
         NIMBLE_LOGI(LOG_TAG, "- %s", dev->toString().c_str());
-#if CONFIG_NIMBLE_CPP_LOG_LEVEL < 3
-        (void)dev;
+    }
 #endif
-     }
 } // dump
 
 /**

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -480,7 +480,10 @@ void NimBLEScan::clearResults() {
 void NimBLEScanResults::dump() const {
     for (const auto& dev : m_deviceVec) {
         NIMBLE_LOGI(LOG_TAG, "- %s", dev->toString().c_str());
-    }
+#if CONFIG_NIMBLE_CPP_LOG_LEVEL < 3
+        (void)dev;
+#endif
+     }
 } // dump
 
 /**


### PR DESCRIPTION
Avoid warning when compiled with All warnings enabled.  

```
.../src/NimBLEScan.cpp: In member function 'void NimBLEScanResults::dump() const': 
.../src/NimBLEScan.cpp:481:22: warning: unused variable 'dev' [-Wunused-variable]
  481 |     for (const auto& dev : m_deviceVec) {
      |                      ^~~
```
      
  alternatively the #if could even wrap the whole for loop ...  