### PR TITLE
fix lto-type-mismatch between declarations

### DIFF
--- a/src/nimble/nimble/host/src/ble_gap.c
+++ b/src/nimble/nimble/host/src/ble_gap.c
@@ -7941,7 +7941,7 @@ ble_gap_host_check_status(void)
 
     /* Check if privacy is disabled */
 #if MYNEWT_VAL(BLE_HOST_BASED_PRIVACY)
-    extern int is_ble_hs_resolv_enabled(void);
+    extern uint8_t is_ble_hs_resolv_enabled(void);
 
     if (is_ble_hs_resolv_enabled()) {
         BLE_HS_LOG(ERROR, "Host based Privacy not disabled \n");


### PR DESCRIPTION
```
.pio/libdeps/tbeam/NimBLE-Arduino/src/nimble/nimble/host/src/ble_gap.c:7944:16: warning: type of 'is_ble_hs_resolv_enabled' does not match original declaration [-Wlto-type-mismatch]
     extern int is_ble_hs_resolv_enabled(void);
                ^
.pio/libdeps/tbeam/NimBLE-Arduino/src/nimble/nimble/host/src/ble_hs_resolv.c:331:1: note: return value type mismatch
 is_ble_hs_resolv_enabled(void)
 ^
.pio/libdeps/tbeam/NimBLE-Arduino/src/nimble/nimble/host/src/ble_hs_resolv.c:331:1: note: type 'uint8_t' should match type 'int'
.pio/libdeps/tbeam/NimBLE-Arduino/src/nimble/nimble/host/src/ble_hs_resolv.c:331:1: note: 'is_ble_hs_resolv_enabled' was previously declared here
.pio/libdeps/tbeam/Crypto/AESEsp32.cpp:33:5: warning: type of 'esp_aes_setkey' does not match original declaration [-Wlto-type-mismatch]
```