### PR TITLE
[Bugfix] Clear attribute value when zero length value is written.

### DIFF
--- a/src/NimBLEAttValue.cpp
+++ b/src/NimBLEAttValue.cpp
@@ -105,7 +105,8 @@ void NimBLEAttValue::deepCopy(const NimBLEAttValue& source) {
 
 // Set the value of the attribute.
 bool NimBLEAttValue::setValue(const uint8_t* value, uint16_t len) {
-    m_attr_len = 0; // Just set the value length to 0 and append instead of repeating code.
+    m_attr_len      = 0; // Just set the value length to 0 and append instead of repeating code.
+    m_attr_value[0] = '\0'; // Set the first byte to 0 incase the len of the new value is 0.
     append(value, len);
     return memcmp(m_attr_value, value, len) == 0 && m_attr_len == len;
 }

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -635,12 +635,12 @@ int NimBLEServer::handleGattEvent(uint16_t connHandle, uint16_t attrHandle, ble_
         case BLE_GATT_ACCESS_OP_WRITE_DSC:
         case BLE_GATT_ACCESS_OP_WRITE_CHR: {
             uint16_t maxLen = val.max_size();
-            if (ctxt->om->om_len > maxLen) {
+            uint16_t len    = ctxt->om->om_len;
+            if (len > maxLen) {
                 return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
 
-            uint8_t  buf[maxLen];
-            uint16_t len = ctxt->om->om_len;
+            uint8_t buf[maxLen];
             memcpy(buf, ctxt->om->om_data, len);
 
             os_mbuf* next;


### PR DESCRIPTION
Fixes #930 