### PR TITLE
Add iBeacon example

### DIFF
--- a/examples/NimBLE_iBeacon/NimBLE_iBeacon.ino
+++ b/examples/NimBLE_iBeacon/NimBLE_iBeacon.ino
@@ -22,10 +22,9 @@ void setup() {
 
 	// Create beacon object
 	NimBLEBeacon beacon;
-	beacon.setManufacturerId(0x4C00); // fake Apple 0x004C LSB (ENDIAN_CHANGE_U16!)
 	beacon.setMajor(1);
 	beacon.setMinor(1);
-	beacon.setSignalPower(0xC5); // Not required
+	beacon.setSignalPower(0xC5); // Optional
 	beacon.setProximityUUID(BLEUUID(iBeaconUUID)); // Unlike Bluedroid, you do not need to reverse endianness here
 
 	// Extract beacon data

--- a/examples/NimBLE_iBeacon/NimBLE_iBeacon.ino
+++ b/examples/NimBLE_iBeacon/NimBLE_iBeacon.ino
@@ -1,0 +1,46 @@
+/**
+ *  iBeacon example
+ *
+ *  This example demonstrates how to publish an Apple-compatible iBeacon
+ *
+ *  Created: on May 26 2025
+ *      Author: lazd
+ */
+
+#include <Arduino.h>
+#include <NimBLEDevice.h>
+#include <NimBLEBeacon.h>
+
+// According to Apple, it's important to have a 100ms advertising time
+#define BEACON_ADVERTISING_TIME	160   // 100ms
+
+// Hey, you! Replace this with your own unique UUID with something like https://www.uuidgenerator.net/
+const char* iBeaconUUID = "26D0814C-F81C-4B2D-AC57-032E2AFF8642";
+
+void setup() {
+	NimBLEDevice::init("NimBLEiBeacon");
+
+	// Create beacon object
+	NimBLEBeacon beacon;
+	beacon.setManufacturerId(0x4C00); // fake Apple 0x004C LSB (ENDIAN_CHANGE_U16!)
+	beacon.setMajor(1);
+	beacon.setMinor(1);
+	beacon.setSignalPower(0xC5); // Not required
+	beacon.setProximityUUID(BLEUUID(iBeaconUUID)); // Unlike Bluedroid, you do not need to reverse endianness here
+
+	// Extract beacon data
+	NimBLEBeacon::BeaconData beaconData = beacon.getData();
+
+	// Create advertisement data
+ 	NimBLEAdvertisementData beaconAdvertisementData;
+	beaconAdvertisementData.setFlags(0x04); // BR_EDR_NOT_SUPPORTED
+	beaconAdvertisementData.setManufacturerData(reinterpret_cast<const uint8_t*>(&beaconData), sizeof(NimBLEBeacon::BeaconData));
+
+	// Start advertising
+	NimBLEAdvertising *advertising = NimBLEDevice::getAdvertising();
+	advertising->setAdvertisingInterval(BEACON_ADVERTISING_TIME);
+	advertising->setAdvertisementData(beaconAdvertisementData);
+	advertising->start();
+}
+
+void loop() {}

--- a/examples/NimBLE_iBeacon/NimBLE_iBeacon.ino
+++ b/examples/NimBLE_iBeacon/NimBLE_iBeacon.ino
@@ -27,13 +27,10 @@ void setup() {
 	beacon.setSignalPower(0xC5); // Optional
 	beacon.setProximityUUID(BLEUUID(iBeaconUUID)); // Unlike Bluedroid, you do not need to reverse endianness here
 
-	// Extract beacon data
-	NimBLEBeacon::BeaconData beaconData = beacon.getData();
-
 	// Create advertisement data
  	NimBLEAdvertisementData beaconAdvertisementData;
 	beaconAdvertisementData.setFlags(0x04); // BR_EDR_NOT_SUPPORTED
-	beaconAdvertisementData.setManufacturerData(reinterpret_cast<const uint8_t*>(&beaconData), sizeof(NimBLEBeacon::BeaconData));
+	beaconAdvertisementData.setManufacturerData(beacon.getData());
 
 	// Start advertising
 	NimBLEAdvertising *advertising = NimBLEDevice::getAdvertising();

--- a/src/NimBLEBeacon.h
+++ b/src/NimBLEBeacon.h
@@ -24,6 +24,7 @@
 class NimBLEUUID;
 
 # include <cstdint>
+# include <vector>
 
 /**
  * @brief Representation of a beacon.
@@ -40,6 +41,10 @@ class NimBLEBeacon {
         uint16_t major{};
         uint16_t minor{};
         int8_t   signalPower{};
+        operator std::vector<uint8_t> () const {
+            return std::vector<uint8_t>(reinterpret_cast<const uint8_t*>(this),
+                                        reinterpret_cast<const uint8_t*>(this) + sizeof(BeaconData));
+        }
     } __attribute__((packed));
 
     const BeaconData& getData();


### PR DESCRIPTION
This example advertises an iBeacon that is recognized by Apple's CLLocationManager. I've tested this approach with a Swift app I'm building and it works great.

Based loosely on a previous [Bluedroid implementation here](https://github.com/nkolban/ESP32_BLE_Arduino/blob/master/examples/BLE_iBeacon/BLE_iBeacon.ino), modified for NimBLE.

This is the example closes #911

cc @jdbravo