### PR TITLE
NimBLEAddress::toString allow formatting to be configured

### DIFF
--- a/src/NimBLEAddress.cpp
+++ b/src/NimBLEAddress.cpp
@@ -23,6 +23,18 @@
 
 # include <algorithm>
 
+# ifdef CONFIG_NIMBLE_CPP_ADDR_FMT_EXCLUDE_DELIMITER
+#  define NIMBLE_CPP_ADDR_DELIMITER ":"
+# else
+#  define NIMBLE_CPP_ADDR_DELIMITER ""
+# endif
+
+# ifdef CONFIG_NIMBLE_CPP_ADDR_FMT_UPPERCASE
+#  define NIMBLE_CPP_ADDR_FMT "%02X%s%02X%s%02X%s%02X%s%02X%s%02X"
+# else
+#  define NIMBLE_CPP_ADDR_FMT "%02x%s%02x%s%02x%s%02x%s%02x%s%02x"
+# endif
+
 static const char* LOG_TAG = "NimBLEAddress";
 
 /*************************************************
@@ -211,12 +223,12 @@ NimBLEAddress::operator std::string() const {
     char buffer[18];
     snprintf(buffer,
              sizeof(buffer),
-             "%02x:%02x:%02x:%02x:%02x:%02x",
-             this->val[5],
-             this->val[4],
-             this->val[3],
-             this->val[2],
-             this->val[1],
+             NIMBLE_CPP_ADDR_FMT,
+             this->val[5], NIMBLE_CPP_ADDR_DELIMITER,
+             this->val[4], NIMBLE_CPP_ADDR_DELIMITER,
+             this->val[3], NIMBLE_CPP_ADDR_DELIMITER,
+             this->val[2], NIMBLE_CPP_ADDR_DELIMITER,
+             this->val[1], NIMBLE_CPP_ADDR_DELIMITER,
              this->val[0]);
     return std::string{buffer};
 } // operator std::string

--- a/src/nimconfig.h
+++ b/src/nimconfig.h
@@ -155,6 +155,16 @@
  */
 // #define CONFIG_NIMBLE_CPP_FREERTOS_TASK_BLOCK_BIT 31
 
+/**
+ * @brief Un-comment to disable showing colon characters when printing address.
+ */
+// #define CONFIG_NIMBLE_CPP_ADDR_FMT_EXCLUDE_DELIMITER 1
+
+/**
+ * @brief Un-comment to use uppercase letters when printing address.
+ */
+//#define CONFIG_NIMBLE_CPP_ADDR_FMT_UPPERCASE 1
+
 /**********************************
  End Arduino user-config
 **********************************/
@@ -359,6 +369,14 @@
 
 #ifndef CONFIG_NIMBLE_CPP_FREERTOS_TASK_BLOCK_BIT
 #define CONFIG_NIMBLE_CPP_FREERTOS_TASK_BLOCK_BIT 31
+#endif
+
+#ifndef CONFIG_NIMBLE_CPP_ADDR_FMT_EXCLUDE_DELIMITER
+#define CONFIG_NIMBLE_CPP_ADDR_FMT_INCLUDE_DELIMITER 0
+#endif
+
+#ifndef CONFIG_NIMBLE_CPP_ADDR_FMT_UPPERCASE
+#define CONFIG_NIMBLE_CPP_ADDR_FMT_UPPERCASE 0
 #endif
 
 #if CONFIG_NIMBLE_CPP_DEBUG_ASSERT_ENABLED && !defined NDEBUG


### PR DESCRIPTION
- Added option CONFIG_NIMBLE_CPP_ADDR_FMT_UPPERCASE
If enabled, allows address to be printed in uppercase letters. (Default: 0)
- Added option CONFIG_NIMBLE_CPP_ADDR_FMT_EXCLUDE_DELIMITER
If enabled, allows address to be printed without colon characters included. (Default: 0)