### PR TITLE
Reduced iram usage

### DIFF
--- a/src/nimble/esp_port/port/include/esp_nimble_cfg.h
+++ b/src/nimble/esp_port/port/include/esp_nimble_cfg.h
@@ -18,11 +18,6 @@
 #define MYNEWT_VAL(x)                           MYNEWT_VAL_ ## x
 #define MYNEWT_VAL_CHOICE(_name, _val)          MYNEWT_VAL_ ## _name ## __ ## _val
 
-#ifndef IRAM_ATTR_64MCPU
-#define IRAM_ATTR_64MCPU
-#endif
-
-
 #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
 #define NIMBLE_CFG_CONTROLLER    0
 #else

--- a/src/nimble/esp_port/port/include/esp_nimble_cfg.h
+++ b/src/nimble/esp_port/port/include/esp_nimble_cfg.h
@@ -19,7 +19,7 @@
 #define MYNEWT_VAL_CHOICE(_name, _val)          MYNEWT_VAL_ ## _name ## __ ## _val
 
 #ifndef IRAM_ATTR_64MCPU
-#define IRAM_ATTR_64MCPU IRAM_ATTR
+#define IRAM_ATTR_64MCPU ARDUINO_ISR_ATTR
 #endif
 
 

--- a/src/nimble/esp_port/port/include/esp_nimble_cfg.h
+++ b/src/nimble/esp_port/port/include/esp_nimble_cfg.h
@@ -19,7 +19,7 @@
 #define MYNEWT_VAL_CHOICE(_name, _val)          MYNEWT_VAL_ ## _name ## __ ## _val
 
 #ifndef IRAM_ATTR_64MCPU
-#define IRAM_ATTR_64MCPU ARDUINO_ISR_ATTR
+#define IRAM_ATTR_64MCPU
 #endif
 
 

--- a/src/nimble/esp_port/port/src/exp_nimble_mem.c
+++ b/src/nimble/esp_port/port/src/exp_nimble_mem.c
@@ -11,7 +11,7 @@
  #include "nimconfig.h"
  #include "../include/esp_nimble_mem.h"
 
- ARDUINO_ISR_ATTR void *nimble_platform_mem_malloc(size_t size)
+ IRAM_ATTR void *nimble_platform_mem_malloc(size_t size)
  {
  #ifdef CONFIG_BT_NIMBLE_MEM_ALLOC_MODE_INTERNAL
      return heap_caps_malloc(size, MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT);
@@ -24,7 +24,7 @@
  #endif
  }
 
- ARDUINO_ISR_ATTR void *nimble_platform_mem_calloc(size_t n, size_t size)
+ IRAM_ATTR void *nimble_platform_mem_calloc(size_t n, size_t size)
  {
  #ifdef CONFIG_BT_NIMBLE_MEM_ALLOC_MODE_INTERNAL
      return heap_caps_calloc(n, size, MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT);

--- a/src/nimble/esp_port/port/src/exp_nimble_mem.c
+++ b/src/nimble/esp_port/port/src/exp_nimble_mem.c
@@ -11,7 +11,7 @@
  #include "nimconfig.h"
  #include "../include/esp_nimble_mem.h"
 
- IRAM_ATTR void *nimble_platform_mem_malloc(size_t size)
+ ARDUINO_ISR_ATTR void *nimble_platform_mem_malloc(size_t size)
  {
  #ifdef CONFIG_BT_NIMBLE_MEM_ALLOC_MODE_INTERNAL
      return heap_caps_malloc(size, MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT);
@@ -24,7 +24,7 @@
  #endif
  }
 
- IRAM_ATTR void *nimble_platform_mem_calloc(size_t n, size_t size)
+ ARDUINO_ISR_ATTR void *nimble_platform_mem_calloc(size_t n, size_t size)
  {
  #ifdef CONFIG_BT_NIMBLE_MEM_ALLOC_MODE_INTERNAL
      return heap_caps_calloc(n, size, MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT);

--- a/src/nimble/esp_port/port/src/exp_nimble_mem.c
+++ b/src/nimble/esp_port/port/src/exp_nimble_mem.c
@@ -11,7 +11,7 @@
  #include "nimconfig.h"
  #include "../include/esp_nimble_mem.h"
 
- IRAM_ATTR void *nimble_platform_mem_malloc(size_t size)
+ void *nimble_platform_mem_malloc(size_t size)
  {
  #ifdef CONFIG_BT_NIMBLE_MEM_ALLOC_MODE_INTERNAL
      return heap_caps_malloc(size, MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT);
@@ -24,7 +24,7 @@
  #endif
  }
 
- IRAM_ATTR void *nimble_platform_mem_calloc(size_t n, size_t size)
+ void *nimble_platform_mem_calloc(size_t n, size_t size)
  {
  #ifdef CONFIG_BT_NIMBLE_MEM_ALLOC_MODE_INTERNAL
      return heap_caps_calloc(n, size, MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT);
@@ -37,7 +37,7 @@
  #endif
  }
 
- IRAM_ATTR void nimble_platform_mem_free(void *ptr)
+ void nimble_platform_mem_free(void *ptr)
  {
      heap_caps_free(ptr);
  }

--- a/src/nimble/porting/nimble/src/nimble_port.c
+++ b/src/nimble/porting/nimble/src/nimble_port.c
@@ -312,7 +312,7 @@ nimble_port_stop(void)
 }
 
 void
-IRAM_ATTR nimble_port_run(void)
+ARDUINO_ISR_ATTR nimble_port_run(void)
 {
     struct ble_npl_event *ev;
 
@@ -328,7 +328,7 @@ IRAM_ATTR nimble_port_run(void)
 }
 
 struct ble_npl_eventq *
-IRAM_ATTR nimble_port_get_dflt_eventq(void)
+ARDUINO_ISR_ATTR nimble_port_get_dflt_eventq(void)
 {
     return &g_eventq_dflt;
 }

--- a/src/nimble/porting/nimble/src/nimble_port.c
+++ b/src/nimble/porting/nimble/src/nimble_port.c
@@ -312,7 +312,7 @@ nimble_port_stop(void)
 }
 
 void
-ARDUINO_ISR_ATTR nimble_port_run(void)
+nimble_port_run(void)
 {
     struct ble_npl_event *ev;
 
@@ -328,7 +328,7 @@ ARDUINO_ISR_ATTR nimble_port_run(void)
 }
 
 struct ble_npl_eventq *
-ARDUINO_ISR_ATTR nimble_port_get_dflt_eventq(void)
+nimble_port_get_dflt_eventq(void)
 {
     return &g_eventq_dflt;
 }

--- a/src/nimble/porting/nimble/src/os_msys_init.c
+++ b/src/nimble/porting/nimble/src/os_msys_init.c
@@ -98,7 +98,7 @@ static struct os_sanity_check os_msys_sc;
  * @return                      The msys pool's minimum safe buffer count.
  */
 static int
-IRAM_ATTR os_msys_sanity_min_count(int idx)
+ARDUINO_ISR_ATTR os_msys_sanity_min_count(int idx)
 {
     switch (idx) {
     case 0:
@@ -114,7 +114,7 @@ IRAM_ATTR os_msys_sanity_min_count(int idx)
 }
 
 static int
-IRAM_ATTR os_msys_sanity(struct os_sanity_check *sc, void *arg)
+ARDUINO_ISR_ATTR os_msys_sanity(struct os_sanity_check *sc, void *arg)
 {
     const struct os_mbuf_pool *omp;
     int min_count;

--- a/src/nimble/porting/nimble/src/os_msys_init.c
+++ b/src/nimble/porting/nimble/src/os_msys_init.c
@@ -98,7 +98,7 @@ static struct os_sanity_check os_msys_sc;
  * @return                      The msys pool's minimum safe buffer count.
  */
 static int
-ARDUINO_ISR_ATTR os_msys_sanity_min_count(int idx)
+os_msys_sanity_min_count(int idx)
 {
     switch (idx) {
     case 0:
@@ -114,7 +114,7 @@ ARDUINO_ISR_ATTR os_msys_sanity_min_count(int idx)
 }
 
 static int
-ARDUINO_ISR_ATTR os_msys_sanity(struct os_sanity_check *sc, void *arg)
+os_msys_sanity(struct os_sanity_check *sc, void *arg)
 {
     const struct os_mbuf_pool *omp;
     int min_count;


### PR DESCRIPTION
The newest versions of Arduino Core seem to treat iram differently (and use a lot more.)

This fixes iram compile issues when using pioarduino with both WiFi and NimBLE. 

Currently not well tested, but client, server, scanning and notifications, seem to work for me. 

