### PR TITLE
[Bugfix](workaround) OnConnect not being called.

### DIFF
--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -988,6 +988,10 @@ int NimBLEClient::handleGapEvent(struct ble_gap_event* event, void* arg) {
             }
 
             rc = event->connect.status;
+            if (rc == BLE_ERR_UNSUPP_REM_FEATURE) {
+                rc = 0; // Workaround: Ignore unsupported remote feature error as it is not a real error.
+            }
+
             if (rc == 0) {
                 pClient->m_connHandle = event->connect.conn_handle;
 

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -354,8 +354,15 @@ int NimBLEServer::handleGapEvent(ble_gap_event* event, void* arg) {
 
     switch (event->type) {
         case BLE_GAP_EVENT_CONNECT: {
-            if (event->connect.status != 0) {
-                NIMBLE_LOGE(LOG_TAG, "Connection failed");
+            rc = event->connect.status;
+            if (rc == BLE_ERR_UNSUPP_REM_FEATURE) {
+                rc = 0; // Workaround: Ignore unsupported remote feature error as it is not a real error.
+            }
+
+            if (rc != 0) {
+                NIMBLE_LOGE(LOG_TAG, "Connection failed rc = %d %s",
+                            rc,
+                            NimBLEUtils::returnCodeToString(rc));
 # if !CONFIG_BT_NIMBLE_EXT_ADV && CONFIG_BT_NIMBLE_ROLE_BROADCASTER
                 NimBLEDevice::startAdvertising();
 # endif


### PR DESCRIPTION
Upstream changes have resulted in a possible status of BLE_ERR_UNSUPP_REM_FEATURE, this resulted in the onConnect callback not being called despite the connection actually being created. This works around that bug to ensure that the connections are correctly tracked.

Fixes #975 