### PR TITLE
Use old freertos porting layer for all but new esp mcu's.

### DIFF
--- a/docs/Command_line_config.md
+++ b/docs/Command_line_config.md
@@ -137,14 +137,7 @@ Sets the core the NimBLE host stack will run on
 `CONFIG_BT_NIMBLE_TASK_STACK_SIZE`  
 
 Set the task stack size for the NimBLE core.  
-- Default is 4096  
-<br/>
-
-`CONFIG_NIMBLE_STACK_USE_MEM_POOLS`
-
- Enable the use of memory pools for stack operations. This will use slightly more RAM but may provide more stability.
- 
-- Options: 0 or 1, default is disabled (0)  
+- Default is 4096   
 <br/>
 
 ### Extended advertising settings, For use with ESP32C3, ESP32S3, ESP32H2 ONLY!

--- a/src/nimble/nimble/host/src/ble_hs.c
+++ b/src/nimble/nimble/host/src/ble_hs.c
@@ -609,7 +609,11 @@ ble_hs_enqueue_hci_event(uint8_t *hci_evt)
     struct ble_npl_event *ev;
 
     ev = os_memblock_get(&ble_hs_hci_ev_pool);
+#if CONFIG_BT_LE_CONTROLLER_NPL_OS_PORTING_SUPPORT
     if (ev && ble_hs_evq->eventq) {
+#else
+    if (ev && ble_hs_evq->q) {
+#endif
         memset (ev, 0, sizeof *ev);
         ble_npl_event_init(ev, ble_hs_event_rx_hci_ev, hci_evt);
         ble_npl_eventq_put(ble_hs_evq, ev);

--- a/src/nimble/porting/nimble/src/nimble_port.c
+++ b/src/nimble/porting/nimble/src/nimble_port.c
@@ -93,30 +93,6 @@ esp_err_t esp_nimble_init(void)
     esp_err_t ret;
 #endif
 #if !SOC_ESP_NIMBLE_CONTROLLER || !CONFIG_BT_CONTROLLER_ENABLED
-    /* Initialize the function pointers for OS porting */
-    npl_freertos_funcs_init();
-
-    npl_freertos_mempool_init();
-
-#if false // Arduino disable
-#if CONFIG_BT_CONTROLLER_ENABLED
-    if(esp_nimble_hci_init() != ESP_OK) {
-        ESP_LOGE(NIMBLE_PORT_LOG_TAG, "hci inits failed\n");
-        return ESP_FAIL;
-    }
-#else
-    ret = ble_buf_alloc();
-    if (ret != ESP_OK) {
-        ble_buf_free();
-        return ESP_FAIL;
-    }
-    ble_transport_init();
-#if MYNEWT_VAL(BLE_QUEUE_CONG_CHECK)
-    ble_adv_list_init();
-#endif
-#endif
-#endif // Arduino disable
-
     /* Initialize default event queue */
     ble_npl_eventq_init(&g_eventq_dflt);
     /* Initialize the global memory pool */
@@ -345,9 +321,6 @@ nimble_port_get_dflt_eventq(void)
 void
 nimble_port_init(void)
 {
-    npl_freertos_funcs_init();
-    npl_freertos_mempool_init();
-
     /* Initialize default event queue */
     ble_npl_eventq_init(&g_eventq_dflt);
     /* Initialize the global memory pool */

--- a/src/nimble/porting/npl/freertos/include/nimble/nimble_npl_os.h
+++ b/src/nimble/porting/npl/freertos/include/nimble/nimble_npl_os.h
@@ -41,7 +41,8 @@ extern "C" {
         (sizeof(array) / sizeof((array)[0]))
 #endif
 
-#ifdef ESP_PLATFORM
+#if CONFIG_BT_LE_CONTROLLER_NPL_OS_PORTING_SUPPORT
+
 extern int ets_printf(const char *fmt, ...);
 #define  BLE_LL_ASSERT(con)                         \
     do{                                             \
@@ -51,9 +52,6 @@ extern int ets_printf(const char *fmt, ...);
             assert(0);                              \
         }                                           \
     }while(0)
-#else
-#define NIMBLE_CFG_CONTROLLER 1
-#endif // ESP_PLATFORM
 
 #define BLE_NPL_OS_ALIGNMENT    (4)/*ble_npl_get_os_alignment()*/
 
@@ -162,12 +160,8 @@ ble_npl_get_current_task_id(void)
 static inline void
 ble_npl_eventq_init(struct ble_npl_eventq *evq)
 {
-#if CONFIG_BT_LE_CONTROLLER_NPL_OS_PORTING_SUPPORT
     void na_npl_freertos_eventq_init(struct ble_npl_eventq *evq);
     na_npl_freertos_eventq_init(evq);
-#else
-    return npl_funcs->p_ble_npl_eventq_init(evq);
-#endif
 }
 
 static inline void
@@ -371,19 +365,11 @@ ble_npl_time_delay(ble_npl_time_t ticks)
 }
 
 #if NIMBLE_CFG_CONTROLLER
-#ifdef ESP_PLATFORM
 static inline void
 ble_npl_hw_set_isr(int irqn, uint32_t addr)
 {
     return npl_funcs->p_ble_npl_hw_set_isr(irqn, addr);
 }
-#else
-static inline void
-ble_npl_hw_set_isr(int irqn, void (*addr)(void))
-{
-    return npl_funcs->p_ble_npl_hw_set_isr(irqn, addr);
-}
-#endif
 #endif
 
 static inline uint32_t
@@ -407,6 +393,334 @@ static inline bool ble_npl_hw_is_in_critical(void)
 #define ble_npl_callout_mem_reset (*npl_funcs->p_ble_npl_callout_mem_reset)
 #define ble_npl_event_deinit (*npl_funcs->p_ble_npl_event_deinit)
 #define ble_npl_event_reset (*npl_funcs->p_ble_npl_event_reset)
+
+#else // CONFIG_BT_LE_CONTROLLER_NPL_OS_PORTING_SUPPORT
+
+#define BLE_NPL_OS_ALIGNMENT    4
+#define BLE_NPL_TIME_FOREVER    portMAX_DELAY
+
+#ifndef ESP_PLATFORM
+#define IRAM_ATTR
+#define NIMBLE_CFG_CONTROLLER 1
+#define NIMBLE_EVT_QUEUE_SIZE 4
+#else
+#define NIMBLE_EVT_QUEUE_SIZE 32
+#endif
+
+/* This should be compatible with TickType_t */
+typedef uint32_t ble_npl_time_t;
+typedef int32_t ble_npl_stime_t;
+
+struct ble_npl_event {
+    bool queued;
+    ble_npl_event_fn *fn;
+    void *arg;
+};
+
+struct ble_npl_eventq {
+    QueueHandle_t q;
+};
+
+struct ble_npl_callout {
+#if CONFIG_BT_NIMBLE_USE_ESP_TIMER
+   esp_timer_handle_t handle;
+#else
+    TimerHandle_t handle;
+#endif
+    struct ble_npl_eventq *evq;
+    struct ble_npl_event ev;
+};
+
+struct ble_npl_mutex {
+    SemaphoreHandle_t handle;
+};
+
+struct ble_npl_sem {
+    SemaphoreHandle_t handle;
+};
+
+/*
+ * Simple APIs are just defined as static inline below, but some are a bit more
+ * complex or require some global state variables and thus are defined in .c
+ * file instead and static inline wrapper just calls proper implementation.
+ * We need declarations of these functions and they are defined in header below.
+ */
+#include "npl_freertos.h"
+
+static inline bool
+ble_npl_os_started(void)
+{
+    return xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED;
+}
+
+static inline void *
+ble_npl_get_current_task_id(void)
+{
+    return xTaskGetCurrentTaskHandle();
+}
+
+static inline void
+ble_npl_eventq_init(struct ble_npl_eventq *evq)
+{
+    evq->q = xQueueCreate(NIMBLE_EVT_QUEUE_SIZE, sizeof(struct ble_npl_eventq *));
+}
+
+static inline void
+ble_npl_eventq_deinit(struct ble_npl_eventq *evq)
+{
+    vQueueDelete(evq->q);
+}
+
+static inline struct ble_npl_event *
+ble_npl_eventq_get(struct ble_npl_eventq *evq, ble_npl_time_t tmo)
+{
+    return npl_freertos_eventq_get(evq, tmo);
+}
+
+static inline void
+ble_npl_eventq_put(struct ble_npl_eventq *evq, struct ble_npl_event *ev)
+{
+    npl_freertos_eventq_put(evq, ev);
+}
+
+static inline void
+ble_npl_eventq_remove(struct ble_npl_eventq *evq, struct ble_npl_event *ev)
+{
+    npl_freertos_eventq_remove(evq, ev);
+}
+
+static inline void
+ble_npl_event_run(struct ble_npl_event *ev)
+{
+    ev->fn(ev);
+}
+
+static inline bool
+ble_npl_eventq_is_empty(struct ble_npl_eventq *evq)
+{
+    return xQueueIsQueueEmptyFromISR(evq->q);
+}
+
+static inline void
+ble_npl_event_init(struct ble_npl_event *ev, ble_npl_event_fn *fn,
+                   void *arg)
+{
+    memset(ev, 0, sizeof(*ev));
+    ev->fn = fn;
+    ev->arg = arg;
+}
+
+static inline void
+ble_npl_event_deinit(struct ble_npl_event *ev)
+{
+
+}
+
+static inline bool
+ble_npl_event_is_queued(struct ble_npl_event *ev)
+{
+    return ev->queued;
+}
+
+static inline void *
+ble_npl_event_get_arg(struct ble_npl_event *ev)
+{
+    return ev->arg;
+}
+
+static inline void
+ble_npl_event_set_arg(struct ble_npl_event *ev, void *arg)
+{
+    ev->arg = arg;
+}
+
+static inline ble_npl_error_t
+ble_npl_mutex_init(struct ble_npl_mutex *mu)
+{
+    return npl_freertos_mutex_init(mu);
+}
+
+static inline ble_npl_error_t
+ble_npl_mutex_deinit(struct ble_npl_mutex *mu)
+{
+    return npl_freertos_mutex_deinit(mu);
+}
+
+static inline ble_npl_error_t
+ble_npl_mutex_pend(struct ble_npl_mutex *mu, ble_npl_time_t timeout)
+{
+    return npl_freertos_mutex_pend(mu, timeout);
+}
+
+static inline ble_npl_error_t
+ble_npl_mutex_release(struct ble_npl_mutex *mu)
+{
+    return npl_freertos_mutex_release(mu);
+}
+
+static inline ble_npl_error_t
+ble_npl_sem_init(struct ble_npl_sem *sem, uint16_t tokens)
+{
+    return npl_freertos_sem_init(sem, tokens);
+}
+
+static inline ble_npl_error_t
+ble_npl_sem_deinit(struct ble_npl_sem *sem)
+{
+    return npl_freertos_sem_deinit(sem);
+}
+
+static inline ble_npl_error_t
+ble_npl_sem_pend(struct ble_npl_sem *sem, ble_npl_time_t timeout)
+{
+    return npl_freertos_sem_pend(sem, timeout);
+}
+
+static inline ble_npl_error_t
+ble_npl_sem_release(struct ble_npl_sem *sem)
+{
+    return npl_freertos_sem_release(sem);
+}
+
+static inline uint16_t
+ble_npl_sem_get_count(struct ble_npl_sem *sem)
+{
+    return uxSemaphoreGetCount(sem->handle);
+}
+
+static inline int
+ble_npl_callout_init(struct ble_npl_callout *co, struct ble_npl_eventq *evq,
+                     ble_npl_event_fn *ev_cb, void *ev_arg)
+{
+    return npl_freertos_callout_init(co, evq, ev_cb, ev_arg);
+}
+
+static inline void
+ble_npl_callout_deinit(struct ble_npl_callout *co)
+{
+    npl_freertos_callout_deinit(co);
+}
+
+static inline ble_npl_error_t
+ble_npl_callout_reset(struct ble_npl_callout *co, ble_npl_time_t ticks)
+{
+    return npl_freertos_callout_reset(co, ticks);
+}
+
+static inline void
+ble_npl_callout_stop(struct ble_npl_callout *co)
+{
+    npl_freertos_callout_stop(co);
+}
+
+static inline bool
+ble_npl_callout_is_active(struct ble_npl_callout *co)
+{
+    return npl_freertos_callout_is_active(co);
+}
+
+static inline ble_npl_time_t
+ble_npl_callout_get_ticks(struct ble_npl_callout *co)
+{
+    return npl_freertos_callout_get_ticks(co);
+}
+
+static inline uint32_t
+ble_npl_callout_remaining_ticks(struct ble_npl_callout *co,
+                                ble_npl_time_t time)
+{
+    return npl_freertos_callout_remaining_ticks(co, time);
+}
+
+static inline void
+ble_npl_callout_set_arg(struct ble_npl_callout *co, void *arg)
+{
+    co->ev.arg = arg;
+}
+
+static inline uint32_t
+ble_npl_time_get(void)
+{
+    return xTaskGetTickCountFromISR();
+}
+
+static inline ble_npl_error_t
+ble_npl_time_ms_to_ticks(uint32_t ms, ble_npl_time_t *out_ticks)
+{
+    return npl_freertos_time_ms_to_ticks(ms, out_ticks);
+}
+
+static inline ble_npl_error_t
+ble_npl_time_ticks_to_ms(ble_npl_time_t ticks, uint32_t *out_ms)
+{
+    return ble_npl_time_ticks_to_ms(ticks, out_ms);
+}
+
+static inline ble_npl_time_t
+ble_npl_time_ms_to_ticks32(uint32_t ms)
+{
+    return ms * configTICK_RATE_HZ / 1000;
+}
+
+static inline uint32_t
+ble_npl_time_ticks_to_ms32(ble_npl_time_t ticks)
+{
+    return ticks * 1000 / configTICK_RATE_HZ;
+}
+
+static inline void
+ble_npl_time_delay(ble_npl_time_t ticks)
+{
+    vTaskDelay(ticks);
+}
+
+#if NIMBLE_CFG_CONTROLLER
+static inline void
+ble_npl_hw_set_isr(int irqn, void (*addr)(void))
+{
+    npl_freertos_hw_set_isr(irqn, addr);
+}
+
+static inline bool
+ble_npl_hw_is_in_critical(void)
+{
+    return (uxGetCriticalNestingDepth() > 0);
+}
+#endif
+
+#ifdef ESP_PLATFORM
+extern portMUX_TYPE ble_port_mutex;
+//critical section
+static inline uint32_t
+ble_npl_hw_enter_critical(void)
+{
+    portENTER_CRITICAL(&ble_port_mutex);
+    return 0;
+}
+
+static inline void
+ble_npl_hw_exit_critical(uint32_t ctx)
+{
+    portEXIT_CRITICAL(&ble_port_mutex);
+}
+
+#else
+static inline uint32_t
+ble_npl_hw_enter_critical(void)
+{
+    vPortEnterCritical();
+    return 0;
+}
+
+static inline void
+ble_npl_hw_exit_critical(uint32_t ctx)
+{
+    (void)ctx;
+    vPortExitCritical();
+}
+#endif
+
+#endif // CONFIG_BT_LE_CONTROLLER_NPL_OS_PORTING_SUPPORT
 
 #ifdef __cplusplus
 }

--- a/src/nimble/porting/npl/freertos/src/npl_os_freertos.c
+++ b/src/nimble/porting/npl/freertos/src/npl_os_freertos.c
@@ -24,285 +24,23 @@
 #include <assert.h>
 #include <stddef.h>
 #include <string.h>
-#include <stdlib.h>
-#include "nimble/console/console.h"
 
 #include "nimble/nimble/include/nimble/nimble_npl.h"
 
-#include "freertos/FreeRTOS.h"
-#include "nimble/porting/nimble/include/os/queue.h"
-#include "freertos/semphr.h"
-#include "freertos/task.h"
-#include "freertos/timers.h"
-#include "freertos/portable.h"
-#include "nimble/porting/npl/freertos/include/nimble/npl_freertos.h"
-
-#include "nimble/porting/nimble/include/os/os_mempool.h"
-
-#if NIMBLE_CFG_CONTROLLER
-#include "nimble/nimble/controller/include/controller/ble_ll.h"
-#endif
-
 #ifdef ESP_PLATFORM
+#include "freertos/portable.h"
 #include "esp_log.h"
-
-#include "soc/soc_caps.h"
-
 portMUX_TYPE ble_port_mutex = portMUX_INITIALIZER_UNLOCKED;
+#  if CONFIG_BT_NIMBLE_USE_ESP_TIMER
+static const char *LOG_TAG = "Timer";
+#  endif
 
 #else
 #include "nrf.h"
-
 static void *radio_isr_addr;
 static void *rng_isr_addr;
 static void *rtc0_isr_addr;
 #endif
-
-#if CONFIG_BT_NIMBLE_USE_ESP_TIMER
-static const char *LOG_TAG = "Timer";
-#endif
-
-#ifdef CONFIG_NIMBLE_STACK_USE_MEM_POOLS
-#define OS_MEM_ALLOC (CONFIG_NIMBLE_STACK_USE_MEM_POOLS)
-#else
-#define OS_MEM_ALLOC (0)
-#endif
-
-#if OS_MEM_ALLOC
-
-#if CONFIG_BT_NIMBLE_ENABLED
-#define BT_LE_HCI_EVT_HI_BUF_COUNT MYNEWT_VAL(BLE_TRANSPORT_EVT_COUNT)
-#define BT_LE_HCI_EVT_LO_BUF_COUNT MYNEWT_VAL(BLE_TRANSPORT_EVT_DISCARDABLE_COUNT)
-#define BT_LE_MAX_EXT_ADV_INSTANCES MYNEWT_VAL(BLE_MULTI_ADV_INSTANCES)
-#define BT_LE_MAX_CONNECTIONS MYNEWT_VAL(BLE_MAX_CONNECTIONS)
-#else
-#include "esp_bt.h"
-#define BT_LE_HCI_EVT_HI_BUF_COUNT DEFAULT_BT_LE_HCI_EVT_HI_BUF_COUNT
-#define BT_LE_HCI_EVT_LO_BUF_COUNT DEFAULT_BT_LE_HCI_EVT_LO_BUF_COUNT
-#define BT_LE_MAX_EXT_ADV_INSTANCES DEFAULT_BT_LE_MAX_EXT_ADV_INSTANCES
-#define BT_LE_MAX_CONNECTIONS DEFAULT_BT_LE_MAX_CONNECTIONS
-#endif
-
-#define BLE_HS_HCI_EVT_COUNT                    \
-    (BT_LE_HCI_EVT_HI_BUF_COUNT +        \
-     BT_LE_HCI_EVT_LO_BUF_COUNT)
-
-
-#define LL_NPL_BASE_EVENT_COUNT     (11)
-#define LL_SCAN_EXT_AUX_EVT_CNT     (MYNEWT_VAL(BLE_LL_EXT_ADV_AUX_PTR_CNT))
-#define HCI_LL_NPL_EVENT_COUNT      (1)
-#define ADV_LL_NPL_EVENT_COUNT      ((BT_LE_MAX_EXT_ADV_INSTANCES+1)*3)
-#define SCAN_LL_NPL_EVENT_COUNT     (2)
-#define RL_LL_NPL_EVENT_COUNT       (1)
-#define SYNC_LL_NPL_EVENT_COUNT     (7)
-
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_CTRL_TO_HOST_FLOW_CONTROL)
-#define LL_CTRL_TO_HOST_FLOW_CTRL_EVT   (1)
-#else
-#define LL_CTRL_TO_HOST_FLOW_CTRL_EVT   (0)
-#endif
-
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_PING)
-#define LL_CFG_FEAT_LE_PING_EVT   (1)
-#else
-#define LL_CFG_FEAT_LE_PING_EVT   (0)
-#endif
-
-#define CONN_MODULE_NPL_EVENT_COUNT (((LL_CFG_FEAT_LE_PING_EVT+2)*BT_LE_MAX_CONNECTIONS)+LL_CTRL_TO_HOST_FLOW_CTRL_EVT)
-
-
-#define BLE_LL_EV_COUNT (LL_NPL_BASE_EVENT_COUNT +      \
-                         LL_SCAN_EXT_AUX_EVT_CNT +      \
-                         HCI_LL_NPL_EVENT_COUNT +       \
-                         ADV_LL_NPL_EVENT_COUNT +       \
-                         SCAN_LL_NPL_EVENT_COUNT +      \
-                         RL_LL_NPL_EVENT_COUNT +        \
-                         SYNC_LL_NPL_EVENT_COUNT +      \
-                         CONN_MODULE_NPL_EVENT_COUNT)
-
-#define BLE_TOTAL_EV_COUNT (BLE_LL_EV_COUNT + BLE_HS_HCI_EVT_COUNT)
-
-#define BLE_TOTAL_EVQ_COUNT (10)
-
-#define BLE_TOTAL_CO_COUNT (40)
-
-#define BLE_TOTAL_SEM_COUNT (10)
-
-#define BLE_TOTAL_MUTEX_COUNT (10)
-
-#if SOC_ESP_NIMBLE_CONTROLLER && CONFIG_BT_CONTROLLER_ENABLED
-
-struct os_mempool ble_freertos_ev_pool;
-static os_membuf_t *ble_freertos_ev_buf = NULL;
-
-struct os_mempool ble_freertos_evq_pool;
-static os_membuf_t *ble_freertos_evq_buf = NULL;
-
-struct os_mempool ble_freertos_co_pool;
-static os_membuf_t *ble_freertos_co_buf = NULL;
-
-struct os_mempool ble_freertos_sem_pool;
-static os_membuf_t *ble_freertos_sem_buf = NULL;
-
-struct os_mempool ble_freertos_mutex_pool;
-static os_membuf_t *ble_freertos_mutex_buf = NULL;
-
-#else
-
-struct os_mempool ble_freertos_ev_pool;
-static os_membuf_t ble_freertos_ev_buf[
-    OS_MEMPOOL_SIZE(BLE_TOTAL_EV_COUNT, sizeof (struct ble_npl_event_freertos))
-];
-
-struct os_mempool ble_freertos_evq_pool;
-static os_membuf_t ble_freertos_evq_buf[
-    OS_MEMPOOL_SIZE(BLE_TOTAL_EVQ_COUNT, sizeof (struct ble_npl_eventq_freertos))
-];
-
-struct os_mempool ble_freertos_co_pool;
-static os_membuf_t ble_freertos_co_buf[
-    OS_MEMPOOL_SIZE(BLE_TOTAL_CO_COUNT, sizeof (struct ble_npl_callout_freertos))
-];
-
-struct os_mempool ble_freertos_sem_pool;
-static os_membuf_t ble_freertos_sem_buf[
-    OS_MEMPOOL_SIZE(BLE_TOTAL_SEM_COUNT, sizeof (struct ble_npl_sem_freertos))
-];
-
-struct os_mempool ble_freertos_mutex_pool;
-static os_membuf_t ble_freertos_mutex_buf[
-    OS_MEMPOOL_SIZE(BLE_TOTAL_MUTEX_COUNT, sizeof (struct ble_npl_mutex_freertos))
-];
-
-#endif
-#else
-
-#ifndef CONFIG_BT_NIMBLE_LL_EVENT_QUEUE_SIZE
-#define CONFIG_BT_NIMBLE_LL_EVENT_QUEUE_SIZE (5)
-#endif
-
-#ifndef CONFIG_BT_NIMBLE_DEFAULT_EVENT_QUEUE_SIZE
-#define CONFIG_BT_NIMBLE_DEFAULT_EVENT_QUEUE_SIZE (10)
-#endif
-
-#define NIMBLE_LL_QUEUE_SIZE CONFIG_BT_NIMBLE_LL_EVENT_QUEUE_SIZE
-#define NIMBLE_DEFAULT_QUEUE_SIZE CONFIG_BT_NIMBLE_DEFAULT_EVENT_QUEUE_SIZE
-
-#endif
-
-bool
-npl_freertos_os_started(void)
-{
-    return xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED;
-}
-
-void *
-npl_freertos_get_current_task_id(void)
-{
-    return xTaskGetCurrentTaskHandle();
-}
-
-void
-npl_freertos_event_init(struct ble_npl_event *ev, ble_npl_event_fn *fn,
-                    void *arg)
-{
-    struct ble_npl_event_freertos *event = NULL;
-#if OS_MEM_ALLOC
-    if (!os_memblock_from(&ble_freertos_ev_pool,ev->event)) {
-        ev->event = os_memblock_get(&ble_freertos_ev_pool);
-    }
-#else
-    if(!ev->event) {
-        ev->event = malloc(sizeof(struct ble_npl_event_freertos));
-    }
-#endif
-    event = (struct ble_npl_event_freertos *)ev->event;
-    BLE_LL_ASSERT(event);
-
-    memset(event, 0, sizeof(*event));
-    event->fn = fn;
-    event->arg = arg;
-}
-
-void
-npl_freertos_event_deinit(struct ble_npl_event *ev)
-{
-    BLE_LL_ASSERT(ev->event);
-#if OS_MEM_ALLOC
-    os_memblock_put(&ble_freertos_ev_pool,ev->event);
-#else
-    free(ev->event);
-#endif
-    ev->event = NULL;
-}
-
-void
-npl_freertos_event_reset(struct ble_npl_event *ev)
-{
-    struct ble_npl_event_freertos *event = (struct ble_npl_event_freertos *)ev->event;
-    BLE_LL_ASSERT(event);
-    event->queued = 0;
-}
-
-void
-npl_freertos_eventq_init(struct ble_npl_eventq *evq)
-{
-    struct ble_npl_eventq_freertos *eventq = NULL;
-#if OS_MEM_ALLOC
-    if (!os_memblock_from(&ble_freertos_evq_pool,evq->eventq)) {
-        evq->eventq = os_memblock_get(&ble_freertos_evq_pool);
-        eventq = (struct ble_npl_eventq_freertos*)evq->eventq;
-        BLE_LL_ASSERT(eventq);
-
-        memset(eventq, 0, sizeof(*eventq));
-        eventq->q = xQueueCreate(BLE_TOTAL_EV_COUNT, sizeof(struct ble_npl_eventq *));
-        BLE_LL_ASSERT(eventq->q);
-    }
-#else
-    if(!evq->eventq) {
-        evq->eventq = malloc(sizeof(struct ble_npl_eventq_freertos));
-        eventq = (struct ble_npl_eventq_freertos*)evq->eventq;
-        BLE_LL_ASSERT(eventq);
-
-        memset(eventq, 0, sizeof(*eventq));
-#if NIMBLE_CFG_CONTROLLER
-        eventq->q = xQueueCreate(evq == &g_ble_ll_data.ll_evq ?
-                                 NIMBLE_LL_QUEUE_SIZE :
-                                 NIMBLE_DEFAULT_QUEUE_SIZE,
-                                 sizeof(struct ble_npl_eventq *));
-#else
-        eventq->q = xQueueCreate(NIMBLE_DEFAULT_QUEUE_SIZE , sizeof(struct ble_npl_eventq *));
-#endif
-        BLE_LL_ASSERT(eventq->q);
-    }
-#endif
-}
-
-void
-npl_freertos_eventq_deinit(struct ble_npl_eventq *evq)
-{
-    struct ble_npl_eventq_freertos *eventq = (struct ble_npl_eventq_freertos *)evq->eventq;
-
-    BLE_LL_ASSERT(eventq);
-    vQueueDelete(eventq->q);
-#if OS_MEM_ALLOC
-    os_memblock_put(&ble_freertos_evq_pool,eventq);
-#else
-    free((void *)eventq);
-#endif
-    evq->eventq = NULL;
-}
-
-void
-npl_freertos_callout_mem_reset(struct ble_npl_callout *co)
-{
-    struct ble_npl_callout_freertos *callout = (struct ble_npl_callout_freertos *)co->co;
-
-    BLE_LL_ASSERT(callout);
-    BLE_LL_ASSERT(callout->handle);
-
-    ble_npl_event_reset(&callout->ev);
-}
 
 #ifdef ESP_PLATFORM
 static inline bool
@@ -360,15 +98,13 @@ struct ble_npl_event *
 npl_freertos_eventq_get(struct ble_npl_eventq *evq, ble_npl_time_t tmo)
 {
     struct ble_npl_event *ev = NULL;
-    struct ble_npl_eventq_freertos *eventq = (struct ble_npl_eventq_freertos *)evq->eventq;
     BaseType_t woken;
     BaseType_t ret;
 
     if (in_isr()) {
-        BLE_LL_ASSERT(tmo == 0);
-        ret = xQueueReceiveFromISR(eventq->q, &ev, &woken);
+        assert(tmo == 0);
+        ret = xQueueReceiveFromISR(evq->q, &ev, &woken);
 #ifdef ESP_PLATFORM
-
         if( woken == pdTRUE ) {
             portYIELD_FROM_ISR();
         }
@@ -376,15 +112,12 @@ npl_freertos_eventq_get(struct ble_npl_eventq *evq, ble_npl_time_t tmo)
         portYIELD_FROM_ISR(woken);
 #endif
     } else {
-        ret = xQueueReceive(eventq->q, &ev, tmo);
+        ret = xQueueReceive(evq->q, &ev, tmo);
     }
-    BLE_LL_ASSERT(ret == pdPASS || ret == errQUEUE_EMPTY);
+    assert(ret == pdPASS || ret == errQUEUE_EMPTY);
 
     if (ev) {
-	struct ble_npl_event_freertos *event = (struct ble_npl_event_freertos *)ev->event;
-	if (event) {
-            event->queued = false;
-	}
+        ev->queued = false;
     }
 
     return ev;
@@ -395,17 +128,15 @@ npl_freertos_eventq_put(struct ble_npl_eventq *evq, struct ble_npl_event *ev)
 {
     BaseType_t woken;
     BaseType_t ret;
-    struct ble_npl_eventq_freertos *eventq = (struct ble_npl_eventq_freertos *)evq->eventq;
-    struct ble_npl_event_freertos *event = (struct ble_npl_event_freertos *)ev->event;
 
-    if (event->queued) {
+    if (ev->queued) {
         return;
     }
 
-    event->queued = true;
+    ev->queued = true;
 
     if (in_isr()) {
-        ret = xQueueSendToBackFromISR(eventq->q, &ev, &woken);
+        ret = xQueueSendToBackFromISR(evq->q, &ev, &woken);
 #ifdef ESP_PLATFORM
         if( woken == pdTRUE ) {
             portYIELD_FROM_ISR();
@@ -414,25 +145,23 @@ npl_freertos_eventq_put(struct ble_npl_eventq *evq, struct ble_npl_event *ev)
         portYIELD_FROM_ISR(woken);
 #endif
     } else {
-        ret = xQueueSendToBack(eventq->q, &ev, portMAX_DELAY);
+        ret = xQueueSendToBack(evq->q, &ev, portMAX_DELAY);
     }
 
-    BLE_LL_ASSERT(ret == pdPASS);
+    assert(ret == pdPASS);
 }
 
 void
 npl_freertos_eventq_remove(struct ble_npl_eventq *evq,
-                       struct ble_npl_event *ev)
+                      struct ble_npl_event *ev)
 {
     struct ble_npl_event *tmp_ev;
     BaseType_t ret;
     int i;
     int count;
     BaseType_t woken, woken2;
-    struct ble_npl_eventq_freertos *eventq = (struct ble_npl_eventq_freertos *)evq->eventq;
-    struct ble_npl_event_freertos *event = (struct ble_npl_event_freertos *)ev->event;
 
-    if (!event->queued) {
+    if (!ev->queued) {
         return;
     }
 
@@ -446,18 +175,18 @@ npl_freertos_eventq_remove(struct ble_npl_eventq *evq,
     if (in_isr()) {
         woken = pdFALSE;
 
-        count = uxQueueMessagesWaitingFromISR(eventq->q);
+        count = uxQueueMessagesWaitingFromISR(evq->q);
         for (i = 0; i < count; i++) {
-            ret = xQueueReceiveFromISR(eventq->q, &tmp_ev, &woken2);
-            BLE_LL_ASSERT(ret == pdPASS);
+            ret = xQueueReceiveFromISR(evq->q, &tmp_ev, &woken2);
+            assert(ret == pdPASS);
             woken |= woken2;
 
             if (tmp_ev == ev) {
                 continue;
             }
 
-            ret = xQueueSendToBackFromISR(eventq->q, &tmp_ev, &woken2);
-            BLE_LL_ASSERT(ret == pdPASS);
+            ret = xQueueSendToBackFromISR(evq->q, &tmp_ev, &woken2);
+            assert(ret == pdPASS);
             woken |= woken2;
         }
 
@@ -472,22 +201,20 @@ npl_freertos_eventq_remove(struct ble_npl_eventq *evq,
 #ifdef ESP_PLATFORM
         portMUX_TYPE ble_npl_mut = portMUX_INITIALIZER_UNLOCKED;
         portENTER_CRITICAL(&ble_npl_mut);
-
-        count = uxQueueMessagesWaiting(eventq->q);
 #else
         vPortEnterCritical();
-        count = uxQueueMessagesWaiting(eventq->q);
 #endif
+        count = uxQueueMessagesWaiting(evq->q);
         for (i = 0; i < count; i++) {
-            ret = xQueueReceive(eventq->q, &tmp_ev, 0);
-            BLE_LL_ASSERT(ret == pdPASS);
+            ret = xQueueReceive(evq->q, &tmp_ev, 0);
+            assert(ret == pdPASS);
 
             if (tmp_ev == ev) {
                 continue;
             }
 
-            ret = xQueueSendToBack(eventq->q, &tmp_ev, 0);
-            BLE_LL_ASSERT(ret == pdPASS);
+            ret = xQueueSendToBack(evq->q, &tmp_ev, 0);
+            assert(ret == pdPASS);
         }
 #ifdef ESP_PLATFORM
         portEXIT_CRITICAL(&ble_npl_mut);
@@ -496,40 +223,18 @@ npl_freertos_eventq_remove(struct ble_npl_eventq *evq,
 #endif
     }
 
-    event->queued = 0;
+    ev->queued = 0;
 }
 
 ble_npl_error_t
 npl_freertos_mutex_init(struct ble_npl_mutex *mu)
 {
-    struct ble_npl_mutex_freertos *mutex = NULL;
-#if OS_MEM_ALLOC
-    if (!os_memblock_from(&ble_freertos_mutex_pool,mu->mutex)) {
-        mu->mutex = os_memblock_get(&ble_freertos_mutex_pool);
-        mutex = (struct ble_npl_mutex_freertos *)mu->mutex;
-
-        if (!mutex) {
-            return BLE_NPL_INVALID_PARAM;
-        }
-
-        memset(mutex, 0, sizeof(*mutex));
-        mutex->handle = xSemaphoreCreateRecursiveMutex();
-        BLE_LL_ASSERT(mutex->handle);
+    if (!mu) {
+        return BLE_NPL_INVALID_PARAM;
     }
-#else
-    if(!mu->mutex) {
-        mu->mutex = malloc(sizeof(struct ble_npl_mutex_freertos));
-        mutex = (struct ble_npl_mutex_freertos *)mu->mutex;
 
-        if (!mutex) {
-            return BLE_NPL_INVALID_PARAM;
-        }
-
-        memset(mutex, 0, sizeof(*mutex));
-        mutex->handle = xSemaphoreCreateRecursiveMutex();
-        BLE_LL_ASSERT(mutex->handle);
-    }
-#endif
+    mu->handle = xSemaphoreCreateRecursiveMutex();
+    assert(mu->handle);
 
     return BLE_NPL_OK;
 }
@@ -537,88 +242,33 @@ npl_freertos_mutex_init(struct ble_npl_mutex *mu)
 ble_npl_error_t
 npl_freertos_mutex_deinit(struct ble_npl_mutex *mu)
 {
-    struct ble_npl_mutex_freertos *mutex = (struct ble_npl_mutex_freertos *)mu->mutex;
-
-    if (!mutex) {
+    if (!mu) {
         return BLE_NPL_INVALID_PARAM;
     }
 
-    BLE_LL_ASSERT(mutex->handle);
-    vSemaphoreDelete(mutex->handle);
-
-#if OS_MEM_ALLOC
-    os_memblock_put(&ble_freertos_mutex_pool,mutex);
-#else
-    free((void *)mutex);
-#endif
-    mu->mutex = NULL;
+    if (mu->handle) {
+        vSemaphoreDelete(mu->handle);
+    }
 
     return BLE_NPL_OK;
 }
-
-void
-npl_freertos_event_run(struct ble_npl_event *ev)
-{
-    struct ble_npl_event_freertos *event = (struct ble_npl_event_freertos *)ev->event;
-    if (event) {
-        event->fn(ev);
-    }
-}
-
-bool
-npl_freertos_eventq_is_empty(struct ble_npl_eventq *evq)
-{
-    struct ble_npl_eventq_freertos *eventq = (struct ble_npl_eventq_freertos *)evq->eventq;
-    return xQueueIsQueueEmptyFromISR(eventq->q);
-}
-
-bool
-npl_freertos_event_is_queued(struct ble_npl_event *ev)
-{
-    struct ble_npl_event_freertos *event = (struct ble_npl_event_freertos *)ev->event;
-    if (event) {
-        return event->queued;
-    }
-    return false;
-}
-
-void *
-npl_freertos_event_get_arg(struct ble_npl_event *ev)
-{
-    struct ble_npl_event_freertos *event = (struct ble_npl_event_freertos *)ev->event;
-    if (event) {
-        return event->arg;
-    }
-    return NULL;
-}
-
-void
-npl_freertos_event_set_arg(struct ble_npl_event *ev, void *arg)
-{
-    struct ble_npl_event_freertos *event = (struct ble_npl_event_freertos *)ev->event;
-    if (event) {
-        event->arg = arg;
-    }
-}
-
 
 ble_npl_error_t
 npl_freertos_mutex_pend(struct ble_npl_mutex *mu, ble_npl_time_t timeout)
 {
     BaseType_t ret;
-    struct ble_npl_mutex_freertos *mutex = (struct ble_npl_mutex_freertos *)mu->mutex;
 
-    if (!mutex) {
+    if (!mu) {
         return BLE_NPL_INVALID_PARAM;
     }
 
-    BLE_LL_ASSERT(mutex->handle);
+    assert(mu->handle);
 
     if (in_isr()) {
         ret = pdFAIL;
-        BLE_LL_ASSERT(0);
+        assert(0);
     } else {
-        ret = xSemaphoreTakeRecursive(mutex->handle, timeout);
+        ret = xSemaphoreTakeRecursive(mu->handle, timeout);
     }
 
     return ret == pdPASS ? BLE_NPL_OK : BLE_NPL_TIMEOUT;
@@ -627,18 +277,16 @@ npl_freertos_mutex_pend(struct ble_npl_mutex *mu, ble_npl_time_t timeout)
 ble_npl_error_t
 npl_freertos_mutex_release(struct ble_npl_mutex *mu)
 {
-    struct ble_npl_mutex_freertos *mutex = (struct ble_npl_mutex_freertos *)mu->mutex;
-
-    if (!mutex) {
+    if (!mu) {
         return BLE_NPL_INVALID_PARAM;
     }
 
-    BLE_LL_ASSERT(mutex->handle);
+    assert(mu->handle);
 
     if (in_isr()) {
-        BLE_LL_ASSERT(0);
+        assert(0);
     } else {
-        if (xSemaphoreGiveRecursive(mutex->handle) != pdPASS) {
+        if (xSemaphoreGiveRecursive(mu->handle) != pdPASS) {
             return BLE_NPL_BAD_MUTEX;
         }
     }
@@ -649,34 +297,12 @@ npl_freertos_mutex_release(struct ble_npl_mutex *mu)
 ble_npl_error_t
 npl_freertos_sem_init(struct ble_npl_sem *sem, uint16_t tokens)
 {
-    struct ble_npl_sem_freertos *semaphor = NULL;
-#if OS_MEM_ALLOC
-    if (!os_memblock_from(&ble_freertos_sem_pool,sem->sem)) {
-        sem->sem = os_memblock_get(&ble_freertos_sem_pool);
-        semaphor = (struct ble_npl_sem_freertos *)sem->sem;
-
-        if (!semaphor) {
-            return BLE_NPL_INVALID_PARAM;
-        }
-
-        memset(semaphor, 0, sizeof(*semaphor));
-        semaphor->handle = xSemaphoreCreateCounting(128, tokens);
-        BLE_LL_ASSERT(semaphor->handle);
+    if (!sem) {
+        return BLE_NPL_INVALID_PARAM;
     }
-#else
-    if(!sem->sem) {
-        sem->sem = malloc(sizeof(struct ble_npl_sem_freertos));
-        semaphor = (struct ble_npl_sem_freertos *)sem->sem;
 
-        if (!semaphor) {
-            return BLE_NPL_INVALID_PARAM;
-        }
-
-        memset(semaphor, 0, sizeof(*semaphor));
-        semaphor->handle = xSemaphoreCreateCounting(128, tokens);
-        BLE_LL_ASSERT(semaphor->handle);
-    }
-#endif
+    sem->handle = xSemaphoreCreateCounting(128, tokens);
+    assert(sem->handle);
 
     return BLE_NPL_OK;
 }
@@ -684,21 +310,13 @@ npl_freertos_sem_init(struct ble_npl_sem *sem, uint16_t tokens)
 ble_npl_error_t
 npl_freertos_sem_deinit(struct ble_npl_sem *sem)
 {
-    struct ble_npl_sem_freertos *semaphor = (struct ble_npl_sem_freertos *)sem->sem;
-
-    if (!semaphor) {
+    if (!sem) {
         return BLE_NPL_INVALID_PARAM;
     }
 
-    BLE_LL_ASSERT(semaphor->handle);
-    vSemaphoreDelete(semaphor->handle);
-
-#if OS_MEM_ALLOC
-    os_memblock_put(&ble_freertos_sem_pool,semaphor);
-#else
-    free((void *)semaphor);
-#endif
-    sem->sem = NULL;
+    if (sem->handle) {
+        vSemaphoreDelete(sem->handle);
+    }
 
     return BLE_NPL_OK;
 }
@@ -708,17 +326,16 @@ npl_freertos_sem_pend(struct ble_npl_sem *sem, ble_npl_time_t timeout)
 {
     BaseType_t woken;
     BaseType_t ret;
-    struct ble_npl_sem_freertos *semaphor = (struct ble_npl_sem_freertos *)sem->sem;
 
-    if (!semaphor) {
+    if (!sem) {
         return BLE_NPL_INVALID_PARAM;
     }
 
-    BLE_LL_ASSERT(semaphor->handle);
+    assert(sem->handle);
 
     if (in_isr()) {
-        BLE_LL_ASSERT(timeout == 0);
-        ret = xSemaphoreTakeFromISR(semaphor->handle, &woken);
+        assert(timeout == 0);
+        ret = xSemaphoreTakeFromISR(sem->handle, &woken);
 #ifdef ESP_PLATFORM
         if( woken == pdTRUE ) {
             portYIELD_FROM_ISR();
@@ -727,7 +344,7 @@ npl_freertos_sem_pend(struct ble_npl_sem *sem, ble_npl_time_t timeout)
         portYIELD_FROM_ISR(woken);
 #endif
     } else {
-        ret = xSemaphoreTake(semaphor->handle, timeout);
+        ret = xSemaphoreTake(sem->handle, timeout);
     }
 
     return ret == pdPASS ? BLE_NPL_OK : BLE_NPL_TIMEOUT;
@@ -738,16 +355,15 @@ npl_freertos_sem_release(struct ble_npl_sem *sem)
 {
     BaseType_t ret;
     BaseType_t woken;
-    struct ble_npl_sem_freertos *semaphor = (struct ble_npl_sem_freertos *)sem->sem;
 
-    if (!semaphor) {
+    if (!sem) {
         return BLE_NPL_INVALID_PARAM;
     }
 
-    BLE_LL_ASSERT(semaphor->handle);
+    assert(sem->handle);
 
     if (in_isr()) {
-        ret = xSemaphoreGiveFromISR(semaphor->handle, &woken);
+        ret = xSemaphoreGiveFromISR(sem->handle, &woken);
 #ifdef ESP_PLATFORM
         if( woken == pdTRUE ) {
             portYIELD_FROM_ISR();
@@ -756,25 +372,24 @@ npl_freertos_sem_release(struct ble_npl_sem *sem)
         portYIELD_FROM_ISR(woken);
 #endif
     } else {
-        ret = xSemaphoreGive(semaphor->handle);
+        ret = xSemaphoreGive(sem->handle);
     }
 
-    BLE_LL_ASSERT(ret == pdPASS);
+    assert(ret == pdPASS);
     return BLE_NPL_OK;
 }
+
 
 #if CONFIG_BT_NIMBLE_USE_ESP_TIMER
 static void
 ble_npl_event_fn_wrapper(void *arg)
 {
-    struct ble_npl_callout_freertos *callout = (struct ble_npl_callout_freertos *)arg;
-    BLE_LL_ASSERT(callout);
+    struct ble_npl_callout *co = (struct ble_npl_callout *)arg;
 
-    if (callout->evq) {
-        ble_npl_eventq_put(callout->evq, &callout->ev);
+    if (co->evq) {
+        ble_npl_eventq_put(co->evq, &co->ev);
     } else {
-        struct ble_npl_event_freertos *event = (struct ble_npl_event_freertos *)callout->ev.event;
-        event->fn(&callout->ev);
+        co->ev.fn(&co->ev);
     }
 }
 
@@ -791,122 +406,53 @@ ble_npl_error_t esp_err_to_npl_error(esp_err_t err)
     case ESP_OK:
         return BLE_NPL_OK;
 
-   default:
+    default:
         return BLE_NPL_ERROR;
     }
 }
 #else
-
 static void
 os_callout_timer_cb(TimerHandle_t timer)
 {
-    struct ble_npl_callout_freertos *callout;
+    struct ble_npl_callout *co;
 
-    callout = pvTimerGetTimerID(timer);
-    BLE_LL_ASSERT(callout);
+    co = pvTimerGetTimerID(timer);
+    assert(co);
 
-    if (callout->evq) {
-        ble_npl_eventq_put(callout->evq, &callout->ev);
+    if (co->evq) {
+        ble_npl_eventq_put(co->evq, &co->ev);
     } else {
-        struct ble_npl_event_freertos *event = (struct ble_npl_event_freertos *)callout->ev.event;
-        event->fn(&callout->ev);
+        co->ev.fn(&co->ev);
     }
 }
 #endif
 
 int
 npl_freertos_callout_init(struct ble_npl_callout *co, struct ble_npl_eventq *evq,
-                      ble_npl_event_fn *ev_cb, void *ev_arg)
+                          ble_npl_event_fn *ev_cb, void *ev_arg)
 {
-    struct ble_npl_callout_freertos *callout = NULL;
-
-#if OS_MEM_ALLOC
-    if (!os_memblock_from(&ble_freertos_co_pool, co->co)) {
-        co->co = os_memblock_get(&ble_freertos_co_pool);
-        callout = (struct ble_npl_callout_freertos *)co->co;
-        BLE_LL_ASSERT(callout);
-
-        memset(callout, 0, sizeof(*callout));
-        ble_npl_event_init(&callout->ev, ev_cb, ev_arg);
-
 #if CONFIG_BT_NIMBLE_USE_ESP_TIMER
-	callout->evq = evq;
+    co->ev.fn = ev_cb;
+    co->ev.arg = ev_arg;
+    co->evq = evq;
 
-	esp_timer_create_args_t create_args = {
-		.callback = ble_npl_event_fn_wrapper,
-		.arg = callout,
-		.name = "nimble_timer"
-	};
+    esp_timer_create_args_t create_args = {
+      .callback = ble_npl_event_fn_wrapper,
+      .arg = co,
+      .name = "nimble_timer"
+    };
 
-        if (esp_timer_create(&create_args, &callout->handle) != ESP_OK) {
-            ble_npl_event_deinit(&callout->ev);
-            os_memblock_put(&ble_freertos_co_pool,callout);
-            co->co = NULL;
-            return -1;
-        }
-
+    ESP_ERROR_CHECK(esp_timer_create(&create_args, &co->handle));
 #else
-	callout->handle = xTimerCreate("co", 1, pdFALSE, callout, os_callout_timer_cb);
-
-        if (!callout->handle) {
-            ble_npl_event_deinit(&callout->ev);
-            os_memblock_put(&ble_freertos_co_pool,callout);
-            co->co = NULL;
+    if (co->handle == NULL) {
+        co->handle = xTimerCreate("co", 1, pdFALSE, co, os_callout_timer_cb);
+        if (co->handle == NULL) {
             return -1;
         }
-
-#endif
-
-    } else {
-	callout = (struct ble_npl_callout_freertos *)co->co;
-	BLE_LL_ASSERT(callout);
-	callout->evq = evq;
-	ble_npl_event_init(&callout->ev, ev_cb, ev_arg);
     }
-#else
 
-    if(!co->co) {
-        co->co = malloc(sizeof(struct ble_npl_callout_freertos));
-        callout = (struct ble_npl_callout_freertos *)co->co;
-        if (!callout) {
-            return -1;
-        }
-
-	memset(callout, 0, sizeof(*callout));
-        ble_npl_event_init(&callout->ev, ev_cb, ev_arg);
-
-#if CONFIG_BT_NIMBLE_USE_ESP_TIMER
-	callout->evq = evq;
-
-	esp_timer_create_args_t create_args = {
-		.callback = ble_npl_event_fn_wrapper,
-		.arg = callout,
-		.name = "nimble_timer"
-	};
-
-        if (esp_timer_create(&create_args, &callout->handle) != ESP_OK) {
-            ble_npl_event_deinit(&callout->ev);
-            free((void *)callout);
-            co->co = NULL;
-            return -1;
-        }
-#else
-	callout->handle = xTimerCreate("co", 1, pdFALSE, callout, os_callout_timer_cb);
-
-        if (!callout->handle) {
-            ble_npl_event_deinit(&callout->ev);
-            free((void *)callout);
-            co->co = NULL;
-            return -1;
-        }
-#endif
-    }
-    else {
-        callout = (struct ble_npl_callout_freertos *)co->co;
-        BLE_LL_ASSERT(callout);
-	callout->evq = evq;
-	ble_npl_event_init(&callout->ev, ev_cb, ev_arg);
-    }
+    co->evq = evq;
+    ble_npl_event_init(&co->ev, ev_cb, ev_arg);
 #endif
     return 0;
 }
@@ -914,51 +460,30 @@ npl_freertos_callout_init(struct ble_npl_callout *co, struct ble_npl_eventq *evq
 void
 npl_freertos_callout_deinit(struct ble_npl_callout *co)
 {
-    struct ble_npl_callout_freertos *callout = (struct ble_npl_callout_freertos *)co->co;
-
-    /* Since we dynamically deinit timers, function can be called for NULL timers. Return for such scenarios */
-    if (!callout) {
+    if (!co->handle) {
         return;
     }
 
-    BLE_LL_ASSERT(callout->handle);
-    ble_npl_event_deinit(&callout->ev);
 #if CONFIG_BT_NIMBLE_USE_ESP_TIMER
-    if(esp_timer_stop(callout->handle))
-        ESP_LOGD(LOG_TAG, "Timer not stopped");
+    if(esp_timer_stop(co->handle))
+	ESP_LOGW(LOG_TAG, "Timer not stopped");
 
-    if(esp_timer_delete(callout->handle))
-        ESP_LOGW(LOG_TAG, "Timer not deleted");
+    if(esp_timer_delete(co->handle))
+	ESP_LOGW(LOG_TAG, "Timer not deleted");
 #else
-    xTimerDelete(callout->handle, portMAX_DELAY);
+    xTimerDelete(co->handle, portMAX_DELAY);
+    ble_npl_event_deinit(&co->ev);
 #endif
-
-#if OS_MEM_ALLOC
-    os_memblock_put(&ble_freertos_co_pool,callout);
-#else
-    free((void *)callout);
-#endif
-
-    co->co = NULL;
     memset(co, 0, sizeof(struct ble_npl_callout));
 }
-
-uint16_t
-npl_freertos_sem_get_count(struct ble_npl_sem *sem)
-{
-    struct ble_npl_sem_freertos *semaphor = (struct ble_npl_sem_freertos *)sem->sem;
-    return uxSemaphoreGetCount(semaphor->handle);
-}
-
 
 ble_npl_error_t
 npl_freertos_callout_reset(struct ble_npl_callout *co, ble_npl_time_t ticks)
 {
-    struct ble_npl_callout_freertos *callout = (struct ble_npl_callout_freertos *)co->co;
 #if CONFIG_BT_NIMBLE_USE_ESP_TIMER
-    esp_timer_stop(callout->handle);
+    esp_timer_stop(co->handle);
 
-    return esp_err_to_npl_error(esp_timer_start_once(callout->handle, ticks*1000));
+    return esp_err_to_npl_error(esp_timer_start_once(co->handle, ticks*1000));
 #else
 
     BaseType_t woken1, woken2, woken3;
@@ -966,10 +491,11 @@ npl_freertos_callout_reset(struct ble_npl_callout *co, ble_npl_time_t ticks)
     if (ticks == 0) {
         ticks = 1;
     }
+
     if (in_isr()) {
-        xTimerStopFromISR(callout->handle, &woken1);
-        xTimerChangePeriodFromISR(callout->handle, ticks, &woken2);
-        xTimerResetFromISR(callout->handle, &woken3);
+        xTimerStopFromISR(co->handle, &woken1);
+        xTimerChangePeriodFromISR(co->handle, ticks, &woken2);
+        xTimerResetFromISR(co->handle, &woken3);
 #ifdef ESP_PLATFORM
         if( woken1 == pdTRUE || woken2 == pdTRUE || woken3 == pdTRUE) {
             portYIELD_FROM_ISR();
@@ -978,9 +504,9 @@ npl_freertos_callout_reset(struct ble_npl_callout *co, ble_npl_time_t ticks)
         portYIELD_FROM_ISR(woken1 || woken2 || woken3);
 #endif
     } else {
-        xTimerStop(callout->handle, portMAX_DELAY);
-        xTimerChangePeriod(callout->handle, ticks, portMAX_DELAY);
-        xTimerReset(callout->handle, portMAX_DELAY);
+        xTimerStop(co->handle, portMAX_DELAY);
+        xTimerChangePeriod(co->handle, ticks, portMAX_DELAY);
+        xTimerReset(co->handle, portMAX_DELAY);
     }
 
     return BLE_NPL_OK;
@@ -990,32 +516,27 @@ npl_freertos_callout_reset(struct ble_npl_callout *co, ble_npl_time_t ticks)
 void
 npl_freertos_callout_stop(struct ble_npl_callout *co)
 {
-    struct ble_npl_callout_freertos *callout = (struct ble_npl_callout_freertos *)co->co;
-
-    if (!callout) {
-	return;
+    if (!co->handle) {
+        return;
     }
-
 #if CONFIG_BT_NIMBLE_USE_ESP_TIMER
-    esp_timer_stop(callout->handle);
+    esp_timer_stop(co->handle);
 #else
-    xTimerStop(callout->handle, portMAX_DELAY);
+    xTimerStop(co->handle, portMAX_DELAY);
 #endif
 }
 
 bool
 npl_freertos_callout_is_active(struct ble_npl_callout *co)
 {
-    struct ble_npl_callout_freertos *callout = (struct ble_npl_callout_freertos *)co->co;
 #if CONFIG_BT_NIMBLE_USE_ESP_TIMER
-    return esp_timer_is_active(callout->handle);
+    return esp_timer_is_active(co->handle);
 #else
     /* Workaround for bug in xTimerIsTimerActive with FreeRTOS V10.2.0, fixed in V10.4.4
      * See: https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/305
      * Sometimes xTimerIsTimerActive returns pdTRUE even though the timer has expired, so we double check.
      */
-    return xTimerIsTimerActive(callout->handle) == pdTRUE &&
-           xTimerGetExpiryTime(callout->handle) > xTaskGetTickCountFromISR();
+    return xTimerIsTimerActive(co->handle) == pdTRUE && xTimerGetExpiryTime(co->handle) > xTaskGetTickCountFromISR();
 #endif
 }
 
@@ -1033,8 +554,7 @@ npl_freertos_callout_get_ticks(struct ble_npl_callout *co)
 
     return 0;
 #else
-    struct ble_npl_callout_freertos *callout = (struct ble_npl_callout_freertos *)co->co;
-    return xTimerGetExpiryTime(callout->handle);
+    return xTimerGetExpiryTime(co->handle);
 #endif
 }
 
@@ -1045,15 +565,13 @@ npl_freertos_callout_remaining_ticks(struct ble_npl_callout *co,
     ble_npl_time_t rt;
     uint32_t exp = 0;
 
-    struct ble_npl_callout_freertos *callout = (struct ble_npl_callout_freertos *)co->co;
-
 #if CONFIG_BT_NIMBLE_USE_ESP_TIMER
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
     uint64_t expiry = 0;
     esp_err_t err;
 
     //Fetch expiry time in microseconds
-    err = esp_timer_get_expiry_time((esp_timer_handle_t)(callout->handle), &expiry);
+    err = esp_timer_get_expiry_time((esp_timer_handle_t)(co->handle), &expiry);
     if (err != ESP_OK) {
         //Error. Could not fetch the expiry time
         return 0;
@@ -1067,7 +585,7 @@ npl_freertos_callout_remaining_ticks(struct ble_npl_callout *co,
     exp = 0;
 #endif //ESP_IDF_VERSION
 #else
-    exp = xTimerGetExpiryTime(callout->handle);
+    exp = xTimerGetExpiryTime(co->handle);
 #endif
 
     if (exp > now) {
@@ -1079,33 +597,12 @@ npl_freertos_callout_remaining_ticks(struct ble_npl_callout *co,
     return rt;
 }
 
-void
-npl_freertos_callout_set_arg(struct ble_npl_callout *co, void *arg)
-{
-    struct ble_npl_callout_freertos *callout = (struct ble_npl_callout_freertos *)co->co;
-    struct ble_npl_event_freertos *event = (struct ble_npl_event_freertos *)callout->ev.event;
-    event->arg = arg;
-}
-
-uint32_t
-npl_freertos_time_get(void)
-{
-#if CONFIG_BT_NIMBLE_USE_ESP_TIMER
-    return esp_timer_get_time() / 1000;
-#else
-    return xTaskGetTickCountFromISR();
-#endif
-}
-
 ble_npl_error_t
 npl_freertos_time_ms_to_ticks(uint32_t ms, ble_npl_time_t *out_ticks)
 {
     uint64_t ticks;
-#if CONFIG_BT_NIMBLE_USE_ESP_TIMER
-    ticks = (uint64_t)ms;
-#else
+
     ticks = ((uint64_t)ms * configTICK_RATE_HZ) / 1000;
-#endif
     if (ticks > UINT32_MAX) {
         return BLE_NPL_EINVAL;
     }
@@ -1119,11 +616,8 @@ ble_npl_error_t
 npl_freertos_time_ticks_to_ms(ble_npl_time_t ticks, uint32_t *out_ms)
 {
     uint64_t ms;
-#if CONFIG_BT_NIMBLE_USE_ESP_TIMER
-    ms = ((uint64_t)ticks);
-#else
+
     ms = ((uint64_t)ticks * 1000) / configTICK_RATE_HZ;
-#endif
     if (ms > UINT32_MAX) {
         return BLE_NPL_EINVAL;
      }
@@ -1133,283 +627,7 @@ npl_freertos_time_ticks_to_ms(ble_npl_time_t ticks, uint32_t *out_ms)
     return 0;
 }
 
-ble_npl_time_t
-npl_freertos_time_ms_to_ticks32(uint32_t ms)
-{
-#if CONFIG_BT_NIMBLE_USE_ESP_TIMER
-    return ms;
-#else
-    return ms * configTICK_RATE_HZ / 1000;
-#endif
-}
-
-uint32_t
-npl_freertos_time_ticks_to_ms32(ble_npl_time_t ticks)
-{
-#if CONFIG_BT_NIMBLE_USE_ESP_TIMER
-    return ticks;
-#else
-    return ticks * 1000 / configTICK_RATE_HZ;
-#endif
-}
-
-void
-npl_freertos_time_delay(ble_npl_time_t ticks)
-{
-#if CONFIG_BT_NIMBLE_USE_ESP_TIMER
-    vTaskDelay(ticks / portTICK_PERIOD_MS);
-#else
-    vTaskDelay(ticks);
-#endif
-}
-
-#ifdef ESP_PLATFORM
-#if NIMBLE_CFG_CONTROLLER || CONFIG_NIMBLE_CONTROLLER_MODE
-void
-npl_freertos_hw_set_isr(int irqn, uint32_t addr)
-{
-    //Do nothing
-}
-#endif
-#endif
-
-
-uint8_t hw_critical_state_status = 0;
-
-uint32_t
-npl_freertos_hw_enter_critical(void)
-{
-    ++hw_critical_state_status;
-#ifdef ESP_PLATFORM
-    portENTER_CRITICAL(&ble_port_mutex);
-#else
-    portENTER_CRITICAL();
-#endif
-    return 0;
-}
-
-uint8_t
-npl_freertos_hw_is_in_critical(void)
-{
-    return hw_critical_state_status;
-}
-
-void
-npl_freertos_hw_exit_critical(uint32_t ctx)
-{
-    --hw_critical_state_status;
-#ifdef ESP_PLATFORM
-    portEXIT_CRITICAL(&ble_port_mutex);
-#else
-    portEXIT_CRITICAL();
-#endif
-
-
-}
-
-uint32_t
-npl_freertos_get_time_forever(void)
-{
-    return portMAX_DELAY;
-}
-
-const struct npl_funcs_t npl_funcs_ro = {
-    .p_ble_npl_os_started = npl_freertos_os_started,
-    .p_ble_npl_get_current_task_id = npl_freertos_get_current_task_id,
-    .p_ble_npl_eventq_init = npl_freertos_eventq_init,
-    .p_ble_npl_eventq_deinit = npl_freertos_eventq_deinit,
-    .p_ble_npl_eventq_get = npl_freertos_eventq_get,
-    .p_ble_npl_eventq_put = npl_freertos_eventq_put,
-    .p_ble_npl_eventq_remove = npl_freertos_eventq_remove,
-    .p_ble_npl_event_run = npl_freertos_event_run,
-    .p_ble_npl_eventq_is_empty = npl_freertos_eventq_is_empty,
-    .p_ble_npl_event_init = npl_freertos_event_init,
-    .p_ble_npl_event_deinit = npl_freertos_event_deinit,
-    .p_ble_npl_event_reset = npl_freertos_event_reset,
-    .p_ble_npl_event_is_queued = npl_freertos_event_is_queued,
-    .p_ble_npl_event_get_arg = npl_freertos_event_get_arg,
-    .p_ble_npl_event_set_arg = npl_freertos_event_set_arg,
-    .p_ble_npl_mutex_init = npl_freertos_mutex_init,
-    .p_ble_npl_mutex_deinit = npl_freertos_mutex_deinit,
-    .p_ble_npl_mutex_pend = npl_freertos_mutex_pend,
-    .p_ble_npl_mutex_release = npl_freertos_mutex_release,
-    .p_ble_npl_sem_init = npl_freertos_sem_init,
-    .p_ble_npl_sem_deinit = npl_freertos_sem_deinit,
-    .p_ble_npl_sem_pend = npl_freertos_sem_pend,
-    .p_ble_npl_sem_release = npl_freertos_sem_release,
-    .p_ble_npl_sem_get_count = npl_freertos_sem_get_count,
-    .p_ble_npl_callout_init = npl_freertos_callout_init,
-    .p_ble_npl_callout_reset = npl_freertos_callout_reset,
-    .p_ble_npl_callout_stop = npl_freertos_callout_stop,
-    .p_ble_npl_callout_deinit = npl_freertos_callout_deinit,
-    .p_ble_npl_callout_mem_reset = npl_freertos_callout_mem_reset,
-    .p_ble_npl_callout_is_active = npl_freertos_callout_is_active,
-    .p_ble_npl_callout_get_ticks = npl_freertos_callout_get_ticks,
-    .p_ble_npl_callout_remaining_ticks = npl_freertos_callout_remaining_ticks,
-    .p_ble_npl_callout_set_arg = npl_freertos_callout_set_arg,
-    .p_ble_npl_time_get = npl_freertos_time_get,
-    .p_ble_npl_time_ms_to_ticks = npl_freertos_time_ms_to_ticks,
-    .p_ble_npl_time_ticks_to_ms = npl_freertos_time_ticks_to_ms,
-    .p_ble_npl_time_ms_to_ticks32 = npl_freertos_time_ms_to_ticks32,
-    .p_ble_npl_time_ticks_to_ms32 = npl_freertos_time_ticks_to_ms32,
-    .p_ble_npl_time_delay = npl_freertos_time_delay,
-#if NIMBLE_CFG_CONTROLLER || CONFIG_NIMBLE_CONTROLLER_MODE
-    .p_ble_npl_hw_set_isr = npl_freertos_hw_set_isr,
-#endif
-    .p_ble_npl_hw_enter_critical = npl_freertos_hw_enter_critical,
-    .p_ble_npl_hw_exit_critical = npl_freertos_hw_exit_critical,
-    .p_ble_npl_get_time_forever = npl_freertos_get_time_forever,
-    .p_ble_npl_hw_is_in_critical = npl_freertos_hw_is_in_critical
-};
-
-struct npl_funcs_t *npl_funcs = NULL;
-
-struct npl_funcs_t * npl_freertos_funcs_get(void)
-{
-    return npl_funcs;
-}
-
-void npl_freertos_funcs_init(void)
-{
-    npl_funcs = (struct npl_funcs_t *)malloc(sizeof(struct npl_funcs_t));
-    if(!npl_funcs) {
-        printf("npl funcs init failed\n");
-        assert(0);
-    }
-    memcpy(npl_funcs, &npl_funcs_ro, sizeof(struct npl_funcs_t));
-}
-
-int npl_freertos_mempool_init(void)
-{
-#if OS_MEM_ALLOC
-    int rc = -1;
-
-#if SOC_ESP_NIMBLE_CONTROLLER && CONFIG_BT_CONTROLLER_ENABLED
-    ble_freertos_ev_buf  = malloc(OS_MEMPOOL_SIZE(BLE_TOTAL_EV_COUNT, sizeof (struct ble_npl_event_freertos)) * sizeof(os_membuf_t));
-    if(!ble_freertos_ev_buf) {
-        goto _error;
-    }
-    ble_freertos_evq_buf  = malloc(OS_MEMPOOL_SIZE(BLE_TOTAL_EVQ_COUNT, sizeof (struct ble_npl_eventq_freertos)) * sizeof(os_membuf_t));
-    if(!ble_freertos_evq_buf) {
-        goto _error;
-    }
-    ble_freertos_co_buf  = malloc(OS_MEMPOOL_SIZE(BLE_TOTAL_CO_COUNT, sizeof (struct ble_npl_callout_freertos)) * sizeof(os_membuf_t));
-    if(!ble_freertos_co_buf) {
-        goto _error;
-    }
-    ble_freertos_sem_buf  = malloc(OS_MEMPOOL_SIZE(BLE_TOTAL_SEM_COUNT, sizeof (struct ble_npl_sem_freertos)) * sizeof(os_membuf_t));
-    if(!ble_freertos_sem_buf) {
-        goto _error;
-    }
-    ble_freertos_mutex_buf  = malloc( OS_MEMPOOL_SIZE(BLE_TOTAL_MUTEX_COUNT, sizeof (struct ble_npl_mutex_freertos)) * sizeof(os_membuf_t));
-    if(!ble_freertos_mutex_buf) {
-        goto _error;
-    }
-
-#endif
-
-    rc = os_mempool_init(&ble_freertos_ev_pool, BLE_TOTAL_EV_COUNT,
-                         sizeof (struct ble_npl_event_freertos), ble_freertos_ev_buf,
-                         "ble_freertos_ev_pool");
-    if(rc != 0) {
-        goto _error;
-    }
-
-    rc = os_mempool_init(&ble_freertos_evq_pool, BLE_TOTAL_EVQ_COUNT,
-                         sizeof (struct ble_npl_eventq_freertos), ble_freertos_evq_buf,
-                         "ble_freertos_evq_pool");
-    if(rc != 0) {
-        goto _error;
-    }
-
-    rc = os_mempool_init(&ble_freertos_co_pool, BLE_TOTAL_CO_COUNT,
-                         sizeof (struct ble_npl_callout_freertos), ble_freertos_co_buf,
-                         "ble_freertos_co_pool");
-    if(rc != 0) {
-        goto _error;
-    }
-
-    rc = os_mempool_init(&ble_freertos_sem_pool, BLE_TOTAL_SEM_COUNT,
-                         sizeof (struct ble_npl_sem_freertos), ble_freertos_sem_buf,
-                         "ble_freertos_sem_pool");
-    if(rc != 0) {
-        goto _error;
-    }
-
-    rc = os_mempool_init(&ble_freertos_mutex_pool, BLE_TOTAL_MUTEX_COUNT,
-                         sizeof (struct ble_npl_mutex_freertos), ble_freertos_mutex_buf,
-                         "ble_freertos_mutex_pool");
-    if(rc == 0) {
-        return rc;
-    }
-_error:
-
-#if SOC_ESP_NIMBLE_CONTROLLER && CONFIG_BT_CONTROLLER_ENABLED
-    if(ble_freertos_ev_buf) {
-        free(ble_freertos_ev_buf);
-	ble_freertos_ev_buf = NULL;
-    }
-    if(ble_freertos_evq_buf) {
-        free(ble_freertos_evq_buf);
-	ble_freertos_evq_buf = NULL;
-    }
-    if(ble_freertos_co_buf) {
-        free(ble_freertos_co_buf);
-	ble_freertos_co_buf = NULL;
-    }
-    if(ble_freertos_sem_buf) {
-        free(ble_freertos_sem_buf);
-	ble_freertos_sem_buf = NULL;
-    }
-    if(ble_freertos_mutex_buf) {
-        free(ble_freertos_mutex_buf);
-	ble_freertos_mutex_buf = NULL;
-    }
-    return -1;
-#else
-
-   BLE_LL_ASSERT(rc == 0);
-   return rc;
-#endif
-#endif // OS_MEM_ALLOC
-return 0;
-}
-
-void npl_freertos_mempool_deinit(void)
-{
-#if OS_MEM_ALLOC && SOC_ESP_NIMBLE_CONTROLLER && CONFIG_BT_CONTROLLER_ENABLED
-    if(ble_freertos_ev_buf) {
-        free(ble_freertos_ev_buf);
-	ble_freertos_ev_buf = NULL;
-    }
-    if(ble_freertos_evq_buf) {
-        free(ble_freertos_evq_buf);
-	ble_freertos_evq_buf = NULL;
-    }
-    if(ble_freertos_co_buf) {
-        free(ble_freertos_co_buf);
-	ble_freertos_co_buf = NULL;
-    }
-    if(ble_freertos_sem_buf) {
-        free(ble_freertos_sem_buf);
-	ble_freertos_sem_buf = NULL;
-    }
-    if(ble_freertos_mutex_buf) {
-        free(ble_freertos_mutex_buf);
-	ble_freertos_mutex_buf = NULL;
-    }
-#endif
-}
-
-void npl_freertos_funcs_deinit(void)
-{
-    if (npl_funcs) {
-        free(npl_funcs);
-    }
-    npl_funcs = NULL;
-}
-
-#else
+#else // !CONFIG_BT_LE_CONTROLLER_NPL_OS_PORTING_SUPPORT
 
 #include <assert.h>
 #include <stddef.h>

--- a/src/nimconfig.h
+++ b/src/nimconfig.h
@@ -150,12 +150,6 @@
 // #define CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE 4096
 
 /**
- * @brief Un-comment to use memory pools for stack operations
- * @details this will use slightly more RAM but may provide more stability.
- */
-// #define CONFIG_NIMBLE_STACK_USE_MEM_POOLS 1
-
-/**
  * @brief Un-comment to change the bit used to block tasks during BLE operations
  * that call NimBLEUtils::taskWait. This should be different than any other
  * task notification flag used in the system.
@@ -272,10 +266,6 @@
 
 #ifndef CONFIG_BT_NIMBLE_LOG_LEVEL
 #define CONFIG_BT_NIMBLE_LOG_LEVEL 5
-#endif
-
-#ifndef CONFIG_NIMBLE_STACK_USE_MEM_POOLS
-#define CONFIG_NIMBLE_STACK_USE_MEM_POOLS 0
 #endif
 
 /** @brief Maximum number of connection oriented channels */


### PR DESCRIPTION
The old porting layer was more efficient and worked better for non-esp devices.