### PR TITLE
Refactor notify/indicate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.13"
       - name: Install platformio
         run: |
           python -m pip install --upgrade pip
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.13"
       - name: Install platformio
         run: |
           python -m pip install --upgrade pip
@@ -145,7 +145,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.13"
       - name: Install platformio
         run: |
           python -m pip install --upgrade pip
@@ -297,7 +297,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.13"
       - name: Install platformio
         run: |
           python -m pip install --upgrade pip
@@ -340,7 +340,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.13"
       - name: Install platformio
         run: |
           python -m pip install --upgrade pip

--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -501,6 +501,18 @@ void NimBLECharacteristicCallbacks::onStatus(NimBLECharacteristic* pCharacterist
 } // onStatus
 
 /**
+ * @brief Callback function to support a Notify/Indicate Status report.
+ * @param [in] pCharacteristic The characteristic that is the source of the event.
+ * @param [in] connInfo A reference to a NimBLEConnInfo instance containing the peer info.
+ * @param [in] code Status return code from the NimBLE stack.
+ * @details The status code for success is 0 for notifications and BLE_HS_EDONE for indications,
+ * any other value is an error.
+ */
+void NimBLECharacteristicCallbacks::onStatus(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo, int code) {
+    NIMBLE_LOGD("NimBLECharacteristicCallbacks", "onStatus: default");
+} // onStatus
+
+/**
  * @brief Callback function called when a client changes subscription status.
  * @param [in] pCharacteristic The characteristic that is the source of the event.
  * @param [in] connInfo A reference to a NimBLEConnInfo instance containing the peer info.

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -276,7 +276,8 @@ class NimBLECharacteristicCallbacks {
     virtual ~NimBLECharacteristicCallbacks() {}
     virtual void onRead(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo);
     virtual void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo);
-    virtual void onStatus(NimBLECharacteristic* pCharacteristic, int code);
+    virtual void onStatus(NimBLECharacteristic* pCharacteristic, int code); // deprecated
+    virtual void onStatus(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo, int code);
     virtual void onSubscribe(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo, uint16_t subValue);
 };
 

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -31,6 +31,7 @@ class NimBLE2904;
 
 # include <string>
 # include <vector>
+# include <array>
 
 /**
  * @brief The model of a BLE Characteristic.
@@ -233,9 +234,34 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
                    bool           is_notification = true,
                    uint16_t       connHandle      = BLE_HS_CONN_HANDLE_NONE) const;
 
+    struct SubPeerEntry {
+        enum : uint8_t { AWAITING_SECURE = 1 << 0, SECURE = 1 << 1, SUB_NOTIFY = 1 << 2, SUB_INDICATE = 1 << 3 };
+        void     setConnHandle(uint16_t connHandle) { m_connHandle = connHandle; }
+        uint16_t getConnHandle() const { return m_connHandle; }
+        void setAwaitingSecure(bool awaiting) { awaiting ? m_flags |= AWAITING_SECURE : m_flags &= ~AWAITING_SECURE; }
+        void setSecured(bool secure) { secure ? m_flags |= SECURE : m_flags &= ~SECURE; }
+        void setSubNotify(bool notify) { notify ? m_flags |= SUB_NOTIFY : m_flags &= ~SUB_NOTIFY; }
+        void setSubIndicate(bool indicate) { indicate ? m_flags |= SUB_INDICATE : m_flags &= ~SUB_INDICATE; }
+        bool isSubNotify() const { return m_flags & SUB_NOTIFY; }
+        bool isSubIndicate() const { return m_flags & SUB_INDICATE; }
+        bool isSecured() const { return m_flags & SECURE; }
+        bool isAwaitingSecure() const { return m_flags & AWAITING_SECURE; }
+
+      private:
+        uint16_t m_connHandle{BLE_HS_CONN_HANDLE_NONE};
+        uint8_t  m_flags{0};
+    };
+    __attribute__((packed));
+
+    using SubPeerArray = std::array<SubPeerEntry, MYNEWT_VAL(BLE_MAX_CONNECTIONS)>;
+    SubPeerArray getSubscribers() const { return m_subPeers; }
+    void         processSubRequest(NimBLEConnInfo& connInfo, uint8_t subVal) const;
+    void         updatePeerStatus(const NimBLEConnInfo& peerInfo) const;
+
     NimBLECharacteristicCallbacks* m_pCallbacks{nullptr};
     NimBLEService*                 m_pService{nullptr};
     std::vector<NimBLEDescriptor*> m_vDescriptors{};
+    mutable SubPeerArray           m_subPeers{};
 }; // NimBLECharacteristic
 
 /**

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -487,6 +487,7 @@ int NimBLEServer::handleGapEvent(ble_gap_event* event, void* arg) {
             }
 
             pChar->m_pCallbacks->onStatus(pChar, event->notify_tx.status);
+            pChar->m_pCallbacks->onStatus(pChar, peerInfo, event->notify_tx.status);
             break;
         } // BLE_GAP_EVENT_NOTIFY_TX
 

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -72,6 +72,7 @@ class NimBLEServer {
     NimBLEService*        getServiceByUUID(const char* uuid, uint16_t instanceId = 0) const;
     NimBLEService*        getServiceByUUID(const NimBLEUUID& uuid, uint16_t instanceId = 0) const;
     NimBLEService*        getServiceByHandle(uint16_t handle) const;
+    NimBLECharacteristic* getCharacteristicByHandle(uint16_t handle) const;
     void                  removeService(NimBLEService* service, bool deleteSvc = false);
     void                  addService(NimBLEService* service);
     uint16_t              getPeerMTU(uint16_t connHandle) const;
@@ -118,6 +119,10 @@ class NimBLEServer {
 
     NimBLEServer();
     ~NimBLEServer();
+    static int handleGapEvent(struct ble_gap_event* event, void* arg);
+    static int handleGattEvent(uint16_t connHandle, uint16_t attrHandle, ble_gatt_access_ctxt* ctxt, void* arg);
+    void       serviceChanged();
+    void       resetGATT();
 
     bool m_gattsStarted : 1;
     bool m_svcChanged : 1;
@@ -125,19 +130,13 @@ class NimBLEServer {
 # if !MYNEWT_VAL(BLE_EXT_ADV)
     bool m_advertiseOnDisconnect : 1;
 # endif
-    NimBLEServerCallbacks*                                 m_pServerCallbacks;
-    std::vector<NimBLEService*>                            m_svcVec;
+    NimBLEServerCallbacks*                                m_pServerCallbacks;
+    std::vector<NimBLEService*>                           m_svcVec;
     std::array<uint16_t, MYNEWT_VAL(BLE_MAX_CONNECTIONS)> m_connectedPeers;
 
 # if MYNEWT_VAL(BLE_ROLE_CENTRAL)
     NimBLEClient* m_pClient{nullptr};
 # endif
-
-    static int handleGapEvent(struct ble_gap_event* event, void* arg);
-    static int handleGattEvent(uint16_t connHandle, uint16_t attrHandle, ble_gatt_access_ctxt* ctxt, void* arg);
-    void       serviceChanged();
-    void       resetGATT();
-
 }; // NimBLEServer
 
 /**


### PR DESCRIPTION
This refactors the handling of sending notifications and indications for greater efficiency.
* Adds client subscription state tracking to NimBLECharacteristic rather than relying on the stack.
* Notifications/indications are now sent directly, no longer calling the callback to read the values. This avoids delays and flash writes in the stack, allowing for greater throughput.
* Notifications will now wait up to 10ms if buffers are full to reattempt transmission before failing. 
* Adds a new overloaded callback to NimBLECharacteristicCallbacks for the notification/indication onStatus method that provides a NimBLEConnInfo reference.

#918