### PR TITLE
[Bugfix] Only call scan deinit callback if nimble was stopped.

### DIFF
--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -1029,14 +1029,13 @@ bool NimBLEDevice::init(const std::string& deviceName) {
 bool NimBLEDevice::deinit(bool clearAll) {
     int rc = 0;
     if (m_initialized) {
-# if MYNEWT_VAL(BLE_ROLE_OBSERVER)
-        if (NimBLEDevice::m_pScan != nullptr) {
-            NimBLEDevice::m_pScan->onHostDeinit();
-        }
-# endif
-
         rc = nimble_port_stop();
         if (rc == 0) {
+# if MYNEWT_VAL(BLE_ROLE_OBSERVER)
+            if (NimBLEDevice::m_pScan != nullptr) {
+                NimBLEDevice::m_pScan->onHostDeinit();
+            }
+# endif
             nimble_port_deinit();
 # ifndef USING_NIMBLE_ARDUINO_HEADERS
 #  if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
@@ -1048,6 +1047,9 @@ bool NimBLEDevice::deinit(bool clearAll) {
 # endif
             m_initialized = false;
             m_synced      = false;
+        } else {
+            NIMBLE_LOGE(LOG_TAG, "nimble_port_stop() failed with error: %d", rc);
+            return false;
         }
     }
 


### PR DESCRIPTION
* Add error handling if nimble failed to stop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth host shutdown handling during device deinitialization.
  * Deinitialization now stops safely when host shutdown fails and reports the failure clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->