### PR TITLE
add XIAO

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A fork of the NimBLE stack refactored for compilation in the Arduino IDE.
 ## Supported MCU's
  - Espressif: ESP32, ESP32C3, ESP32S3
  - Nordic: nRF51, nRF52 series (**Requires** using [n-able arduino core](https://github.com/h2zero/n-able-Arduino))
+ - Seeed Studio: [XIAO ESP32-C3](https://www.seeedstudio.com/Seeed-XIAO-ESP32C3-p-5431.html)、[XIAO ESP32-C6](https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32C6-p-5884.html)、[XIAO ESP32-S3](https://www.seeedstudio.com/XIAO-ESP32S3-p-5627.html)
 
 **Note for ESP-IDF users: This repo will not compile correctly in ESP-IDF. An ESP-IDF component version of this library can be [found here.](https://github.com/h2zero/esp-nimble-cpp)**
 


### PR DESCRIPTION
<img width="1342" alt="image" src="https://github.com/user-attachments/assets/c5ae7d3b-6c60-4564-9a98-b5c70b733700" />
<img width="1342" alt="image" src="https://github.com/user-attachments/assets/513a2031-4f76-4735-b26d-e69f9ab29fff" />
<img width="1342" alt="image" src="https://github.com/user-attachments/assets/6efb45e7-90a5-45c2-b32e-84669e969ed2" />

Hello! We have successfully implemented the NImBLE routine using the XIAO ESP32 series development board. In order to better support and share this achievement, we would like to add relevant information about our development board in the README file.

Thank you very much for considering our request! Looking forward to your reply.