### PR TITLE
Change default security settings to BLE secure connections off.

### DIFF
--- a/examples/NimBLE_Client/NimBLE_Client.ino
+++ b/examples/NimBLE_Client/NimBLE_Client.ino
@@ -266,8 +266,7 @@ void setup() {
      *  These are the default values, only shown here for demonstration.
      */
     // NimBLEDevice::setSecurityAuth(false, false, true);
-
-    NimBLEDevice::setSecurityAuth(/*BLE_SM_PAIR_AUTHREQ_BOND | BLE_SM_PAIR_AUTHREQ_MITM |*/ BLE_SM_PAIR_AUTHREQ_SC);
+    // NimBLEDevice::setSecurityAuth(BLE_SM_PAIR_AUTHREQ_BOND | BLE_SM_PAIR_AUTHREQ_MITM | BLE_SM_PAIR_AUTHREQ_SC);
 
     /** Optional: set the transmit power */
     NimBLEDevice::setPower(3); /** 3dbm */

--- a/examples/NimBLE_Secure_Client/NimBLE_Secure_Client.ino
+++ b/examples/NimBLE_Secure_Client/NimBLE_Secure_Client.ino
@@ -30,7 +30,7 @@ void setup() {
 
     NimBLEDevice::init("");
     NimBLEDevice::setPower(3);                               /** +3db */
-    NimBLEDevice::setSecurityAuth(true, true, true);         /** bonding, MITM, BLE secure connections */
+    NimBLEDevice::setSecurityAuth(true, true, false);        /** bonding, MITM, don't need BLE secure connections as we are using passkey pairing */
     NimBLEDevice::setSecurityIOCap(BLE_HS_IO_KEYBOARD_ONLY); /** passkey */
     NimBLEScan*       pScan   = NimBLEDevice::getScan();
     NimBLEScanResults results = pScan->getResults(5 * 1000);

--- a/examples/NimBLE_Secure_Server/NimBLE_Secure_Server.ino
+++ b/examples/NimBLE_Secure_Server/NimBLE_Secure_Server.ino
@@ -19,7 +19,7 @@ void setup() {
     NimBLEDevice::init("NimBLE");
     NimBLEDevice::setPower(3); /** +3db */
 
-    NimBLEDevice::setSecurityAuth(true, true, true); /** bonding, MITM, BLE secure connections */
+    NimBLEDevice::setSecurityAuth(true, true, false); /** bonding, MITM, don't need BLE secure connections as we are using passkey pairing */
     NimBLEDevice::setSecurityPasskey(123456);
     NimBLEDevice::setSecurityIOCap(BLE_HS_IO_DISPLAY_ONLY); /** Display only passkey */
     NimBLEServer*         pServer                  = NimBLEDevice::createServer();

--- a/examples/NimBLE_Server/NimBLE_Server.ino
+++ b/examples/NimBLE_Server/NimBLE_Server.ino
@@ -144,8 +144,8 @@ void setup(void) {
      *  These are the default values, only shown here for demonstration.
      */
     // NimBLEDevice::setSecurityAuth(false, false, true);
+    // NimBLEDevice::setSecurityAuth(BLE_SM_PAIR_AUTHREQ_BOND | BLE_SM_PAIR_AUTHREQ_MITM | BLE_SM_PAIR_AUTHREQ_SC);
 
-    NimBLEDevice::setSecurityAuth(/*BLE_SM_PAIR_AUTHREQ_BOND | BLE_SM_PAIR_AUTHREQ_MITM |*/ BLE_SM_PAIR_AUTHREQ_SC);
     pServer = NimBLEDevice::createServer();
     pServer->setCallbacks(&serverCallbacks);
 

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -975,7 +975,7 @@ bool NimBLEDevice::init(const std::string& deviceName) {
         ble_hs_cfg.sm_io_cap         = BLE_HS_IO_NO_INPUT_OUTPUT;
         ble_hs_cfg.sm_bonding        = 0;
         ble_hs_cfg.sm_mitm           = 0;
-        ble_hs_cfg.sm_sc             = 1;
+        ble_hs_cfg.sm_sc             = 0;
         ble_hs_cfg.sm_our_key_dist   = BLE_SM_PAIR_KEY_DIST_ENC;
         ble_hs_cfg.sm_their_key_dist = BLE_SM_PAIR_KEY_DIST_ENC;
 # if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)


### PR DESCRIPTION
Fixing some connection issues when enabled, users should enable if desired.