### PR TITLE
NimBLELog timestamps

### DIFF
--- a/src/NimBLELog.h
+++ b/src/NimBLELog.h
@@ -147,27 +147,28 @@
 
 # else
 #  include "nimble/console/console.h"
+#  include "esp32-hal.h"
 
 #  if MYNEWT_VAL(NIMBLE_CPP_LOG_LEVEL) >= 4
-#   define NIMBLE_LOGD(tag, format, ...) console_printf("D %s: " format "\n", tag, ##__VA_ARGS__)
+#   define NIMBLE_LOGD(tag, format, ...) console_printf("D (%lu) %s: " format "\n", millis(), tag, ##__VA_ARGS__)
 #  else
 #   define NIMBLE_LOGD(tag, format, ...) (void)tag
 #  endif
 
 #  if MYNEWT_VAL(NIMBLE_CPP_LOG_LEVEL) >= 3
-#   define NIMBLE_LOGI(tag, format, ...) console_printf("I %s: " format "\n", tag, ##__VA_ARGS__)
+#   define NIMBLE_LOGI(tag, format, ...) console_printf("I (%lu) %s: " format "\n", millis(), tag, ##__VA_ARGS__)
 #  else
 #   define NIMBLE_LOGI(tag, format, ...) (void)tag
 #  endif
 
 #  if MYNEWT_VAL(NIMBLE_CPP_LOG_LEVEL) >= 2
-#   define NIMBLE_LOGW(tag, format, ...) console_printf("W %s: " format "\n", tag, ##__VA_ARGS__)
+#   define NIMBLE_LOGW(tag, format, ...) console_printf("W (%lu) %s: " format "\n", millis(), tag, ##__VA_ARGS__)
 #  else
 #   define NIMBLE_LOGW(tag, format, ...) (void)tag
 #  endif
 
 #  if MYNEWT_VAL(NIMBLE_CPP_LOG_LEVEL) >= 1
-#   define NIMBLE_LOGE(tag, format, ...) console_printf("E %s: " format "\n", tag, ##__VA_ARGS__)
+#   define NIMBLE_LOGE(tag, format, ...) console_printf("E (%lu) %s: " format "\n", millis(), tag, ##__VA_ARGS__)
 #  else
 #   define NIMBLE_LOGE(tag, format, ...) (void)tag
 #  endif

--- a/src/NimBLELog.h
+++ b/src/NimBLELog.h
@@ -147,7 +147,7 @@
 
 # else
 #  include "nimble/console/console.h"
-#  include "esp32-hal.h"
+#  include <Arduino.h>
 
 #  if MYNEWT_VAL(NIMBLE_CPP_LOG_LEVEL) >= 4
 #   define NIMBLE_LOGD(tag, format, ...) console_printf("D (%lu) %s: " format "\n", millis(), tag, ##__VA_ARGS__)

--- a/src/nimble/porting/npl/freertos/include/nimble/nimble_npl_os.h
+++ b/src/nimble/porting/npl/freertos/include/nimble/nimble_npl_os.h
@@ -651,7 +651,7 @@ ble_npl_time_ms_to_ticks(uint32_t ms, ble_npl_time_t *out_ticks)
 static inline ble_npl_error_t
 ble_npl_time_ticks_to_ms(ble_npl_time_t ticks, uint32_t *out_ms)
 {
-    return ble_npl_time_ticks_to_ms(ticks, out_ms);
+    return npl_freertos_time_ticks_to_ms(ticks, out_ms);
 }
 
 static inline ble_npl_time_t


### PR DESCRIPTION
adds timestamps to NimBLELog messages :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added timestamps to Arduino console log messages, making log output easier to trace and read.
  * Fixed a time-conversion issue in the FreeRTOS porting layer that could cause incorrect behavior during tick-to-millisecond conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->