### PR TITLE
[Bugfix] whitelist bounds checks

### DIFF
--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -766,7 +766,7 @@ size_t NimBLEDevice::getWhiteListCount() {
  * @returns The NimBLEAddress at the whitelist index or null address if not found.
  */
 NimBLEAddress NimBLEDevice::getWhiteListAddress(size_t index) {
-    if (index > m_whiteList.size()) {
+    if (index >= m_whiteList.size()) {
         NIMBLE_LOGE(LOG_TAG, "Invalid index; %u", index);
         return NimBLEAddress{};
     }


### PR DESCRIPTION
Corrected the boundary check in `getWhiteListAddress` from `index > m_whiteList.size()` to `index >= m_whiteList.size()`, fixing an off-by-one error when accessing whitelist entries.
