### PR TITLE
Add custom nvs namespace feature.

### DIFF
--- a/src/nimble/nimble/host/store/config/src/ble_store_nvs.c
+++ b/src/nimble/nimble/host/store/config/src/ble_store_nvs.c
@@ -42,7 +42,7 @@
 #define NIMBLE_NVS_CCCD_SEC_KEY                  "cccd_sec"
 #define NIMBLE_NVS_CSFC_SEC_KEY                  "csfc_sec"
 #define NIMBLE_NVS_PEER_RECORDS_KEY              "p_dev_rec"
-#define NIMBLE_NVS_NAMESPACE                     "nimble_bond"
+#define NIMBLE_NVS_DEFAULT_NAMESPACE             "nimble_bond"
 
 #if MYNEWT_VAL(ENC_ADV_DATA)
 #define NIMBLE_NVS_EAD_SEC_KEY                   "ead_sec"
@@ -51,11 +51,31 @@
 #define NIMBLE_NVS_LOCAL_IRK_KEY                "local_irk"
 #define NIMBLE_NVS_RPA_RECORDS_KEY               "rpa_rec"
 
-static const char *TAG = "NIMBLE_NVS";
+static const char *LOG_TAG = "NIMBLE_NVS";
+static char nimble_nvs_namespace_buf[NIMBLE_NVS_STR_NAME_MAX_LEN];
+static const char *NIMBLE_NVS_NAMESPACE = NIMBLE_NVS_DEFAULT_NAMESPACE;
 
 /*****************************************************************************
  * $ MISC                                                                    *
  *****************************************************************************/
+
+void
+set_nimble_nvs_namespace(const char *ns)
+{
+    if (ns == NULL) {
+        NIMBLE_NVS_NAMESPACE = NIMBLE_NVS_DEFAULT_NAMESPACE;
+        return;
+    }
+
+    if (strlen(ns) < NIMBLE_NVS_STR_NAME_MAX_LEN) {
+        strncpy(nimble_nvs_namespace_buf, ns, NIMBLE_NVS_STR_NAME_MAX_LEN - 1);
+        nimble_nvs_namespace_buf[NIMBLE_NVS_STR_NAME_MAX_LEN - 1] = '\0';
+        NIMBLE_NVS_NAMESPACE = nimble_nvs_namespace_buf;
+    } else {
+        ESP_LOGE(LOG_TAG, "Namespace string is too long, using default namespace");
+        NIMBLE_NVS_NAMESPACE = NIMBLE_NVS_DEFAULT_NAMESPACE;
+    }
+}
 
 static void
 get_nvs_key_string(int obj_type, int index, char *key_string)
@@ -139,7 +159,7 @@ get_nvs_peer_record(char *key_string, struct ble_hs_dev_records *p_dev_rec)
 
     err = nvs_open(NIMBLE_NVS_NAMESPACE, NVS_READWRITE, &nimble_handle);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS open operation failed");
+        ESP_LOGE(LOG_TAG, "NVS open operation failed");
         return BLE_HS_ESTORE_FAIL;
     }
 
@@ -168,7 +188,7 @@ get_nvs_db_value(int obj_type, char *key_string, union ble_store_value *val)
 
     err = nvs_open(NIMBLE_NVS_NAMESPACE, NVS_READWRITE, &nimble_handle);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS open operation failed");
+        ESP_LOGE(LOG_TAG, "NVS open operation failed");
         return BLE_HS_ESTORE_FAIL;
     }
 
@@ -244,7 +264,7 @@ get_nvs_db_attribute(int obj_type, bool empty, void *value, int num_value)
         /* Check if the user is searching for empty index to write to */
         if (err == ESP_ERR_NVS_NOT_FOUND) {
             if (empty) {
-                ESP_LOGD(TAG, "Empty NVS index found = %d for obj_type = %d", i, obj_type);
+                ESP_LOGD(LOG_TAG, "Empty NVS index found = %d for obj_type = %d", i, obj_type);
                 return i;
             }
         } else if (err == ESP_OK) {
@@ -291,7 +311,7 @@ get_nvs_db_attribute(int obj_type, bool empty, void *value, int num_value)
                 }
             }
         } else {
-            ESP_LOGE(TAG, "NVS read operation failed while fetching size !!");
+            ESP_LOGE(LOG_TAG, "NVS read operation failed while fetching size !!");
             return -1;
         }
     }
@@ -315,13 +335,13 @@ ble_nvs_delete_value(int obj_type, int8_t index)
     char key_string[NIMBLE_NVS_STR_NAME_MAX_LEN];
 
     if (index > get_nvs_max_obj_value(obj_type)) {
-        ESP_LOGE(TAG, "Invalid index provided to delete");
+        ESP_LOGE(LOG_TAG, "Invalid index provided to delete");
         return BLE_HS_EUNKNOWN;
     }
 
     err = nvs_open(NIMBLE_NVS_NAMESPACE, NVS_READWRITE, &nimble_handle);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS open operation failed !!");
+        ESP_LOGE(LOG_TAG, "NVS open operation failed !!");
         return BLE_HS_ESTORE_FAIL;
     }
 
@@ -352,20 +372,20 @@ ble_nvs_write_key_value(char *key, const void *value, size_t required_size)
 
     err = nvs_open(NIMBLE_NVS_NAMESPACE, NVS_READWRITE, &nimble_handle);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS open operation failed !!");
+        ESP_LOGE(LOG_TAG, "NVS open operation failed !!");
         return BLE_HS_ESTORE_FAIL;
     }
 
     err = nvs_set_blob(nimble_handle, key, value, required_size);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS write operation failed !!");
+        ESP_LOGE(LOG_TAG, "NVS write operation failed !!");
         goto error;
     }
 
     /* NVS commit and close */
     err = nvs_commit(nimble_handle);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS commit operation failed !!");
+        ESP_LOGE(LOG_TAG, "NVS commit operation failed !!");
         goto error;
     }
 
@@ -389,13 +409,13 @@ ble_store_nvs_write(int obj_type, const union ble_store_value *val)
 
     write_key_index = get_nvs_db_attribute(obj_type, 1, NULL, 0);
     if (write_key_index == -1) {
-        ESP_LOGE(TAG, "NVS operation failed !!");
+        ESP_LOGE(LOG_TAG, "NVS operation failed !!");
         return BLE_HS_ESTORE_FAIL;
     } else if (write_key_index > get_nvs_max_obj_value(obj_type)) {
 
         /* bare-bone config code will take care of capacity overflow event,
          * however another check added for consistency */
-        ESP_LOGD(TAG, "NVS size overflow.");
+        ESP_LOGD(LOG_TAG, "NVS size overflow.");
         return BLE_HS_ESTORE_CAP;
     }
 
@@ -436,13 +456,13 @@ ble_store_nvs_peer_records(int obj_type, const struct ble_hs_dev_records *p_dev_
 
     write_key_index = get_nvs_db_attribute(obj_type, 1, NULL, 0);
     if (write_key_index == -1) {
-        ESP_LOGE(TAG, "NVS operation failed !!");
+        ESP_LOGE(LOG_TAG, "NVS operation failed !!");
         return BLE_HS_ESTORE_FAIL;
     } else if (write_key_index > get_nvs_max_obj_value(obj_type)) {
 
         /* bare-bone config code will take care of capacity overflow event,
          * however another check added for consistency */
-        ESP_LOGD(TAG, "NVS size overflow.");
+        ESP_LOGD(LOG_TAG, "NVS size overflow.");
         return BLE_HS_ESTORE_CAP;
     }
 
@@ -476,7 +496,7 @@ populate_db_from_nvs(int obj_type, void *dst, int *db_num)
             if (err == ESP_ERR_NVS_NOT_FOUND) {
                 continue;
             } else if (err != ESP_OK) {
-                ESP_LOGE(TAG, "NVS read operation failed !!");
+                ESP_LOGE(LOG_TAG, "NVS read operation failed !!");
                 return -1;
             }
 #if MYNEWT_VAL(BLE_HOST_BASED_PRIVACY)
@@ -485,14 +505,14 @@ populate_db_from_nvs(int obj_type, void *dst, int *db_num)
             if (err == ESP_ERR_NVS_NOT_FOUND) {
                 continue;
             } else if (err != ESP_OK) {
-                ESP_LOGE(TAG, "NVS read operation failed !!");
+                ESP_LOGE(LOG_TAG, "NVS read operation failed !!");
                 return -1;
             }
         }
 
         /* NVS index has data, fill up the ram db with it */
         if (obj_type == BLE_STORE_OBJ_TYPE_PEER_DEV_REC) {
-            ESP_LOGD(TAG, "Peer dev records filled from NVS index = %d", i);
+            ESP_LOGD(LOG_TAG, "Peer dev records filled from NVS index = %d", i);
             memcpy(db_item, &p_dev_rec, sizeof(struct ble_hs_dev_records));
             db_item += sizeof(struct ble_hs_dev_records);
             (*db_num)++;
@@ -500,35 +520,35 @@ populate_db_from_nvs(int obj_type, void *dst, int *db_num)
 #endif
         {
             if (obj_type == BLE_STORE_OBJ_TYPE_CCCD) {
-                ESP_LOGD(TAG, "CCCD in RAM is filled up from NVS index = %d", i);
+                ESP_LOGD(LOG_TAG, "CCCD in RAM is filled up from NVS index = %d", i);
                 memcpy(db_item, &cur.cccd, sizeof(struct ble_store_value_cccd));
                 db_item += sizeof(struct ble_store_value_cccd);
                 (*db_num)++;
             } else if (obj_type == BLE_STORE_OBJ_TYPE_CSFC) {
-                ESP_LOGD(TAG, "CSFC in RAM is filled up from NVS index = %d", i);
+                ESP_LOGD(LOG_TAG, "CSFC in RAM is filled up from NVS index = %d", i);
                 memcpy(db_item, &cur.csfc, sizeof(struct ble_store_value_csfc));
                 db_item += sizeof(struct ble_store_value_csfc);
                 (*db_num)++;
 #if MYNEWT_VAL(ENC_ADV_DATA)
             } else if (obj_type == BLE_STORE_OBJ_TYPE_ENC_ADV_DATA) {
-                  ESP_LOGD(TAG, "EAD in RAM is filled up from NVS index = %d", i);
+                  ESP_LOGD(LOG_TAG, "EAD in RAM is filled up from NVS index = %d", i);
                   memcpy(db_item, &cur.ead, sizeof(struct ble_store_value_ead));
                   db_item += sizeof(struct ble_store_value_ead);
                   (*db_num)++;
 #endif
            } else if(obj_type == BLE_STORE_OBJ_TYPE_LOCAL_IRK) {
-                  ESP_LOGD(TAG, "Local IRK in RAM is filled up from NVS index = %d", i);
+                  ESP_LOGD(LOG_TAG, "Local IRK in RAM is filled up from NVS index = %d", i);
                   memcpy(db_item, &cur.local_irk, sizeof(struct ble_store_value_local_irk));
                   db_item += sizeof(struct ble_store_value_local_irk);
                   (*db_num)++;
 
             } else if(obj_type == BLE_STORE_OBJ_TYPE_PEER_ADDR) {
-                  ESP_LOGD(TAG, "RPA_REC in RAM is filled up from NVS index = %d", i);
+                  ESP_LOGD(LOG_TAG, "RPA_REC in RAM is filled up from NVS index = %d", i);
                   memcpy(db_item, &cur.rpa_rec, sizeof(struct ble_store_value_rpa_rec));
                   db_item += sizeof(struct ble_store_value_rpa_rec);
                   (*db_num)++;
             } else {
-                ESP_LOGD(TAG, "KEY in RAM is filled up from NVS index = %d", i);
+                ESP_LOGD(LOG_TAG, "KEY in RAM is filled up from NVS index = %d", i);
                 memcpy(db_item, &cur.sec, sizeof(struct ble_store_value_sec));
                 db_item += sizeof(struct ble_store_value_sec);
                 (*db_num)++;
@@ -554,15 +574,15 @@ ble_nvs_restore_sec_keys(void)
     err = populate_db_from_nvs(BLE_STORE_OBJ_TYPE_OUR_SEC, ble_store_config_our_secs,
                                &ble_store_config_num_our_secs);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS operation failed for 'our sec'");
+        ESP_LOGE(LOG_TAG, "NVS operation failed for 'our sec'");
         return err;
     }
-    ESP_LOGD(TAG, "ble_store_config_our_secs restored %d bonds", ble_store_config_num_our_secs);
+    ESP_LOGD(LOG_TAG, "ble_store_config_our_secs restored %d bonds", ble_store_config_num_our_secs);
 
     err = populate_db_from_nvs(BLE_STORE_OBJ_TYPE_PEER_SEC, ble_store_config_peer_secs,
                                &ble_store_config_num_peer_secs);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS operation failed for 'peer sec'");
+        ESP_LOGE(LOG_TAG, "NVS operation failed for 'peer sec'");
         return err;
     }
 
@@ -586,7 +606,7 @@ ble_nvs_restore_sec_keys(void)
     ble_store_config_our_bond_count = ble_store_config_our_secs[ble_store_config_num_our_secs - 1].bond_count;
     ble_store_config_peer_bond_count = ble_store_config_peer_secs[ble_store_config_num_peer_secs - 1].bond_count;
 
-    ESP_LOGD(TAG, "ble_store_config_peer_secs restored %d bonds",
+    ESP_LOGD(LOG_TAG, "ble_store_config_peer_secs restored %d bonds",
              ble_store_config_num_peer_secs);
 #endif
 
@@ -594,10 +614,10 @@ ble_nvs_restore_sec_keys(void)
     err = populate_db_from_nvs(BLE_STORE_OBJ_TYPE_CCCD, ble_store_config_cccds,
                                &ble_store_config_num_cccds);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS operation failed for 'CCCD'");
+        ESP_LOGE(LOG_TAG, "NVS operation failed for 'CCCD'");
         return err;
     }
-    ESP_LOGD(TAG, "ble_store_config_cccds restored %d bonds",
+    ESP_LOGD(LOG_TAG, "ble_store_config_cccds restored %d bonds",
              ble_store_config_num_cccds);
 #endif
 
@@ -605,10 +625,10 @@ ble_nvs_restore_sec_keys(void)
     err = populate_db_from_nvs(BLE_STORE_OBJ_TYPE_CSFC, ble_store_config_csfcs,
                                &ble_store_config_num_csfcs);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS operation failed for 'CSFC'");
+        ESP_LOGE(LOG_TAG, "NVS operation failed for 'CSFC'");
         return err;
     }
-    ESP_LOGD(TAG, "ble_store_config_csfcs restored %d bonds",
+    ESP_LOGD(LOG_TAG, "ble_store_config_csfcs restored %d bonds",
              ble_store_config_num_csfcs);
 #endif
 
@@ -616,28 +636,28 @@ ble_nvs_restore_sec_keys(void)
     err = populate_db_from_nvs(BLE_STORE_OBJ_TYPE_ENC_ADV_DATA, ble_store_config_eads,
                                &ble_store_config_num_eads);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS operation failed for 'EAD'");
+        ESP_LOGE(LOG_TAG, "NVS operation failed for 'EAD'");
         return err;
     }
-    ESP_LOGD(TAG, "ble_store_config_eads restored %d bonds",
+    ESP_LOGD(LOG_TAG, "ble_store_config_eads restored %d bonds",
              ble_store_config_num_eads);
 #endif
     err = populate_db_from_nvs(BLE_STORE_OBJ_TYPE_LOCAL_IRK, ble_store_config_local_irks,
                            &ble_store_config_num_local_irks);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS operation failed for 'Local IRK'");
+        ESP_LOGE(LOG_TAG, "NVS operation failed for 'Local IRK'");
         return err;
     }
-    ESP_LOGD(TAG, "ble_store_config_local_irks restored %d irks",
+    ESP_LOGD(LOG_TAG, "ble_store_config_local_irks restored %d irks",
              ble_store_config_num_local_irks);
 
     err = populate_db_from_nvs(BLE_STORE_OBJ_TYPE_PEER_ADDR, ble_store_config_rpa_recs,
                                &ble_store_config_num_rpa_recs);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS operation failed for 'RPA_REC'");
+        ESP_LOGE(LOG_TAG, "NVS operation failed for 'RPA_REC'");
         return err;
     }
-    ESP_LOGD(TAG, "ble_store_config_rpa_recs restored %d bonds",
+    ESP_LOGD(LOG_TAG, "ble_store_config_rpa_recs restored %d bonds",
              ble_store_config_num_rpa_recs);
 
     return 0;
@@ -654,12 +674,12 @@ ble_nvs_restore_peer_records(void)
     err = populate_db_from_nvs(BLE_STORE_OBJ_TYPE_PEER_DEV_REC, peer_dev_rec,
                                &ble_store_num_peer_dev_rec);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS operation failed fetching 'Peer Dev Records'");
+        ESP_LOGE(LOG_TAG, "NVS operation failed fetching 'Peer Dev Records'");
         return err;
     }
 
     ble_rpa_set_num_peer_dev_records(ble_store_num_peer_dev_rec);
-    ESP_LOGD(TAG, "peer_dev_rec restored %d records", ble_store_num_peer_dev_rec);
+    ESP_LOGD(LOG_TAG, "peer_dev_rec restored %d records", ble_store_num_peer_dev_rec);
 
     return 0;
 }
@@ -673,14 +693,14 @@ int ble_store_config_persist_cccds(void)
 
     nvs_count = get_nvs_db_attribute(BLE_STORE_OBJ_TYPE_CCCD, 0, NULL, 0);
     if (nvs_count == -1) {
-        ESP_LOGE(TAG, "NVS operation failed while persisting CCCD");
+        ESP_LOGE(LOG_TAG, "NVS operation failed while persisting CCCD");
         return BLE_HS_ESTORE_FAIL;
     }
 
     if (nvs_count < ble_store_config_num_cccds) {
 
         /* NVS db count less than RAM count, write operation */
-        ESP_LOGD(TAG, "Persisting CCCD value in NVS...");
+        ESP_LOGD(LOG_TAG, "Persisting CCCD value in NVS...");
         val.cccd = ble_store_config_cccds[ble_store_config_num_cccds - 1];
         return ble_store_nvs_write(BLE_STORE_OBJ_TYPE_CCCD, &val);
     } else if (nvs_count > ble_store_config_num_cccds) {
@@ -688,10 +708,10 @@ int ble_store_config_persist_cccds(void)
         nvs_idx = get_nvs_db_attribute(BLE_STORE_OBJ_TYPE_CCCD, 0,
                                        ble_store_config_cccds, ble_store_config_num_cccds);
         if (nvs_idx == -1) {
-            ESP_LOGE(TAG, "NVS delete operation failed for CCCD");
+            ESP_LOGE(LOG_TAG, "NVS delete operation failed for CCCD");
             return BLE_HS_ESTORE_FAIL;
         }
-        ESP_LOGD(TAG, "Deleting CCCD, nvs idx = %d", nvs_idx);
+        ESP_LOGD(LOG_TAG, "Deleting CCCD, nvs idx = %d", nvs_idx);
         return ble_nvs_delete_value(BLE_STORE_OBJ_TYPE_CCCD, nvs_idx);
     }
     return 0;
@@ -706,13 +726,13 @@ int ble_store_config_persist_csfcs(void)
 
     nvs_count = get_nvs_db_attribute(BLE_STORE_OBJ_TYPE_CSFC, 0, NULL, 0);
     if (nvs_count == -1) {
-        ESP_LOGE(TAG, "NVS operation failed while persisting CSFC");
+        ESP_LOGE(LOG_TAG, "NVS operation failed while persisting CSFC");
         return BLE_HS_ESTORE_FAIL;
     }
 
     if (nvs_count < ble_store_config_num_csfcs) {
         /* NVS db count less than RAM count, write operation */
-        ESP_LOGD(TAG, "Persisting CSFC value in NVS...");
+        ESP_LOGD(LOG_TAG, "Persisting CSFC value in NVS...");
         val.csfc = ble_store_config_csfcs[ble_store_config_num_csfcs - 1];
         return ble_store_nvs_write(BLE_STORE_OBJ_TYPE_CSFC, &val);
     } else if (nvs_count > ble_store_config_num_csfcs) {
@@ -720,10 +740,10 @@ int ble_store_config_persist_csfcs(void)
         nvs_idx = get_nvs_db_attribute(BLE_STORE_OBJ_TYPE_CSFC, 0,
                                        ble_store_config_csfcs, ble_store_config_num_csfcs);
         if (nvs_idx == -1) {
-            ESP_LOGE(TAG, "NVS delete operation failed for CSFC");
+            ESP_LOGE(LOG_TAG, "NVS delete operation failed for CSFC");
             return BLE_HS_ESTORE_FAIL;
         }
-        ESP_LOGD(TAG, "Deleting CSFC, nvs idx = %d", nvs_idx);
+        ESP_LOGD(LOG_TAG, "Deleting CSFC, nvs idx = %d", nvs_idx);
         return ble_nvs_delete_value(BLE_STORE_OBJ_TYPE_CSFC, nvs_idx);
     }
     return 0;
@@ -738,13 +758,13 @@ int ble_store_config_persist_eads(void)
 
     nvs_count = get_nvs_db_attribute(BLE_STORE_OBJ_TYPE_ENC_ADV_DATA, 0, NULL, 0);
     if (nvs_count == -1) {
-        ESP_LOGE(TAG, "NVS operation failed while persisting EAD");
+        ESP_LOGE(LOG_TAG, "NVS operation failed while persisting EAD");
         return BLE_HS_ESTORE_FAIL;
     }
 
     if (nvs_count < ble_store_config_num_eads) {
         /* NVS db count less than RAM count, write operation */
-        ESP_LOGD(TAG, "Persisting EAD value in NVS...");
+        ESP_LOGD(LOG_TAG, "Persisting EAD value in NVS...");
         val.ead = ble_store_config_eads[ble_store_config_num_eads - 1];
         return ble_store_nvs_write(BLE_STORE_OBJ_TYPE_ENC_ADV_DATA, &val);
     } else if (nvs_count > ble_store_config_num_eads) {
@@ -752,10 +772,10 @@ int ble_store_config_persist_eads(void)
         nvs_idx = get_nvs_db_attribute(BLE_STORE_OBJ_TYPE_ENC_ADV_DATA, 0,
                                        ble_store_config_eads, ble_store_config_num_eads);
         if (nvs_idx == -1) {
-            ESP_LOGE(TAG, "NVS delete operation failed for EAD");
+            ESP_LOGE(LOG_TAG, "NVS delete operation failed for EAD");
             return BLE_HS_ESTORE_FAIL;
         }
-        ESP_LOGD(TAG, "Deleting EAD, nvs idx = %d", nvs_idx);
+        ESP_LOGD(LOG_TAG, "Deleting EAD, nvs idx = %d", nvs_idx);
         return ble_nvs_delete_value(BLE_STORE_OBJ_TYPE_ENC_ADV_DATA, nvs_idx);
     }
     return 0;
@@ -768,13 +788,13 @@ int ble_store_config_persist_local_irk(void)
 
     nvs_count = get_nvs_db_attribute(BLE_STORE_OBJ_TYPE_LOCAL_IRK, 0, NULL, 0);
     if (nvs_count == -1) {
-        ESP_LOGE(TAG, "NVS operation failed while persisting EAD");
+        ESP_LOGE(LOG_TAG, "NVS operation failed while persisting EAD");
         return BLE_HS_ESTORE_FAIL;
     }
 
     if (nvs_count < ble_store_config_num_local_irks) {
         /* NVS db count less than RAM count, write operation */
-        ESP_LOGD(TAG, "Persisting Local IRK value in NVS...");
+        ESP_LOGD(LOG_TAG, "Persisting Local IRK value in NVS...");
         val.local_irk = ble_store_config_local_irks[ble_store_config_num_local_irks-1];
         return ble_store_nvs_write(BLE_STORE_OBJ_TYPE_LOCAL_IRK, &val);
     } else if (nvs_count > ble_store_config_num_local_irks) {
@@ -782,10 +802,10 @@ int ble_store_config_persist_local_irk(void)
         nvs_idx = get_nvs_db_attribute(BLE_STORE_OBJ_TYPE_LOCAL_IRK, 0,
                                        ble_store_config_local_irks, ble_store_config_num_local_irks);
         if (nvs_idx == -1) {
-            ESP_LOGE(TAG, "NVS delete operation failed for Local IRK");
+            ESP_LOGE(LOG_TAG, "NVS delete operation failed for Local IRK");
             return BLE_HS_ESTORE_FAIL;
         }
-        ESP_LOGD(TAG, "Deleting Local IRK, nvs idx = %d", nvs_idx);
+        ESP_LOGD(LOG_TAG, "Deleting Local IRK, nvs idx = %d", nvs_idx);
         return ble_nvs_delete_value(BLE_STORE_OBJ_TYPE_LOCAL_IRK, nvs_idx);
     }
     return 0;
@@ -797,12 +817,12 @@ int ble_store_config_persist_rpa_recs(void)
     union ble_store_value val;
     nvs_count = get_nvs_db_attribute(BLE_STORE_OBJ_TYPE_PEER_ADDR, 0, NULL, 0);
      if (nvs_count == -1) {
-        ESP_LOGE(TAG, "NVS operation failed while persisting RPA_RECS");
+        ESP_LOGE(LOG_TAG, "NVS operation failed while persisting RPA_RECS");
         return BLE_HS_ESTORE_FAIL;
     }
     if (nvs_count < ble_store_config_num_rpa_recs) {
         /* NVS db count less than RAM count, write operation */
-        ESP_LOGD(TAG, "Persisting RPA_RECS value in NVS...");
+        ESP_LOGD(LOG_TAG, "Persisting RPA_RECS value in NVS...");
         val.rpa_rec = ble_store_config_rpa_recs[ble_store_config_num_rpa_recs - 1];
         return ble_store_nvs_write(BLE_STORE_OBJ_TYPE_PEER_ADDR, &val);
     } else if (nvs_count > ble_store_config_num_rpa_recs) {
@@ -810,10 +830,10 @@ int ble_store_config_persist_rpa_recs(void)
         nvs_idx = get_nvs_db_attribute(BLE_STORE_OBJ_TYPE_PEER_ADDR, 0,
                                        ble_store_config_rpa_recs, ble_store_config_num_rpa_recs);
         if (nvs_idx == -1) {
-            ESP_LOGE(TAG, "NVS delete operation failed for RPA_REC");
+            ESP_LOGE(LOG_TAG, "NVS delete operation failed for RPA_REC");
             return BLE_HS_ESTORE_FAIL;
         }
-        ESP_LOGD(TAG, "Deleting RPA_REC, nvs idx = %d", nvs_idx);
+        ESP_LOGD(LOG_TAG, "Deleting RPA_REC, nvs idx = %d", nvs_idx);
         return ble_nvs_delete_value(BLE_STORE_OBJ_TYPE_PEER_ADDR, nvs_idx);
     }
     return 0;
@@ -827,14 +847,14 @@ int ble_store_config_persist_peer_secs(void)
 
     nvs_count = get_nvs_db_attribute(BLE_STORE_OBJ_TYPE_PEER_SEC, 0, NULL, 0);
     if (nvs_count == -1) {
-        ESP_LOGE(TAG, "NVS operation failed while persisting peer sec");
+        ESP_LOGE(LOG_TAG, "NVS operation failed while persisting peer sec");
         return BLE_HS_ESTORE_FAIL;
     }
 
     if (nvs_count < ble_store_config_num_peer_secs) {
 
         /* NVS db count less than RAM count, write operation */
-        ESP_LOGD(TAG, "Persisting peer sec value in NVS...");
+        ESP_LOGD(LOG_TAG, "Persisting peer sec value in NVS...");
         val.sec = ble_store_config_peer_secs[ble_store_config_num_peer_secs - 1];
         return ble_store_nvs_write(BLE_STORE_OBJ_TYPE_PEER_SEC, &val);
     } else if (nvs_count > ble_store_config_num_peer_secs) {
@@ -842,10 +862,10 @@ int ble_store_config_persist_peer_secs(void)
         nvs_idx = get_nvs_db_attribute(BLE_STORE_OBJ_TYPE_PEER_SEC, 0,
                                        ble_store_config_peer_secs, ble_store_config_num_peer_secs);
         if (nvs_idx == -1) {
-            ESP_LOGE(TAG, "NVS delete operation failed for peer sec");
+            ESP_LOGE(LOG_TAG, "NVS delete operation failed for peer sec");
             return BLE_HS_ESTORE_FAIL;
         }
-        ESP_LOGD(TAG, "Deleting peer sec, nvs idx = %d", nvs_idx);
+        ESP_LOGD(LOG_TAG, "Deleting peer sec, nvs idx = %d", nvs_idx);
         return ble_nvs_delete_value(BLE_STORE_OBJ_TYPE_PEER_SEC, nvs_idx);
     }
     return 0;
@@ -858,14 +878,14 @@ int ble_store_config_persist_our_secs(void)
 
     nvs_count = get_nvs_db_attribute(BLE_STORE_OBJ_TYPE_OUR_SEC, 0, NULL, 0);
     if (nvs_count == -1) {
-        ESP_LOGE(TAG, "NVS operation failed while persisting our sec");
+        ESP_LOGE(LOG_TAG, "NVS operation failed while persisting our sec");
         return BLE_HS_ESTORE_FAIL;
     }
 
     if (nvs_count < ble_store_config_num_our_secs) {
 
         /* NVS db count less than RAM count, write operation */
-        ESP_LOGD(TAG, "Persisting our sec value to NVS...");
+        ESP_LOGD(LOG_TAG, "Persisting our sec value to NVS...");
         val.sec = ble_store_config_our_secs[ble_store_config_num_our_secs - 1];
         return ble_store_nvs_write(BLE_STORE_OBJ_TYPE_OUR_SEC, &val);
     } else if (nvs_count > ble_store_config_num_our_secs) {
@@ -873,10 +893,10 @@ int ble_store_config_persist_our_secs(void)
         nvs_idx = get_nvs_db_attribute(BLE_STORE_OBJ_TYPE_OUR_SEC, 0,
                                        ble_store_config_our_secs, ble_store_config_num_our_secs);
         if (nvs_idx == -1) {
-            ESP_LOGE(TAG, "NVS delete operation failed for our sec");
+            ESP_LOGE(LOG_TAG, "NVS delete operation failed for our sec");
             return BLE_HS_ESTORE_FAIL;
         }
-        ESP_LOGD(TAG, "Deleting our sec, nvs idx = %d", nvs_idx);
+        ESP_LOGD(LOG_TAG, "Deleting our sec, nvs idx = %d", nvs_idx);
         return ble_nvs_delete_value(BLE_STORE_OBJ_TYPE_OUR_SEC, nvs_idx);
     }
     return 0;
@@ -892,14 +912,14 @@ int ble_store_persist_peer_records(void)
 
     nvs_count = get_nvs_db_attribute(BLE_STORE_OBJ_TYPE_PEER_DEV_REC, 0, NULL, 0);
     if (nvs_count == -1) {
-        ESP_LOGE(TAG, "NVS operation failed while persisting peer_dev_rec");
+        ESP_LOGE(LOG_TAG, "NVS operation failed while persisting peer_dev_rec");
         return BLE_HS_ESTORE_FAIL;
     }
 
     if (nvs_count < ble_store_num_peer_dev_rec) {
 
         /* NVS db count less than RAM count, write operation */
-        ESP_LOGD(TAG, "Persisting peer dev record to NVS...");
+        ESP_LOGD(LOG_TAG, "Persisting peer dev record to NVS...");
         peer_rec = peer_dev_rec[ble_store_num_peer_dev_rec - 1];
         return ble_store_nvs_peer_records(BLE_STORE_OBJ_TYPE_PEER_DEV_REC, &peer_rec);
     } else if (nvs_count > ble_store_num_peer_dev_rec) {
@@ -908,10 +928,10 @@ int ble_store_persist_peer_records(void)
                                        peer_dev_rec,
                                        ble_store_num_peer_dev_rec);
         if (nvs_idx == -1) {
-            ESP_LOGE(TAG, "NVS delete operation failed for peer records");
+            ESP_LOGE(LOG_TAG, "NVS delete operation failed for peer records");
             return BLE_HS_ESTORE_FAIL;
         }
-        ESP_LOGD(TAG, "Deleting peer record, nvs idx = %d", nvs_idx);
+        ESP_LOGD(LOG_TAG, "Deleting peer record, nvs idx = %d", nvs_idx);
         return ble_nvs_delete_value(BLE_STORE_OBJ_TYPE_PEER_DEV_REC, nvs_idx);
     }
     return 0;
@@ -924,12 +944,12 @@ void ble_store_config_conf_init(void)
 
     err = ble_nvs_restore_sec_keys();
     if (err != 0) {
-        ESP_LOGE(TAG, "NVS operation failed, can't retrieve the bonding info");
+        ESP_LOGE(LOG_TAG, "NVS operation failed, can't retrieve the bonding info");
     }
 #if MYNEWT_VAL(BLE_HOST_BASED_PRIVACY)
     err = ble_nvs_restore_peer_records();
     if (err != 0) {
-        ESP_LOGE(TAG, "NVS operation failed, can't retrieve the peer records");
+        ESP_LOGE(LOG_TAG, "NVS operation failed, can't retrieve the peer records");
     }
 #endif
 }

--- a/src/nimconfig.h
+++ b/src/nimconfig.h
@@ -190,6 +190,10 @@
 #  define MYNEWT_VAL_BLE_HCI_VS (0)
 # endif
 
+# ifdef __cplusplus
+extern "C" void set_nimble_nvs_namespace(const char *ns);
+# endif
+
 #else // !ESP_PLATFORM
 # if defined(NRF51)
 #  include "syscfg/devcfg/nrf51cfg.h"


### PR DESCRIPTION
Adds the function `set_nimble_nvs_namespace(const char*)` for users to switch bond data stores.

Fixes #959 
Fixes #1102 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NVS namespace is now configurable at runtime (no rebuild required).
  * Added a runtime API to change the active namespace, usable from both C and C++ builds.

* **Bug Fixes**
  * Input validation for namespace values: NULL resets to default; overly long values are rejected with an error and default fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->