### PR TITLE
Update NimBLE_Async_Client.ino

### DIFF
--- a/examples/NimBLE_Async_Client/NimBLE_Async_Client.ino
+++ b/examples/NimBLE_Async_Client/NimBLE_Async_Client.ino
@@ -50,7 +50,7 @@ class ScanCallbacks : public NimBLEScanCallbacks {
     }
 
     void onScanEnd(const NimBLEScanResults& results, int reason) override {
-        Serial.printf("Scan Ended\n");
+        Serial.printf("Scan ended reason = %d; restarting scan\n", reason);
         NimBLEDevice::getScan()->start(scanTimeMs);
     }
 } scanCallbacks;


### PR DESCRIPTION
updated message to indicate scan restarting, not just ending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced logging in the NimBLE async client example to display scan termination reasons and confirm scan restart behavior for improved debugging and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->