### PR TITLE
fix: whiteListRemove use-after-free — loop continues on invalidated iterator

### DIFF
--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -728,7 +728,7 @@ bool NimBLEDevice::onWhiteList(const NimBLEAddress& address) {
 bool NimBLEDevice::whiteListAdd(const NimBLEAddress& address) {
     if (!NimBLEDevice::onWhiteList(address)) {
         m_whiteList.push_back(address);
-        int rc = ble_gap_wl_set(reinterpret_cast<ble_addr_t*>(&m_whiteList[0]), m_whiteList.size());
+        int rc = ble_gap_wl_set(reinterpret_cast<ble_addr_t*>(m_whiteList.data()), m_whiteList.size());
         if (rc != 0) {
             NIMBLE_LOGE(LOG_TAG, "Failed adding to whitelist rc=%d", rc);
             m_whiteList.pop_back();
@@ -748,7 +748,7 @@ bool NimBLEDevice::whiteListRemove(const NimBLEAddress& address) {
     for (auto it = m_whiteList.begin(); it < m_whiteList.end(); ++it) {
         if (*it == address) {
             m_whiteList.erase(it);
-            int rc = ble_gap_wl_set(reinterpret_cast<ble_addr_t*>(&m_whiteList[0]), m_whiteList.size());
+            int rc = ble_gap_wl_set(reinterpret_cast<ble_addr_t*>(m_whiteList.data()), m_whiteList.size());
             if (rc != 0) {
                 m_whiteList.push_back(address);
                 NIMBLE_LOGE(LOG_TAG, "Failed removing from whitelist rc=%d", rc);

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -756,6 +756,10 @@ bool NimBLEDevice::whiteListRemove(const NimBLEAddress& address) {
             }
 
             std::vector<NimBLEAddress>(m_whiteList).swap(m_whiteList);
+            break; // `it` was invalidated by erase() and its buffer freed by the
+                   // swap above; continuing would iterate a dangling iterator.
+                   // Duplicates are impossible (whiteListAdd checks onWhiteList),
+                   // so a single match is total.
         }
     }
 


### PR DESCRIPTION
`whiteListRemove` iterates `m_whiteList` and, on a match:

1. `m_whiteList.erase(it)` — invalidates `it` (and all iterators at/after it),
2. `std::vector<NimBLEAddress>(m_whiteList).swap(m_whiteList)` — the shrink-to-fit swap frees the ENTIRE buffer `it` points into,
3. the loop then continues: `++it` and `it < m_whiteList.end()` operate on a dangling iterator into freed memory — undefined behavior on every removal that finds a match.

When the freed buffer's stale pointer happens to compare "in range" against the new allocation (pure heap-layout luck), `*it == address` reads freed memory, and a spurious re-match calls `m_whiteList.erase(it)` with a foreign iterator — the vector's internal element move then writes address-shaped data across unrelated heap memory.

**Observed in the field** (ESP32-C3, arduino-esp32 / IDF 5.5.4) as two distinct intermittent heap-corruption crashes under whitelist churn, both inside or adjacent to `whiteListRemove`:

- `assert failed: multi_heap_free multi_heap_poisoning.c:279 (head != NULL)` — the vector buffer's heap-block header overwritten with BLE-address bytes (`CORRUPT HEAP: Bad head ... Expected 0xabba1234 got 0xbb250000`, the `25 bb` being the LSB-first wire bytes of a whitelisted peer address);
- `assert failed: xQueueSemaphoreTake queue.c:1713 (pxQueue->uxItemSize == 0)` — the NimBLE host mutex clobbered by the same wild write, tripping on the next `ble_hs_lock()`.

**Fix:** `break` after the shrink. Since `whiteListAdd` guards against duplicates (`onWhiteList()` check before `push_back`), at most one element can match — breaking out after the removal preserves semantics exactly.

**Verification:** with this fix, the same churn workload (repeated whitelist rebuilds around pair/disconnect cycles) runs clean under `CONFIG_HEAP_POISONING_COMPREHENSIVE` plus periodic `heap_caps_check_integrity_all()` sweeps — previously ~2 crashes per 5 cycles.

Side note (not touched here to keep the diff minimal): `&m_whiteList[0]` on line 751 is also UB when the vector becomes empty after erasing the last entry — `m_whiteList.data()` would be the safe spelling.
