### PR TITLE
Characteristic Aggregate Format Descriptor (0x2905) support for Peripheral device

### DIFF
--- a/src/NimBLE2905.cpp
+++ b/src/NimBLE2905.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020-2025 Ryan Powell <ryan@nable-embedded.io> and
+ * esp-nimble-cpp, NimBLE-Arduino contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "NimBLE2905.h"
+#include "NimBLELog.h"
+
+#include "NimBLECharacteristic.h"
+#if CONFIG_BT_NIMBLE_ENABLED && MYNEWT_VAL(BLE_ROLE_PERIPHERAL)
+
+// Define default if not already defined
+#ifndef NIMBLE_MAX_AGGREGATE_FORMAT_DESCRIPTORS
+    #define NIMBLE_MAX_AGGREGATE_FORMAT_DESCRIPTORS 5  // Default value
+#else
+    // Ensure the value is within a valid range
+    #if NIMBLE_MAX_AGGREGATE_FORMAT_DESCRIPTORS < 1 || NIMBLE_MAX_AGGREGATE_FORMAT_DESCRIPTORS > 255
+        #error "NIMBLE_MAX_AGGREGATE_FORMAT_DESCRIPTORS must be between 1 and 128"
+    #endif
+#endif
+
+static const char* LOG_TAG = "NimBLE2905";
+
+NimBLE2905::NimBLE2905(NimBLECharacteristic* pChr)
+    : NimBLEDescriptor(NimBLEUUID(static_cast<uint16_t>(0x2905)), BLE_GATT_CHR_F_READ, NIMBLE_MAX_AGGREGATE_FORMAT_DESCRIPTORS * sizeof(uint16_t), pChr) {
+} // NimBLE2905
+
+void NimBLE2905::initValue() {
+    const size_t count = m_vAggregatedDescriptors.size();
+    uint16_t aggregatedHandles[count];
+
+    for (size_t i = 0; i < count; ++i) {
+        auto* desc = m_vAggregatedDescriptors[i];
+        uint16_t handle = desc->getHandle();
+
+        if (handle == 0) {
+            NIMBLE_LOGE(LOG_TAG, "Failed to initialize value: presentation format descriptor handle is not initialized");
+            return;
+        }
+
+        aggregatedHandles[i] = desc->getHandle();
+    } // initValue
+
+    setValue(reinterpret_cast<const uint8_t*>(aggregatedHandles), sizeof(aggregatedHandles));
+
+    // Presentation formats no longer needed, let's free some memory
+    m_vAggregatedDescriptors.clear();
+    m_vAggregatedDescriptors.shrink_to_fit();
+} // initValue
+
+
+/**
+ * @brief Add presentation format descriptor.
+ * @param [in] presentationFormat The 2904 descriptor to aggregate.
+ */
+void NimBLE2905::add2904Descriptor(const NimBLE2904* presentationFormat) {
+    if (presentationFormat == nullptr) {
+        NIMBLE_LOGE(LOG_TAG, "Failed to add presentation format descriptor: nullptr");
+        return;
+    }
+
+    if (m_vAggregatedDescriptors.size() < NIMBLE_MAX_AGGREGATE_FORMAT_DESCRIPTORS) {
+        m_vAggregatedDescriptors.push_back(presentationFormat);
+    } else {
+        NIMBLE_LOGE(LOG_TAG, "Failed to add presentation format descriptor: maximum capacity reached");
+    }
+} // add2904Descriptor
+
+
+#endif // CONFIG_BT_NIMBLE_ENABLED && MYNEWT_VAL(BLE_ROLE_PERIPHERAL)

--- a/src/NimBLE2905.cpp
+++ b/src/NimBLE2905.cpp
@@ -38,22 +38,23 @@ NimBLE2905::NimBLE2905(NimBLECharacteristic* pChr)
 } // NimBLE2905
 
 void NimBLE2905::initValue() {
-    const size_t count = m_vAggregatedDescriptors.size();
-    uint16_t aggregatedHandles[count];
+    uint16_t aggregatedHandles[NIMBLE_MAX_AGGREGATE_FORMAT_DESCRIPTORS];
+    size_t validCount = 0;
 
-    for (size_t i = 0; i < count; ++i) {
-        auto* desc = m_vAggregatedDescriptors[i];
+    for (auto* desc : m_vAggregatedDescriptors) {
         uint16_t handle = desc->getHandle();
 
         if (handle == 0) {
             NIMBLE_LOGE(LOG_TAG, "Failed to initialize value: presentation format descriptor handle is not initialized");
-            return;
+            continue;
         }
 
-        aggregatedHandles[i] = desc->getHandle();
-    } // initValue
+        aggregatedHandles[validCount++] = handle;
+    }
 
-    setValue(reinterpret_cast<const uint8_t*>(aggregatedHandles), sizeof(aggregatedHandles));
+    if (validCount > 0) {
+        setValue(reinterpret_cast<const uint8_t*>(aggregatedHandles), validCount * sizeof(uint16_t));
+    }
 
     // Presentation formats no longer needed, let's free some memory
     m_vAggregatedDescriptors.clear();

--- a/src/NimBLE2905.cpp
+++ b/src/NimBLE2905.cpp
@@ -27,7 +27,7 @@
 #else
     // Ensure the value is within a valid range
     #if NIMBLE_MAX_AGGREGATE_FORMAT_DESCRIPTORS < 1 || NIMBLE_MAX_AGGREGATE_FORMAT_DESCRIPTORS > 255
-        #error "NIMBLE_MAX_AGGREGATE_FORMAT_DESCRIPTORS must be between 1 and 128"
+        #error "NIMBLE_MAX_AGGREGATE_FORMAT_DESCRIPTORS must be between 1 and 255"
     #endif
 #endif
 

--- a/src/NimBLE2905.h
+++ b/src/NimBLE2905.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020-2025 Ryan Powell <ryan@nable-embedded.io> and
+ * esp-nimble-cpp, NimBLE-Arduino contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NIMBLE_CPP_2905_H_
+#define NIMBLE_CPP_2905_H_
+
+#include "syscfg/syscfg.h"
+#if CONFIG_BT_NIMBLE_ENABLED && MYNEWT_VAL(BLE_ROLE_PERIPHERAL)
+
+# include "NimBLEDescriptor.h"
+
+/**
+ * @brief Characteristic Aggregate Format descriptor (UUID: 0x2905).
+ *
+ * @details Contains an ordered list of handles referencing 0x2904 Presentation Format
+ * descriptors that define the parent characteristic’s value.
+ */
+class NimBLE2905 : public NimBLEDescriptor {
+  public:
+    NimBLE2905(NimBLECharacteristic* pChr = nullptr);
+
+    void add2904Descriptor(const NimBLE2904* presentationFormat);
+  private:
+
+    /**
+     * @brief Descriptor for the Characteristic Aggregate Format (UUID: 0x2905).
+     *
+     * @details Contains an ordered list of handles referencing the 0x2904
+     * Presentation Format descriptors that define the parent characteristic's value.
+     *
+     * @see NimBLEServer::start()
+     */
+    void initValue();
+
+    friend class NimBLECharacteristic;
+    friend class NimBLEServer;
+
+    std::vector<const NimBLE2904*> m_vAggregatedDescriptors;
+}; // NimBLE2904
+
+#endif // CONFIG_BT_NIMBLE_ENABLED && MYNEWT_VAL(BLE_ROLE_PERIPHERAL)
+#endif // NIMBLE_CPP_2904_H_

--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -26,6 +26,7 @@
 # endif
 
 # include "NimBLE2904.h"
+# include "NimBLE2905.h"
 # include "NimBLEDevice.h"
 # include "NimBLELog.h"
 
@@ -86,6 +87,9 @@ NimBLEDescriptor* NimBLECharacteristic::createDescriptor(const NimBLEUUID& uuid,
     if (uuid == NimBLEUUID(static_cast<uint16_t>(0x2904))) {
         NIMBLE_LOGW(LOG_TAG, "0x2904 descriptor should be created with create2904()");
         pDescriptor = create2904();
+    } else if (uuid == NimBLEUUID(static_cast<uint16_t>(0x2905))) {
+        NIMBLE_LOGW(LOG_TAG, "0x2905 descriptor should be created with create2905()");
+        pDescriptor = create2905();
     } else {
         pDescriptor = new NimBLEDescriptor(uuid, properties, maxLen, this);
     }
@@ -103,6 +107,16 @@ NimBLE2904* NimBLECharacteristic::create2904() {
     addDescriptor(pDescriptor);
     return pDescriptor;
 } // create2904
+
+/**
+ * @brief Create a Characteristic Aggregate Format Descriptor for this characteristic.
+ * @return A pointer to a NimBLE2905 descriptor.
+ */
+NimBLE2905* NimBLECharacteristic::create2905() {
+    NimBLE2905* pDescriptor = new NimBLE2905(this);
+    addDescriptor(pDescriptor);
+    return pDescriptor;
+} // create2905
 
 /**
  * @brief Add a descriptor to the characteristic.

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -26,6 +26,7 @@ class NimBLEService;
 class NimBLECharacteristic;
 class NimBLEDescriptor;
 class NimBLE2904;
+class NimBLE2905;
 
 # include "NimBLELocalValueAttribute.h"
 
@@ -69,6 +70,7 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
                                        uint32_t          properties = NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE,
                                        uint16_t          maxLen     = BLE_ATT_ATTR_MAX_LEN);
     NimBLE2904*       create2904();
+    NimBLE2905*       create2905();
     NimBLEDescriptor* getDescriptorByUUID(const char* uuid, uint16_t index = 0) const;
     NimBLEDescriptor* getDescriptorByUUID(const NimBLEUUID& uuid, uint16_t index = 0) const;
     NimBLEDescriptor* getDescriptorByHandle(uint16_t handle) const;

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -18,6 +18,7 @@
 #include "NimBLEServer.h"
 #if CONFIG_BT_NIMBLE_ENABLED && MYNEWT_VAL(BLE_ROLE_PERIPHERAL)
 
+# include "NimBLE2905.h"
 # include "NimBLEDevice.h"
 # include "NimBLELog.h"
 
@@ -316,6 +317,19 @@ bool NimBLEServer::start() {
         }
     }
 # endif
+
+    // Populate any Aggregate Format (0x2905) descriptors now that every attribute handle has been
+    // assigned during ble_gatts_start() (via the GATT register callback). A 0x2905 value is the
+    // ordered list of its aggregated 0x2904 presentation-format descriptor handles.
+    for (const auto& svc : m_svcVec) {
+        for (const auto& chr : svc->getCharacteristics()) {
+            for (auto& desc : chr->m_vDescriptors) {
+                if (desc->getUUID() == NimBLEUUID(static_cast<uint16_t>(0x2905))) {
+                    static_cast<NimBLE2905*>(desc)->initValue();
+                }
+            }
+        }
+    }
 
     // If the services have changed indicate it now
     if (m_svcChanged) {

--- a/src/nimconfig.h
+++ b/src/nimconfig.h
@@ -5,6 +5,9 @@
  *            Arduino User Options             *
  **********************************************/
 
+/**  @brief Uncomment to change the maximum number of aggregated presentation format descriptors; 5 by default. */
+// #define NIMBLE_MAX_AGGREGATE_FORMAT_DESCRIPTORS 5
+
 /** @brief Un-comment to change the number of simultaneous connections (esp controller max is 9) */
 // #define MYNEWT_VAL_BLE_MAX_CONNECTIONS 3
 


### PR DESCRIPTION
## Summary
This PR adds full support for the **Characteristic Aggregate Format Descriptor** (UUID `0x2905`) when operating as a **BLE peripheral**. Correct implementation requires reliable handle mapping for multiple Presentation Format descriptors (`0x2904`), which previously failed due to duplicate handle assignment.  

This PR also introduces PlatformIO build support for the existing examples and includes a usage demonstration of this new capability in `NimBLE_Server.ino`.

## Problem
Descriptor handle resolution used UUID-only lookup (`ble_gatts_find_dsc()`), which meant:

- Multiple same-UUID descriptors were assigned the **same handle**
- The Aggregate Format descriptor (`0x2905`) could not assemble a correct referenced handle list
- Aggregated read/write behavior was broken for peripheral services that include multiple presentation formats

The BLE specification requires each referenced descriptor to have a **unique** handle for valid aggregation.

## Fix
- Reworked descriptor handle assignment to follow descriptor registration order from `ble_gatt_dsc_def`
- Each descriptor instance now retains the unique handle assigned by the NimBLE stack
- Aggregate Format descriptor correctly lists all Presentation Format descriptors associated with a characteristic

## Additional Enhancements
- **PlatformIO support** added for all example projects  
  They still function as regular Arduino sketches   
  and can now also be built and flashed using PlatformIO:
```shell
 pio run -e example_server -t upload 
 ```
  
- Updated the `NimBLE_Server.ino` example to include a **practical usage example** of the Aggregate Format descriptor feature:
```C
  /**
     *  2905 “Aggregate Format” descriptor is a special case. When create2905() is called,
     *  it creates an instance of NimBLE2905 with the correct properties and size.
     *  We must then explicitly add the constituent 2904 descriptors that define the
     *  aggregate format (e.g., name, fat percent, weight) using add2904Descriptor().
     *  This ensures the aggregate descriptor correctly references all its component descriptors.
     */
    NimBLE2905* pFormatAggregate = pBurgerIngredientsCharacteristic->create2905();
    pFormatAggregate->add2904Descriptor(pFormatName);
    pFormatAggregate->add2904Descriptor(pFormatFatPercent);
    pFormatAggregate->add2904Descriptor(pFormatWeight);
```
- Added a configuration macro for controlling maximum aggregated descriptors:  
  ```cpp
  /** Uncomment to change the maximum number of aggregated presentation format descriptors; 5 by default. */
  // #define NIMBLE_MAX_AGGREGATE_FORMAT_DESCRIPTORS 5
## Impact
- Standards-compliant support for 0x2905 on NimBLE peripherals
- Reliable operation for multiple Presentation Format descriptors (`0x2904`)
- Backwards compatible with existing applications and development workflows
- Easier testing, debugging, and example execution with PlatformIO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Characteristic Aggregate Format descriptor (UUID 0x2905) in peripheral applications.
  * Applications can create aggregate descriptors referencing multiple Presentation Format descriptors.
  * Aggregate values are populated automatically after the server assigns attribute handles.
  * Added a configurable limit for referenced Presentation Format descriptors.
* **Bug Fixes**
  * Invalid or unavailable descriptor references are safely skipped during aggregate initialization.
  * Prevented null or excess descriptor entries from being added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->