### PR TITLE
fix(server): notify characteristics on client disconnect

### DIFF
--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -432,6 +432,23 @@ int NimBLEServer::handleGapEvent(ble_gap_event* event, void* arg) {
             }
 
             peerInfo.m_desc = event->disconnect.conn;
+
+            // Notify characteristics that the client has unsubscribed.
+            // This ensures onSubscribe callbacks are called with subValue=0
+            // so applications can clean up their subscription state.
+            for (const auto& svc : pServer->m_svcVec) {
+                for (const auto& chr : svc->getCharacteristics()) {
+                    auto subscribers = chr->getSubscribers();
+                    for (const auto& entry : subscribers) {
+                        if (entry.getConnHandle() == event->disconnect.conn.conn_handle &&
+                            (entry.isSubNotify() || entry.isSubIndicate())) {
+                            chr->processSubRequest(peerInfo, 0);
+                            break;
+                        }
+                    }
+                }
+            }
+
             pServer->m_pServerCallbacks->onDisconnect(pServer, peerInfo, event->disconnect.reason);
 # if !MYNEWT_VAL(BLE_EXT_ADV)
             if (pServer->m_advertiseOnDisconnect) {


### PR DESCRIPTION
## Summary

When a BLE client disconnects, characteristics with active subscriptions are not notified. This leaves applications with stale subscription state, causing issues with reconnection.

This PR adds code to the `BLE_GAP_EVENT_DISCONNECT` handler to iterate through all characteristics and call `processSubRequest(peerInfo, 0)` for any that had active subscriptions from the disconnecting client.

## Problem

Applications using wrappers like NuS-NimBLE-Serial track subscriber counts via the `onSubscribe` callback. Without this fix:
1. Client connects and subscribes → `onSubscribe(subValue=1)` called → count = 1
2. Client disconnects abruptly → no callback → count stays at 1
3. Client reconnects → subscription state is stale → reconnection fails

## Solution

In `BLE_GAP_EVENT_DISCONNECT`, before calling `onDisconnect`:
- Iterate through all services and characteristics
- For each characteristic with an active subscription from the disconnecting client
- Call `processSubRequest(peerInfo, 0)` to trigger the `onSubscribe` callback with `subValue=0`

This ensures:
1. The `onSubscribe` callback is called with `subValue=0`
2. Applications tracking subscriber counts get properly notified
3. Subscription state is cleaned up for reliable reconnection

## Testing

Tested with ESP32-S3 and NuS-NimBLE-Serial. Before the fix, reconnection after disconnect would fail. After the fix, reconnection works reliably.